### PR TITLE
feat: allow moderators on opt-in roles

### DIFF
--- a/src/Http/Controllers/AccessControl/AddModeratorController.php
+++ b/src/Http/Controllers/AccessControl/AddModeratorController.php
@@ -10,6 +10,7 @@ use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Roles\BaseRoleService;
 use Seatplus\Auth\Services\Roles\ManualRoleService;
 use Seatplus\Auth\Services\Roles\OnRequestRoleService;
+use Seatplus\Auth\Services\Roles\OptInRoleService;
 use Seatplus\Web\Http\Controllers\Controller;
 
 class AddModeratorController extends Controller
@@ -24,12 +25,12 @@ class AddModeratorController extends Controller
         $roleService = $this->baseRoleService->getTypeService();
 
         abort_unless(
-            $roleService instanceof OnRequestRoleService || $roleService instanceof ManualRoleService,
+            $roleService instanceof OnRequestRoleService || $roleService instanceof ManualRoleService || $roleService instanceof OptInRoleService,
             403,
             'This role type does not support moderators'
         );
 
-        /** @var OnRequestRoleService|ManualRoleService $roleService */
+        /** @var OnRequestRoleService|ManualRoleService|OptInRoleService $roleService */
         $roleService->setModerator(User::findOrFail($user_id), true);
 
         return redirect()->back()->with('success', 'Moderator added');

--- a/src/Http/Controllers/AccessControl/RemoveModeratorController.php
+++ b/src/Http/Controllers/AccessControl/RemoveModeratorController.php
@@ -10,6 +10,7 @@ use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Roles\BaseRoleService;
 use Seatplus\Auth\Services\Roles\ManualRoleService;
 use Seatplus\Auth\Services\Roles\OnRequestRoleService;
+use Seatplus\Auth\Services\Roles\OptInRoleService;
 use Seatplus\Web\Http\Controllers\Controller;
 
 class RemoveModeratorController extends Controller
@@ -24,12 +25,12 @@ class RemoveModeratorController extends Controller
         $roleService = $this->baseRoleService->getTypeService();
 
         abort_unless(
-            $roleService instanceof OnRequestRoleService || $roleService instanceof ManualRoleService,
+            $roleService instanceof OnRequestRoleService || $roleService instanceof ManualRoleService || $roleService instanceof OptInRoleService,
             403,
             'This role type does not support moderators'
         );
 
-        /** @var OnRequestRoleService|ManualRoleService $roleService */
+        /** @var OnRequestRoleService|ManualRoleService|OptInRoleService $roleService */
         $roleService->setModerator(User::findOrFail($user_id), false);
 
         return redirect()->back()->with('success', 'Moderator removed');

--- a/tests/Feature/Lifecycle/OptInRoleLifecycleTest.php
+++ b/tests/Feature/Lifecycle/OptInRoleLifecycleTest.php
@@ -72,12 +72,14 @@ it('eligible user can join opt-in role and then leave via HTTP', function () {
     expect(test()->test_user->fresh()->hasRole(test()->role))->toBeFalse();
 });
 
-it('opt-in role rejects moderator assignment', function () {
+it('opt-in role accepts moderator assignment', function () {
     test()->actingAs(test()->admin)
         ->postJson(route('acl.update.opt-in', test()->role->id), [])
         ->assertRedirect();
 
     test()->actingAs(test()->admin)
         ->post(route('acl.moderator.add', [test()->role->id, test()->admin->id]))
-        ->assertForbidden();
+        ->assertRedirect();
+
+    expect(test()->role->refresh()->roleMemberships()->where('can_moderate', true)->exists())->toBeTrue();
 });


### PR DESCRIPTION
## Summary

Extends moderator support to opt-in roles in the web layer.

## Changes

- **`AddModeratorController`** — also accepts `OptInRoleService` (in addition to `OnRequestRoleService` + `ManualRoleService`)
- **`RemoveModeratorController`** — same

## Depends on

seatplus/auth PR #405 (`feat: allow moderators on opt-in roles`) must merge first — `OptInRoleService::setModerator()` is defined there.