### PR TITLE
chore: drop @tailwindcss/aspect-ratio for v4-native aspect-*

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.4.0",
-                "@tailwindcss/aspect-ratio": "^0.4.0",
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/typography": "^0.5.4",
                 "@tailwindcss/vite": "^4.3.2",
@@ -1171,16 +1170,6 @@
                 "@vue/composition-api": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@tailwindcss/aspect-ratio": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.2.tgz",
-            "integrity": "sha512-8QPrypskfBa7QIMuKHg2TA7BqES6vhBrDLOv8Unb6FcFyd3TjKbc6lcmb9UPQHxfl24sXoJ41ux/H7qQQvfaSQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
             }
         },
         "node_modules/@tailwindcss/forms": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.4.0",
-        "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/typography": "^0.5.4",
         "@tailwindcss/vite": "^4.3.2",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -6,7 +6,6 @@
 
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
-@plugin '@tailwindcss/aspect-ratio';
 
 @theme {
   --font-sans:

--- a/resources/js/Pages/Onboarding/Introduction.vue
+++ b/resources/js/Pages/Onboarding/Introduction.vue
@@ -8,9 +8,9 @@
             aria-hidden="true"
           />
           <div class="mx-auto max-w-md px-4 sm:max-w-3xl sm:px-6 lg:max-w-none lg:p-0">
-            <div class="aspect-w-10 aspect-h-6 sm:aspect-w-2 sm:aspect-h-1 lg:aspect-w-1">
+            <div class="aspect-[10/6] sm:aspect-[2/1] lg:aspect-square">
               <img
-                class="rounded-3xl object-cover object-center shadow-2xl"
+                class="h-full w-full rounded-3xl object-cover object-center shadow-2xl"
                 :src="`https://images.evetech.net/characters/${mainCharacterId}/portrait?size=512`"
                 :alt="resolvedObject?.name"
               >


### PR DESCRIPTION
Removes the `@tailwindcss/aspect-ratio` plugin in favour of v4-native `aspect-ratio` support. Rebased directly onto `5.x` (independent of #1518).

## Changes
The only remaining consumer of the old plugin was `Onboarding/Introduction.vue`'s portrait box:
- `aspect-w-10 aspect-h-6 sm:aspect-w-2 sm:aspect-h-1 lg:aspect-w-1` → `aspect-[10/6] sm:aspect-[2/1] lg:aspect-square`
- The native utility sets `aspect-ratio` on the element and (unlike the plugin) does **not** absolutely-position children, so the `<img>` gains `h-full w-full` to fill the box — it already had `object-cover object-center`.
- `app.css`: dropped `@plugin '@tailwindcss/aspect-ratio'`.
- `package.json`: dropped the `@tailwindcss/aspect-ratio` dependency.

## Verification
CI **Frontend Build & Lint** passed (`app-*.css` 71.98 kB, built in 1.4s). All test shards + static analysis + pint green.

## Recommended visual check
One changed page — the onboarding **Introduction** step. Confirm the character portrait renders at the right ratio (10:6 mobile → 2:1 sm → square lg), rounded + shadowed, no distortion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)