### PR TITLE
test: web-owned browser tests (run against assembled core)

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -133,15 +133,121 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  browser:
+    name: Browser (vs core)
+    runs-on: ubuntu-latest
+
+    env:
+      DB_CONNECTION: pgsql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_DATABASE: laravel
+      DB_USERNAME: seatplus
+      DB_PASSWORD: secret
+      REDIS_HOST: 127.0.0.1
+      REDIS_PORT: 6379
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: laravel
+          POSTGRES_USER: seatplus
+          POSTGRES_PASSWORD: secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U seatplus -d laravel"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      # Check this PR out into ./web, then assemble a real core app around it.
+      - uses: actions/checkout@v4
+        with:
+          path: web
+
+      - name: Clone core
+        run: git clone --depth 1 -b 5.x https://github.com/seatplus/core.git core
+
+      - name: Overlay this PR into core/packages/web
+        run: |
+          rm -rf core/packages/web
+          cp -R web core/packages/web
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: mbstring, dom, fileinfo, pgsql, pdo_pgsql, redis, sockets
+          coverage: none
+
+      # Point core at the overlaid web via a path repo and alias the PR branch to a
+      # 5.x dev version so it satisfies core's `seatplus/web: ^5.0` constraint.
+      - name: Resolve core against the PR's web
+        working-directory: core
+        run: |
+          composer config repositories.web '{"type":"path","url":"packages/web"}'
+          composer require "seatplus/web:dev-${{ github.head_ref }} as 5.99.99" -W --no-interaction --no-scripts
+
+      - name: Prepare app env + publish assets
+        working-directory: core
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+          php artisan vendor:publish --tag=web-static --force
+          php artisan vendor:publish --tag=web --force
+
+      - name: Copy this PR's browser tests into core
+        working-directory: core
+        run: |
+          mkdir -p tests/Browser/web
+          cp -R packages/web/tests/Browser/. tests/Browser/web/
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build assets + Playwright
+        working-directory: core
+        run: |
+          npm install
+          npm install --save-dev playwright
+          npm run build
+          npx playwright install --with-deps chromium
+
+      - name: Run browser tests
+        working-directory: core
+        run: vendor/bin/pest tests/Browser --no-coverage
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-browser-screenshots
+          path: core/tests/Browser/Screenshots/
+          if-no-files-found: warn
+
   laravel:
     name: Laravel
     runs-on: ubuntu-latest
-    needs: [lint, test, frontend]
+    needs: [lint, test, frontend, browser]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.lint.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.frontend.result }}" != "success" ]]; then
+          if [[ "${{ needs.lint.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.frontend.result }}" != "success" || "${{ needs.browser.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -172,18 +172,19 @@ jobs:
           --health-retries 5
 
     steps:
-      # Check this PR out into ./web, then assemble a real core app around it.
-      - uses: actions/checkout@v4
+      # Assemble a real app: core at 5.x, with THIS PR checked out in place at
+      # core/packages/web (a path repo core resolves seatplus/web from).
+      - name: Checkout core
+        uses: actions/checkout@v4
         with:
-          path: web
+          repository: seatplus/core
+          ref: 5.x
+          path: core
 
-      - name: Clone core
-        run: git clone --depth 1 -b 5.x https://github.com/seatplus/core.git core
-
-      - name: Overlay this PR into core/packages/web
-        run: |
-          rm -rf core/packages/web
-          cp -R web core/packages/web
+      - name: Checkout this PR's web into core
+        uses: actions/checkout@v4
+        with:
+          path: core/packages/web
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -192,13 +193,15 @@ jobs:
           extensions: mbstring, dom, fileinfo, pgsql, pdo_pgsql, redis, sockets
           coverage: none
 
-      # Point core at the overlaid web via a path repo and alias the PR branch to a
-      # 5.x dev version so it satisfies core's `seatplus/web: ^5.0` constraint.
-      - name: Resolve core against the PR's web
+      # Give the overlaid path package an explicit version so core's
+      # `seatplus/web: ^5.0` resolves straight to it (a path repo is canonical /
+      # top-priority). Avoids the detached-checkout dev-<sha> version mismatch.
+      - name: Resolve core against the overlaid web
         working-directory: core
         run: |
+          python3 -c "import json; f='packages/web/composer.json'; d=json.load(open(f)); d['version']='5.99.99'; json.dump(d, open(f,'w'), indent=4)"
           composer config repositories.web '{"type":"path","url":"packages/web"}'
-          composer require "seatplus/web:dev-${{ github.head_ref }} as 5.99.99" -W --no-interaction --no-scripts
+          composer update seatplus/web -W --no-interaction --no-scripts
 
       - name: Prepare app env + publish assets
         working-directory: core

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Overlay this PR into core/packages/web
         run: |
-          rm -rf core/packages/web
+          mkdir -p core/packages
           cp -R web core/packages/web
 
       - name: Setup PHP

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -241,6 +241,7 @@ jobs:
           name: web-browser-screenshots
           path: core/tests/Browser/Screenshots/
           if-no-files-found: warn
+          retention-days: 7
 
   laravel:
     name: Laravel

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -79,7 +79,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -119,7 +119,7 @@ jobs:
         run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -175,14 +175,14 @@ jobs:
       # Assemble a real app: core at 5.x, with THIS PR checked out in place at
       # core/packages/web (a path repo core resolves seatplus/web from).
       - name: Checkout core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: seatplus/core
           ref: 5.x
           path: core
 
       - name: Checkout this PR's web into core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: core/packages/web
 
@@ -218,7 +218,7 @@ jobs:
           cp -R packages/web/tests/Browser/. tests/Browser/web/
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -236,7 +236,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web-browser-screenshots
           path: core/tests/Browser/Screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ public/js/
 /resources/js/routes/
 /resources/js/actions/
 /resources/js/wayfinder/
+
+# pest-plugin-browser screenshots (captured at test time, not committed)
+/tests/Browser/Screenshots/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,10 @@
     <testsuites>
         <testsuite name="Seatplus Test Suite">
             <directory>tests</directory>
+            <!-- Browser tests run against a real assembled core app, not this
+                 Testbench harness. They live here so they're authored + shipped
+                 with the package, but core's browser CI executes them. -->
+            <exclude>tests/Browser</exclude>
         </testsuite>
     </testsuites>
     <php>

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -4,6 +4,13 @@
 /*Tailwind CSS*/
 @import 'tailwindcss';
 
+/* Explicitly scan the Vue/JS sources for class names. Tailwind v4's automatic
+   content detection skips gitignored paths, and in the consuming app (core)
+   resources/js is a gitignored published artifact — without this, no utility
+   classes are generated and the app renders unstyled. @source overrides the
+   gitignore exclusion. Path is relative to this file (resources/css). */
+@source "../js/**/*.{vue,js}";
+
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
 

--- a/tests/Browser/LoginSmokeTest.php
+++ b/tests/Browser/LoginSmokeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Browser smoke test for the login page — authored in the web package (where the
+ * Vue pages live) but executed against a real, fully-assembled core app, never
+ * under web's own Testbench harness (web's phpunit.xml excludes tests/Browser).
+ *
+ * It runs in two places, both driving the same assembled app:
+ *   - core's browser CI, against the released web package, and
+ *   - a web PR's browser job, which clones core and overlays this branch into
+ *     packages/web so the PR's frontend is what renders.
+ *
+ * `visit()` / assertNoSmoke() / screenshot() come from pest-plugin-browser, which
+ * is provided by the core app the tests run inside — not by the web package.
+ */
+it('renders the login page', function () {
+    $page = visit('/login');
+
+    $page->assertNoSmoke();
+    $page->assertSee('Sign in');
+    $page->screenshot(true, 'login');
+});


### PR DESCRIPTION
First step toward browser tests that live **in the web package** (next to the Vue pages) but execute against a **real, fully-assembled core app** — because web's Testbench harness can't serve a real page.

## What's here
- **`tests/Browser/LoginSmokeTest.php`** — `visit('/login')` → `assertNoSmoke()` + `assertSee('Sign in')` + screenshot. Uses `pest-plugin-browser` globals, which are provided by the **core** app the test runs inside (not by this package).
- **`phpunit.xml`** — excludes `tests/Browser` from web's own suite. Verified: web's Pest discovers 265 tests, none from Browser, so `composer test` never tries to run a browser test under Testbench.
- **`.gitignore`** — `tests/Browser/Screenshots/`.

## How it runs (two contexts, same assembled app)
- **Core browser CI** — against the released web package (web ships `tests/` in its Packagist dist, so core copies them in).
- **Web PR browser job** — clones core, overlays this branch into `packages/web` via a path repo, so the PR's frontend is what renders. *(Workflow added separately — it needs the `workflow` OAuth scope this automation token lacks; the exact YAML is handed off with this work.)*

## Not yet
- Authed-page tests (`$this->actingAs(User::factory()->create())` + `RefreshDatabase`, per pest-plugin-browser docs) — added once this guest smoke proves the pipeline green in CI (needs a `php artisan migrate` step + factory wiring in the run, validated in CI since it can't run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)