### PR TITLE
chore: declare lodash `_` as an eslint global

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ export default [
         languageOptions: {
             globals: {
                 ...globals.browser,
+                _: "readonly",
                 route: "readonly",
                 axios: "readonly",
             },


### PR DESCRIPTION
Lodash is used as the global `_` (`_.get`, `_.map`, …) across the Vue sources, but it was never registered in the flat eslint config's `globals` block. As a result every lodash call trips `no-undef` in the advisory lint step — the bulk of the noise currently reported there.

This registers `_: "readonly"` alongside the existing `route`/`axios` globals, clearing all the `'_' is not defined` errors in one line.

**Scope:** lint config only — no behaviour change, no dependency change. The remaining advisory-lint items (unused imports, single-word component names, `no-prototype-builtins`) are a longer tail better addressed per-file during the per-controller modernization work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)