### PR TITLE
refactor: adopt eveapi 4.1.4 camelCase relations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "laravel/framework": "^13.0",
         "laravel/socialite": "^5.0",
         "seatplus/eveapi": "^4.1.4",
-        "seatplus/auth": "^4.1",
+        "seatplus/auth": "^4.1.1",
         "conedevelopment/i18n": "^1.1",
         "doctrine/dbal": "^3.0",
         "inertiajs/inertia-laravel": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.5",
         "laravel/framework": "^13.0",
         "laravel/socialite": "^5.0",
-        "seatplus/eveapi": "^4.1.2",
+        "seatplus/eveapi": "^4.1.4",
         "seatplus/auth": "^4.1",
         "conedevelopment/i18n": "^1.1",
         "doctrine/dbal": "^3.0",

--- a/src/Http/Controllers/Character/ContactsController.php
+++ b/src/Http/Controllers/Character/ContactsController.php
@@ -79,7 +79,7 @@ class ContactsController extends Controller
             'alliance_contacts' => $corp_alliance_standing->filter(fn (Contact $contact) => $contact->contactable_type === AllianceInfo::class),
         ]);
 
-        $query = Contact::with(['labels', 'character_affiliation', 'corporation_affiliation', 'alliance_affiliation', 'faction_affiliation'])
+        $query = Contact::with(['labels', 'characterAffiliation', 'corporationAffiliation', 'allianceAffiliation', 'factionAffiliation'])
             ->where('contactable_id', $character_id);
 
         return ContactResource::collection(

--- a/src/Http/Controllers/Character/ContractsController.php
+++ b/src/Http/Controllers/Character/ContractsController.php
@@ -62,7 +62,7 @@ class ContractsController extends Controller
     public function getCharacterContractsDetails(int $character_id, Request $request): AnonymousResourceCollection
     {
         $query = Contract::whereHas('characters', fn (Builder $query) => $query->where('character_id', $character_id))
-            ->with(['items', 'items.type', 'items.type.group', 'start_location', 'end_location', 'assignee_character', 'assignee_corporation', 'issuer_character', 'issuer_corporation'])
+            ->with(['items', 'items.type', 'items.type.group', 'startLocation', 'endLocation', 'assigneeCharacter', 'assigneeCorporation', 'issuerCharacter', 'issuerCorporation'])
             ->tap(new LocationWatchListScope($request->all()))
             ->tap(new TypeWatchListScope($request->all()));
 
@@ -73,7 +73,7 @@ class ContractsController extends Controller
     {
         $query = Contract::query()->whereHas('characters', fn (Builder $query) => $query->where('character_id', $character_id))
             ->where('contract_id', $contract_id)
-            ->with('items', 'items.type', 'start_location', 'end_location', 'assignee_character', 'assignee_corporation', 'issuer_character', 'issuer_corporation');
+            ->with('items', 'items.type', 'startLocation', 'endLocation', 'assigneeCharacter', 'assigneeCorporation', 'issuerCharacter', 'issuerCorporation');
 
         if (request()->header('X-Modal', false)) {
             return $query->get()->toJson();

--- a/src/Http/Controllers/Character/WalletsController.php
+++ b/src/Http/Controllers/Character/WalletsController.php
@@ -46,7 +46,7 @@ class WalletsController extends Controller
     {
         $dispatchTransferObject = CreateDispatchTransferObject::new()->create(WalletJournal::class);
 
-        $ids = $this->getCharacterIds($dispatchTransferObject, 'wallet_journals');
+        $ids = $this->getCharacterIds($dispatchTransferObject, 'walletJournals');
 
         return inertia('Character/Wallet/Index', [
             'dispatchTransferObject' => $dispatchTransferObject,
@@ -58,7 +58,7 @@ class WalletsController extends Controller
     {
         $query = WalletJournal::query()
             ->where('wallet_journable_id', $character_id)
-            ->with('wallet_journable')
+            ->with('walletJournable')
             ->orderByDesc('date');
 
         request()->whenHas('ref_type', fn (array $types) => $query->whereIn('ref_type', $types));

--- a/src/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController.php
+++ b/src/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController.php
@@ -85,7 +85,7 @@ class MemberComplianceController
                 'characters.alliance.ssoScopes',
                 'characters.application.corporation.ssoScopes',
                 'characters.application.corporation.alliance.ssoScopes',
-                'characters.refresh_token',
+                'characters.refreshToken',
                 'application.corporation.ssoScopes',
                 'application.corporation.alliance.ssoScopes',
             ]);

--- a/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
+++ b/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
@@ -72,7 +72,7 @@ class MemberTrackingController extends Controller
         ])->flatten(1)->filter();
 
         $query = CorporationMemberTracking::where('corporation_id', $corporation_id)
-            ->with('character.refresh_token', 'location.locatable', 'ship');
+            ->with('character.refreshToken', 'location.locatable', 'ship');
 
         return MemberTrackingResource::collection($query->paginate())->additional(['required_scopes' => $sso_scopes]);
     }

--- a/src/Http/Controllers/Corporation/Recruitment/ApplicationsController.php
+++ b/src/Http/Controllers/Corporation/Recruitment/ApplicationsController.php
@@ -74,8 +74,8 @@ class ApplicationsController extends Controller
     public function getOpenCorporationApplications(int $corporation_id, int $decision_count): AnonymousResourceCollection
     {
         $query = Application::query()
-            ->with('log_entries')
-            ->whereHas('log_entries', function (Builder $query) {
+            ->with('logEntries')
+            ->whereHas('logEntries', function (Builder $query) {
                 $query->where('type', 'decision');
             }, '=', $decision_count)
             ->ofCorporation($corporation_id)
@@ -98,13 +98,13 @@ class ApplicationsController extends Controller
         $application = Application::query()
             ->with([
                 'corporation',
-                'log_entries.causer' => function (MorphTo $morphTo) {
+                'logEntries.causer' => function (MorphTo $morphTo) {
                     $morphTo->morphWith([User::class => ['mainCharacter']]);
                 },
                 'applicationable' => function (MorphTo $morphTo) {
                     $morphTo->morphWith([
-                        User::class => ['mainCharacter', 'characters', 'characters.batch_update'],
-                        CharacterInfo::class => ['batch_update'],
+                        User::class => ['mainCharacter', 'characters', 'characters.batchUpdate'],
+                        CharacterInfo::class => ['batchUpdate'],
                     ]);
                 },
             ])
@@ -178,13 +178,13 @@ class ApplicationsController extends Controller
     {
         return Application::query()
             ->with([
-                'log_entries.causer' => function (MorphTo $morphTo) {
+                'logEntries.causer' => function (MorphTo $morphTo) {
                     $morphTo->morphWith([User::class => ['mainCharacter']]);
                 },
                 'applicationable' => function (MorphTo $morphTo) {
                     $morphTo->morphWith([
-                        User::class => ['mainCharacter', 'characters', 'characters.batch_update'],
-                        CharacterInfo::class => ['batch_update'],
+                        User::class => ['mainCharacter', 'characters', 'characters.batchUpdate'],
+                        CharacterInfo::class => ['batchUpdate'],
                     ]);
                 },
             ])

--- a/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
+++ b/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
@@ -55,7 +55,7 @@ class CorporationWalletController extends Controller
     {
         return WalletJournal::where('wallet_journable_id', $corporation_id)
             ->where('division', $division_id)
-            ->with('wallet_journable')
+            ->with('walletJournable')
             ->orderByDesc('date')
             ->paginate();
     }

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -40,7 +40,7 @@ class HomeController extends Controller
     public function home(): Response
     {
         return Inertia::render('Dashboard/Index', [
-            'characters' => CharacterInfo::with('corporation', 'alliance', 'application', 'balance', 'batch_update')
+            'characters' => CharacterInfo::with('corporation', 'alliance', 'application', 'balance', 'batchUpdate')
                 ->whereIn('character_id', auth()->user()->characters->pluck('character_id')->toArray())
                 ->get(),
         ]);

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -71,9 +71,9 @@ class HandleInertiaRequests extends Middleware
                     'mainCharacter',
                     'characters' => [
                         'corporation',
-                        'refresh_token',
+                        'refreshToken',
                         'alliance',
-                        'character_affiliation',
+                        'characterAffiliation',
                     ],
                 ])
                     ->where('id', auth()->user()->getAuthIdentifier())

--- a/src/Http/Resources/ContractRessource.php
+++ b/src/Http/Resources/ContractRessource.php
@@ -42,9 +42,9 @@ class ContractRessource extends JsonResource
     public function toArray(Request $request): array
     {
         /** @var Location|null $start_location */
-        $start_location = $this->start_location;
+        $start_location = $this->startLocation;
         /** @var Location|null $end_location */
-        $end_location = $this->end_location;
+        $end_location = $this->endLocation;
 
         return [
             'contract_id' => $this->contract_id,

--- a/src/Http/Resources/UserRessource.php
+++ b/src/Http/Resources/UserRessource.php
@@ -48,7 +48,7 @@ class UserRessource extends JsonResource
             'characters' => $this->characters
                 ->map(function (CharacterInfo $character): array {
                     /** @var RefreshToken|null $refresh_token */
-                    $refresh_token = $character->refresh_token;
+                    $refresh_token = $character->refreshToken;
 
                     return [
                         'character_id' => $character->character_id,

--- a/src/Services/Recruitment/GetApplicationCharacterScopesService.php
+++ b/src/Services/Recruitment/GetApplicationCharacterScopesService.php
@@ -51,7 +51,7 @@ class GetApplicationCharacterScopesService
             'alliance.ssoScopes',
             'application.corporation.ssoScopes',
             'application.corporation.alliance.ssoScopes',
-            'refresh_token',
+            'refreshToken',
         ]);
 
         $user = User::whereHas('characters', fn (Builder $q) => $q->where('character_infos.character_id', $character->character_id))
@@ -72,7 +72,7 @@ class GetApplicationCharacterScopesService
             $this->getUserApplicationScopes($user),
         ));
 
-        $token_scopes = $character->refresh_token->scopes ?? [];
+        $token_scopes = $character->refreshToken->scopes ?? [];
         $missing_scopes = array_values(array_diff($required_scopes, $token_scopes));
 
         return [

--- a/src/Services/SearchService.php
+++ b/src/Services/SearchService.php
@@ -62,10 +62,10 @@ class SearchService
         /** @var RefreshToken|null $token */
         $token = Cache::remember("esi-search:$user_id", now()->addHour()->diffInSeconds(), function () {
             $user = User::query()
-                ->with('characters.refresh_token')
+                ->with('characters.refreshToken')
                 ->find(auth()->user()->getAuthIdentifier());
 
-            $tokens = $user->characters->map(fn (CharacterInfo $character) => $character->refresh_token)->filter();
+            $tokens = $user->characters->map(fn (CharacterInfo $character) => $character->refreshToken)->filter();
 
             return $tokens->firstWhere(fn (RefreshToken $token) => in_array('esi-search.search_structures.v1', $token->scopes));
         });

--- a/tests/Feature/ComplianceLifeCycleTest.php
+++ b/tests/Feature/ComplianceLifeCycleTest.php
@@ -191,7 +191,7 @@ test('director user without permission can review its corp members', function ()
     SsoScopes::updateOrCreate([
         'morphable_id' => test()->test_character->corporation->corporation_id,
     ], [
-        'selected_scopes' => test()->test_character->refresh_token->scopes,
+        'selected_scopes' => test()->test_character->refreshToken->scopes,
         'morphable_type' => CorporationInfo::class,
         'type' => 'default',
     ]);
@@ -322,7 +322,7 @@ function createScopeSetting(array $permissons = [], $type = 'default')
     expect(SsoScopes::all())->toBeEmpty();
 
     // Make sure secondary character is missing the required scope
-    expect(in_array('esi-assets.read_assets.v1', test()->secondary_character->refresh_token->scopes))->toBeFalse();
+    expect(in_array('esi-assets.read_assets.v1', test()->secondary_character->refreshToken->scopes))->toBeFalse();
 
     SsoScopes::updateOrCreate([
         'morphable_id' => test()->secondary_character->corporation->corporation_id,

--- a/tests/Feature/Controller/DispatchJobControllerTest.php
+++ b/tests/Feature/Controller/DispatchJobControllerTest.php
@@ -46,7 +46,7 @@ it('dispatches job', function () {
 });
 
 test('one get dispatchable character entities', function () {
-    updateRefreshTokenWithScopes(test()->test_character->refresh_token, test()->dispatch_transfer_object['required_scopes']);
+    updateRefreshTokenWithScopes(test()->test_character->refreshToken, test()->dispatch_transfer_object['required_scopes']);
 
     expect(test()->test_character->contacts()->count())->toBeGreaterThan(0);
 
@@ -86,7 +86,7 @@ test('one get dispatchable corporation entities', function () {
     expect(test()->test_character->roles->hasRole('roles', 'Director'))->toBeTrue();
 
     // update the refresh token with the required scopes
-    updateRefreshTokenWithScopes(test()->test_character->refresh_token, $dispatch_transfer_object['required_scopes']);
+    updateRefreshTokenWithScopes(test()->test_character->refreshToken, $dispatch_transfer_object['required_scopes']);
 
     // create contact for the corporation
     Contact::factory()->create([

--- a/tests/Feature/Controller/GetAffiliatedCorporationsControllerTest.php
+++ b/tests/Feature/Controller/GetAffiliatedCorporationsControllerTest.php
@@ -31,7 +31,7 @@ it('get affiliated corporations', function () {
 
     expect(CorporationInfo::find(test()->test_character->corporation->corporation_id))
         ->not()->toBeNull()
-        ->wallet_journals->toHaveCount(5);
+        ->walletJournals->toHaveCount(5);
 
     $response = test()->actingAs(test()->test_user->refresh())
         ->get(route('get.affiliated.corporations', [

--- a/tests/Feature/EsiSearchTest.php
+++ b/tests/Feature/EsiSearchTest.php
@@ -32,7 +32,7 @@ it('can navigate to the enabling ESI Search page', function () {
         );
 
     // pretent that the token has been created
-    updateRefreshTokenWithScopes($this->test_character->refresh_token, ['esi-search.search_structures.v1']);
+    updateRefreshTokenWithScopes($this->test_character->refreshToken, ['esi-search.search_structures.v1']);
 
     // now if we return to the page, we should get redirected
     test()->actingAs($this->test_user)
@@ -42,7 +42,7 @@ it('can navigate to the enabling ESI Search page', function () {
 
 // try get the token and succeed to do so
 it('returns truthy if the user has the necessary scope', function () {
-    updateRefreshTokenWithScopes($this->test_character->refresh_token, ['esi-search.search_structures.v1']);
+    updateRefreshTokenWithScopes($this->test_character->refreshToken, ['esi-search.search_structures.v1']);
 
     $result = $this->actingAs($this->test_user)
         ->get(route('autosuggestion.token'))

--- a/tests/Feature/RecruitmentLifeCycleTest.php
+++ b/tests/Feature/RecruitmentLifeCycleTest.php
@@ -595,7 +595,7 @@ test('recruiter can comment on application', function () {
                     'application',
                     fn (Assert $page) => $page
                         ->has(
-                            'logEntries',
+                            'log_entries',
                             1,
                             fn (Assert $page) => $page
                                 ->where('comment', $comment)
@@ -672,7 +672,7 @@ it('returns activity log entries for closed applications', function () {
             fn (AssertableJson $json) => $json->where('id', $application->id)
                 ->where('status', 'rejected')
                 ->where(
-                    'logEntries',
+                    'log_entries',
                     fn (Collection $collection) => Arr::has($collection->first(), 'causer')
                 )
                 ->etc()

--- a/tests/Feature/RecruitmentLifeCycleTest.php
+++ b/tests/Feature/RecruitmentLifeCycleTest.php
@@ -595,7 +595,7 @@ test('recruiter can comment on application', function () {
                     'application',
                     fn (Assert $page) => $page
                         ->has(
-                            'log_entries',
+                            'logEntries',
                             1,
                             fn (Assert $page) => $page
                                 ->where('comment', $comment)
@@ -655,7 +655,7 @@ it('returns activity log entries for closed applications', function () {
         'status' => 'rejected',
     ]));
 
-    $application->log_entries()->create([
+    $application->logEntries()->create([
         'causer_type' => CharacterInfo::class,
         'causer_id' => test()->test_character->character_id,
         'type' => faker()->randomElement(['decision', 'comment']),
@@ -672,7 +672,7 @@ it('returns activity log entries for closed applications', function () {
             fn (AssertableJson $json) => $json->where('id', $application->id)
                 ->where('status', 'rejected')
                 ->where(
-                    'log_entries',
+                    'logEntries',
                     fn (Collection $collection) => Arr::has($collection->first(), 'causer')
                 )
                 ->etc()

--- a/tests/Unit/Services/GetEntityFromIdTest.php
+++ b/tests/Unit/Services/GetEntityFromIdTest.php
@@ -9,7 +9,7 @@ use Seatplus\Web\Services\GetEntityFromId;
 test('happy path', function () {
     $character = CharacterInfo::factory()->create();
 
-    $character_affiliation = $character->character_affiliation;
+    $character_affiliation = $character->characterAffiliation;
 
     $expected_result = [
         'id' => $character_affiliation->character_id,
@@ -38,7 +38,7 @@ test('happy path', function () {
 test('happy path without alliance', function () {
     $character = CharacterInfo::factory()->create();
 
-    $character_affiliation = $character->character_affiliation;
+    $character_affiliation = $character->characterAffiliation;
 
     $character_affiliation->alliance_id = null;
     $character_affiliation->save();
@@ -62,7 +62,7 @@ test('happy path without alliance', function () {
 test('happy path via corporation id', function () {
     $character = CharacterInfo::factory()->create();
 
-    $character_affiliation = $character->character_affiliation;
+    $character_affiliation = $character->characterAffiliation;
 
     $expected_result = [
         'id' => $character_affiliation->corporation_id,
@@ -83,7 +83,7 @@ test('happy path via corporation id', function () {
 test('happy path via alliance id', function () {
     $character = CharacterInfo::factory()->create();
 
-    $character_affiliation = $character->character_affiliation;
+    $character_affiliation = $character->characterAffiliation;
 
     $expected_result = [
         'id' => $character_affiliation->alliance_id,

--- a/tests/Unit/Services/SearchServiceTest.php
+++ b/tests/Unit/Services/SearchServiceTest.php
@@ -5,7 +5,7 @@ use Seatplus\Eveapi\Models\Universe\System;
 use Seatplus\Web\Services\SearchService;
 
 it('searches esi with a scoped token and returns the raw result', function () {
-    $token = test()->test_character->refresh_token;
+    $token = test()->test_character->refreshToken;
     updateRefreshTokenWithScopes($token, ['esi-search.search_structures.v1']);
 
     $system = System::factory()->create(['name' => 'jita']);


### PR DESCRIPTION
Adopts eveapi **4.1.4**'s camelCase relation methods across web (which `^4.1.2` now resolves to). Mirrors eveapi #684 and auth #411.

### Renamed relation references
`refresh_token`→`refreshToken`, `log_entries`→`logEntries`, `wallet_journals`→`walletJournals`, `wallet_journable`→`walletJournable`, `batch_update`→`batchUpdate`, Contract `start_location`/`end_location`/`assignee_*`/`issuer_*` → camelCase, Contact `*_affiliation` → `*Affiliation`.

### Deliberately kept snake (not relations)
The `'wallet_journals'` **permission** name, `ContractResource`'s `start_location`/`end_location` **JSON output keys**, `RefreshToken` **column** writes, and **local variables** (web's own-code camelCasing is deferred — same scope split as auth#411).

### ⛔ Blocked on auth release — CI will be RED until then
The remaining test failures (`undefined relationship [refresh_token]`) are **not** in web's code — they come from web's installed `vendor/seatplus/auth` **4.1.0**, whose `BuildScopesArrayService` still eager-loads the snake `'refresh_token'` relation against the now-camelCase eveapi model. That's exactly what **auth#411** fixes.

**Dependency chain:** eveapi 4.1.4 ✅ released → **auth#411 (merge + release needed)** → this PR. Once auth#411 releases, `composer update seatplus/auth` here (bumping the constraint to the released version if needed) turns CI green.

### Gates on web's own code
Pint ✅ · PHPStan ✅. Verified locally that patching the installed auth's one eager-load to camelCase clears **all** remaining failures, confirming web's adoption is complete and the only blocker is the unreleased auth.

Ref seatplus/core#235.