### PR TITLE
import correct heroicon modul path

### DIFF
--- a/resources/js/Shared/Components/Mails/MobileMailList.vue
+++ b/resources/js/Shared/Components/Mails/MobileMailList.vue
@@ -58,7 +58,7 @@ import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import ResolveIdToName from "../../ResolveIdToName.vue";
 import InfiniteLoadingHelper from "../../InfiniteLoadingHelper.vue";
-import {ChevronUpIcon} from "@heroicons/vue/20/solid/esm";
+import { ChevronUpIcon } from "@heroicons/vue/20/solid";
 import {Disclosure, DisclosureButton, DisclosurePanel} from "@headlessui/vue";
 
 export default {


### PR DESCRIPTION
This fixes a bug where the prod build failed:

```
[vite]: Rollup failed to resolve import "@heroicons/vue/20/solid/esm" from "/Users/user/PhpstormProjects/base-app/src/resources/js/Shared/Components/Mails/MobileMailList.vue".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
error during build:
Error: [vite]: Rollup failed to resolve import "@heroicons/vue/20/solid/esm" from "/Users/user/PhpstormProjects/base-app/src/resources/js/Shared/Components/Mails/MobileMailList.vue".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
```