### PR TITLE
test: authenticated browser smoke test

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -22,17 +22,15 @@ const I18nPlugin = {
 }
 
 createInertiaApp({
-    resolve: (name) => {
-        const page = resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue'));
+    resolve: async (name) => {
+        const module = await resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue'));
 
-        page.then((module) => {
-            if (module.default.layout === undefined) {
-                module.default.layout = SingleColumnLayout;
-            }
-        });
+        // Default persistent layout for pages that don't set their own. Assign it
+        // before returning (not in a fire-and-forget .then) so it's applied on the
+        // initial mount.
+        module.default.layout ??= SingleColumnLayout;
 
-        return page;
-
+        return module;
     },
     setup({ el, App, props, plugin }) {
         return createApp({ render: () => h(App, props) })

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -27,13 +27,7 @@
 namespace Seatplus\Web\Http\Middleware;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Session;
 use Inertia\Middleware;
-use Seatplus\Auth\Models\User;
-use Seatplus\Web\Http\Resources\UserRessource;
-use Seatplus\Web\Services\Sidebar\SidebarEntries;
-use Seatplus\Web\Support\Locales;
-use Seatplus\Web\Support\Translations;
 
 class HandleInertiaRequests extends Middleware
 {
@@ -52,49 +46,8 @@ class HandleInertiaRequests extends Middleware
         return parent::version($request);
     }
 
-    /**
-     * Defines the props that are shared by default.
-     *
-     * @see https://inertiajs.com/shared-data
-     */
-    public function share(Request $request): array
-    {
-        return array_merge(parent::share($request), [
-            // Locale is resolved + set by the SetLocale middleware before controllers/props run.
-            'locale' => fn () => app()->getLocale(),
-            'locales' => fn () => Locales::available(),
-            // Shared chrome translations (baseline) — the notification labels the persistent
-            // layout (Toast.vue) needs on every page. Page-specific groups arrive as a
-            // `pageTranslations` prop and are merged client-side.
-            'translations' => fn () => Translations::gather(['web::notifications']),
-            'activeSidebarElement' => $request->route()?->getName(),
-            'flash' => fn () => [
-                'success' => session()->pull('success'),
-                'info' => session()->pull('info'),
-                'warning' => session()->pull('warning'),
-                'error' => session()->pull('error'),
-            ],
-            'sidebar' => fn () => auth()->guest() ? [] : (new SidebarEntries)->getFilteredEntries(),
-            'user' => fn () => auth()->guest() ? '' : UserRessource::make(
-                User::with([
-                    'mainCharacter',
-                    'characters' => [
-                        'corporation',
-                        'refreshToken',
-                        'alliance',
-                        'characterAffiliation',
-                    ],
-                ])
-                    ->where('id', auth()->user()->getAuthIdentifier())
-                    ->first()
-            ),
-            'errors' => fn () => Session::get('errors')
-                ? Session::get('errors')->getBag('default')->getMessages()
-                : (object) [],
-            'images' => fn () => [
-                'logo' => asset(config('web.images.logo')),
-                'icon' => asset(config('web.images.icon')),
-            ],
-        ]);
-    }
+    // Shared Inertia props are registered at the provider level via Inertia::share()
+    // in WebServiceProvider::boot(), so they apply even when this pushed group
+    // middleware isn't run (e.g. the Pest browser in-process server). See the note
+    // there and seatplus/web#1530.
 }

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -27,7 +27,13 @@
 namespace Seatplus\Web\Http\Middleware;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
 use Inertia\Middleware;
+use Seatplus\Auth\Models\User;
+use Seatplus\Web\Http\Resources\UserRessource;
+use Seatplus\Web\Services\Sidebar\SidebarEntries;
+use Seatplus\Web\Support\Locales;
+use Seatplus\Web\Support\Translations;
 
 class HandleInertiaRequests extends Middleware
 {
@@ -46,8 +52,49 @@ class HandleInertiaRequests extends Middleware
         return parent::version($request);
     }
 
-    // Shared Inertia props are registered at the provider level via Inertia::share()
-    // in WebServiceProvider::boot(), so they apply even when this pushed group
-    // middleware isn't run (e.g. the Pest browser in-process server). See the note
-    // there and seatplus/web#1530.
+    /**
+     * Defines the props that are shared by default.
+     *
+     * @see https://inertiajs.com/shared-data
+     */
+    public function share(Request $request): array
+    {
+        return array_merge(parent::share($request), [
+            // Locale is resolved + set by the SetLocale middleware before controllers/props run.
+            'locale' => fn () => app()->getLocale(),
+            'locales' => fn () => Locales::available(),
+            // Shared chrome translations (baseline) — the notification labels the persistent
+            // layout (Toast.vue) needs on every page. Page-specific groups arrive as a
+            // `pageTranslations` prop and are merged client-side.
+            'translations' => fn () => Translations::gather(['web::notifications']),
+            'activeSidebarElement' => $request->route()?->getName(),
+            'flash' => fn () => [
+                'success' => session()->pull('success'),
+                'info' => session()->pull('info'),
+                'warning' => session()->pull('warning'),
+                'error' => session()->pull('error'),
+            ],
+            'sidebar' => fn () => auth()->guest() ? [] : (new SidebarEntries)->getFilteredEntries(),
+            'user' => fn () => auth()->guest() ? '' : UserRessource::make(
+                User::with([
+                    'mainCharacter',
+                    'characters' => [
+                        'corporation',
+                        'refreshToken',
+                        'alliance',
+                        'characterAffiliation',
+                    ],
+                ])
+                    ->where('id', auth()->user()->getAuthIdentifier())
+                    ->first()
+            ),
+            'errors' => fn () => Session::get('errors')
+                ? Session::get('errors')->getBag('default')->getMessages()
+                : (object) [],
+            'images' => fn () => [
+                'logo' => asset(config('web.images.logo')),
+                'icon' => asset(config('web.images.icon')),
+            ],
+        ]);
+    }
 }

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -26,15 +26,21 @@
 
 namespace Seatplus\Web;
 
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\ServiceProvider;
 use Inertia\ExceptionResponse;
 use Inertia\Inertia;
+use Seatplus\Auth\Models\User;
 use Seatplus\Web\Console\Commands\AssignSuperuser;
 use Seatplus\Web\Console\Commands\CheckTranslationKeys;
 use Seatplus\Web\Contracts\WebJobsRepository;
 use Seatplus\Web\Http\Middleware\Authenticate;
 use Seatplus\Web\Http\Middleware\HandleInertiaRequests;
 use Seatplus\Web\Http\Middleware\SetLocale;
+use Seatplus\Web\Http\Resources\UserRessource;
+use Seatplus\Web\Services\Sidebar\SidebarEntries;
+use Seatplus\Web\Support\Locales;
+use Seatplus\Web\Support\Translations;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 
 class WebServiceProvider extends ServiceProvider
@@ -58,6 +64,50 @@ class WebServiceProvider extends ServiceProvider
         // even when the per-request middleware isn't run — e.g. Pest browser's
         // in-process server, which doesn't apply provider-pushed group middleware.
         Inertia::setRootView('web::app');
+
+        // Shared Inertia props, registered at provider level for the same reason
+        // as the root view: they must be present even when the pushed group
+        // middleware (HandleInertiaRequests) isn't applied (e.g. the Pest browser
+        // in-process server) — otherwise pages that read shared props (the sidebar
+        // reads `images`/`user`/`sidebar`) crash on mount. Closures are evaluated
+        // per response, so request()/auth()/session() resolve per request.
+        Inertia::share([
+            // Locale is resolved + set by the SetLocale middleware before controllers/props run.
+            'locale' => fn () => app()->getLocale(),
+            'locales' => fn () => Locales::available(),
+            // Shared chrome translations (baseline) — the notification labels the persistent
+            // layout (Toast.vue) needs on every page. Page-specific groups arrive as a
+            // `pageTranslations` prop and are merged client-side.
+            'translations' => fn () => Translations::gather(['web::notifications']),
+            'activeSidebarElement' => fn () => request()->route()?->getName(),
+            'flash' => fn () => [
+                'success' => session()->pull('success'),
+                'info' => session()->pull('info'),
+                'warning' => session()->pull('warning'),
+                'error' => session()->pull('error'),
+            ],
+            'sidebar' => fn () => auth()->guest() ? [] : (new SidebarEntries)->getFilteredEntries(),
+            'user' => fn () => auth()->guest() ? '' : UserRessource::make(
+                User::with([
+                    'mainCharacter',
+                    'characters' => [
+                        'corporation',
+                        'refreshToken',
+                        'alliance',
+                        'characterAffiliation',
+                    ],
+                ])
+                    ->where('id', auth()->user()->getAuthIdentifier())
+                    ->first()
+            ),
+            'errors' => fn () => Session::get('errors')
+                ? Session::get('errors')->getBag('default')->getMessages()
+                : (object) [],
+            'images' => fn () => [
+                'logo' => asset(config('web.images.logo')),
+                'icon' => asset(config('web.images.icon')),
+            ],
+        ]);
 
         // Add Migrations
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations/');

--- a/src/WebServiceProvider.php
+++ b/src/WebServiceProvider.php
@@ -26,21 +26,16 @@
 
 namespace Seatplus\Web;
 
-use Illuminate\Support\Facades\Session;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Support\ServiceProvider;
 use Inertia\ExceptionResponse;
 use Inertia\Inertia;
-use Seatplus\Auth\Models\User;
 use Seatplus\Web\Console\Commands\AssignSuperuser;
 use Seatplus\Web\Console\Commands\CheckTranslationKeys;
 use Seatplus\Web\Contracts\WebJobsRepository;
 use Seatplus\Web\Http\Middleware\Authenticate;
 use Seatplus\Web\Http\Middleware\HandleInertiaRequests;
 use Seatplus\Web\Http\Middleware\SetLocale;
-use Seatplus\Web\Http\Resources\UserRessource;
-use Seatplus\Web\Services\Sidebar\SidebarEntries;
-use Seatplus\Web\Support\Locales;
-use Seatplus\Web\Support\Translations;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 
 class WebServiceProvider extends ServiceProvider
@@ -60,54 +55,8 @@ class WebServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'web');
 
         // Default the Inertia root view to this package's blade at the provider
-        // level (not only via HandleInertiaRequests::rootView()), so it applies
-        // even when the per-request middleware isn't run — e.g. Pest browser's
-        // in-process server, which doesn't apply provider-pushed group middleware.
+        // level (belt-and-suspenders alongside HandleInertiaRequests::rootView()).
         Inertia::setRootView('web::app');
-
-        // Shared Inertia props, registered at provider level for the same reason
-        // as the root view: they must be present even when the pushed group
-        // middleware (HandleInertiaRequests) isn't applied (e.g. the Pest browser
-        // in-process server) — otherwise pages that read shared props (the sidebar
-        // reads `images`/`user`/`sidebar`) crash on mount. Closures are evaluated
-        // per response, so request()/auth()/session() resolve per request.
-        Inertia::share([
-            // Locale is resolved + set by the SetLocale middleware before controllers/props run.
-            'locale' => fn () => app()->getLocale(),
-            'locales' => fn () => Locales::available(),
-            // Shared chrome translations (baseline) — the notification labels the persistent
-            // layout (Toast.vue) needs on every page. Page-specific groups arrive as a
-            // `pageTranslations` prop and are merged client-side.
-            'translations' => fn () => Translations::gather(['web::notifications']),
-            'activeSidebarElement' => fn () => request()->route()?->getName(),
-            'flash' => fn () => [
-                'success' => session()->pull('success'),
-                'info' => session()->pull('info'),
-                'warning' => session()->pull('warning'),
-                'error' => session()->pull('error'),
-            ],
-            'sidebar' => fn () => auth()->guest() ? [] : (new SidebarEntries)->getFilteredEntries(),
-            'user' => fn () => auth()->guest() ? '' : UserRessource::make(
-                User::with([
-                    'mainCharacter',
-                    'characters' => [
-                        'corporation',
-                        'refreshToken',
-                        'alliance',
-                        'characterAffiliation',
-                    ],
-                ])
-                    ->where('id', auth()->user()->getAuthIdentifier())
-                    ->first()
-            ),
-            'errors' => fn () => Session::get('errors')
-                ? Session::get('errors')->getBag('default')->getMessages()
-                : (object) [],
-            'images' => fn () => [
-                'logo' => asset(config('web.images.logo')),
-                'icon' => asset(config('web.images.icon')),
-            ],
-        ]);
 
         // Add Migrations
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations/');
@@ -190,13 +139,22 @@ class WebServiceProvider extends ServiceProvider
         $router->aliasMiddleware('auth', Authenticate::class);
 
         /*
-         * Localization: resolve + set the request locale before controllers/props run.
+         * Append our web-group middleware through the HTTP kernel rather than the
+         * router. The kernel's constructor runs syncMiddlewareToRouter(), which
+         * *replaces* the router's group definitions with the kernel's own
+         * $middlewareGroups — so anything pushed straight onto the router
+         * ($router->pushMiddlewareToGroup) is lost whenever the kernel is resolved
+         * after this provider boots. Under normal FPM the kernel is built first
+         * (public/index.php) so a router push survives; but Pest's in-process
+         * browser server resolves the kernel lazily *after* boot, wiping it and
+         * leaving Inertia shared props unshared (renders a blank #app). Appending
+         * via the kernel mutates $middlewareGroups itself, so it persists across
+         * every re-sync. Order matters: SetLocale sets the locale that
+         * HandleInertiaRequests then shares.
          */
-        $router->pushMiddlewareToGroup('web', SetLocale::class);
-
-        // Inertia.JS adding
-        // $router->pushMiddlewareToGroup('web', Middleware::class);
-        $router->pushMiddlewareToGroup('web', HandleInertiaRequests::class);
+        $kernel = $this->app->make(HttpKernel::class);
+        $kernel->appendMiddlewareToGroup('web', SetLocale::class);
+        $kernel->appendMiddlewareToGroup('web', HandleInertiaRequests::class);
 
         // Add acl-permission Middelware
         $router->aliasMiddleware('permission', PermissionMiddleware::class);

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -1,25 +1,39 @@
 <?php
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Seatplus\Auth\Database\Factories\UserFactory;
+use Illuminate\Support\Str;
+use Seatplus\Auth\Models\User;
 
 /*
  * Authenticated browser smoke test — runs against the real assembled core app.
  *
  * Logs in a factory user and hits an authed route. A fresh user has no SSO
- * scopes yet, so the auth + CheckRequiredScopes + Onboarding middleware chain
- * routes them through the onboarding/scopes flow rather than the dashboard —
- * which is exactly what we want to smoke: that an authenticated page renders
- * with no JS/console errors and styled. (A scoped-user dashboard test is a
- * follow-up once the scope/character setup is factored out.)
- *
- * We instantiate the auth UserFactory directly rather than User::factory(),
- * because core has no Testbench factory-name guessing.
+ * scopes, so the auth + CheckRequiredScopes + Onboarding middleware chain routes
+ * them through the onboarding/scopes flow rather than the dashboard — which is
+ * exactly what we smoke: that an authenticated page renders with no JS/console
+ * errors and styled. (A scoped-user dashboard test is a follow-up.)
  */
+
 uses(RefreshDatabase::class);
 
+/*
+ * Core (a plain Laravel app) has none of the web package's Testbench factory-name
+ * guessing, so User::factory() and the related factories it invokes (CharacterInfo,
+ * …) can't be resolved by default. Map the seatplus model namespaces to their
+ * package factory namespaces, mirroring the web TestCase.
+ */
+beforeEach(function () {
+    Factory::guessFactoryNamesUsing(fn (string $model) => match (true) {
+        Str::startsWith($model, 'Seatplus\\Auth') => 'Seatplus\\Auth\\Database\\Factories\\'.class_basename($model).'Factory',
+        Str::startsWith($model, 'Seatplus\\Eveapi') => 'Seatplus\\Eveapi\\Database\\Factories\\'.class_basename($model).'Factory',
+        Str::startsWith($model, 'Seatplus\\Web') => 'Seatplus\\Web\\Database\\Factories\\'.class_basename($model).'Factory',
+        default => 'Database\\Factories\\'.class_basename($model).'Factory',
+    });
+});
+
 it('renders an authenticated page without errors', function () {
-    $user = UserFactory::new()->create();
+    $user = User::factory()->create();
 
     $this->actingAs($user);
 

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -61,19 +61,26 @@ it('renders the dashboard for an authenticated user', function () {
 it('wires the character portrait to the EVE image server', function () {
     $character = provisionAuthenticatedUser();
 
-    // EveImage lazy-loads the portrait via an IntersectionObserver, so wait for the
-    // dashboard to render before inspecting the <img>. We assert the *URL wiring*
-    // (correct CCP images.evetech.net portrait endpoint), not that the bytes load —
-    // the factory character id has no real portrait on Tranquility, so
-    // assertNoBrokenImages would be a false negative here.
+    // EveImage lazy-loads the portrait via an IntersectionObserver, so we need an
+    // assertion that waits for the <img> to mount — assertAttributeContains does
+    // (getAttribute retries until the element is attached); a plain snapshot count
+    // races the observer and finds nothing.
     //
-    // The selector encodes the assertion (host + character + portrait variant) and
-    // assertPresent counts matches, so it tolerates the character appearing more
-    // than once (e.g. the sidebar avatar at size=64 and the dashboard card at 512).
-    $selector = "img[src*='images.evetech.net/characters/{$character->character_id}/portrait']";
+    // Scope to the dashboard character-card portrait (h-12 w-12) so the locator
+    // resolves to exactly one element — the character also appears as the sidebar
+    // avatar (h-9 w-9), and a multi-match locator trips Playwright's strict mode.
+    //
+    // We assert the *URL wiring* (correct CCP images.evetech.net portrait endpoint),
+    // not that the bytes load — the factory character id has no real portrait on
+    // Tranquility, so assertNoBrokenImages would be a false negative here.
+    $selector = "img.h-12.w-12[src*='characters/{$character->character_id}/portrait']";
 
     $page = visit('/home');
     $page->waitForText('Characters');
 
-    $page->assertPresent($selector);
+    $page->assertAttributeContains(
+        $selector,
+        'src',
+        "images.evetech.net/characters/{$character->character_id}/portrait",
+    );
 });

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -35,6 +35,9 @@ it('renders the dashboard for an authenticated user', function () {
 
     $page = visit('/home');
 
+    // TEMP DIAGNOSTIC: raw page HTML to CI log (untruncated) to see what #app contains.
+    fwrite(STDERR, "\n<<<PAGEHTML>>>\n".$page->content()."\n<<<ENDHTML>>>\n");
+
     $page->assertNoSmoke();
     $page->assertSee('Characters');
     $page->screenshot(true, 'dashboard');

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -35,9 +35,6 @@ it('renders the dashboard for an authenticated user', function () {
 
     $page = visit('/home');
 
-    // TEMP DIAGNOSTIC: raw page HTML to CI log (untruncated) to see what #app contains.
-    fwrite(STDERR, "\n<<<PAGEHTML>>>\n".$page->content()."\n<<<ENDHTML>>>\n");
-
     $page->assertNoSmoke();
     $page->assertSee('Characters');
     $page->screenshot(true, 'dashboard');

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -1,46 +1,36 @@
 <?php
 
-use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
 use Seatplus\Auth\Models\User;
+use Seatplus\Web\Models\Onboarding;
 
 /*
- * Authenticated browser smoke test — runs against the real assembled core app.
+ * Authenticated dashboard smoke test — runs against the real assembled core app.
  *
- * Logs in a factory user and hits an authed route. A fresh user has no SSO
- * scopes, so the auth + CheckRequiredScopes + Onboarding middleware chain routes
- * them through the onboarding/scopes flow rather than the dashboard — which is
- * exactly what we smoke: that an authenticated page renders with no JS/console
- * errors and styled. (A scoped-user dashboard test is a follow-up.)
+ * Logs in a factory user and loads /home, asserting the actual Dashboard renders
+ * (PageHeader "Home") with no JS/console errors and styled — not just that some
+ * page came back. In testing CheckRequiredScopes is skipped (non-production) and
+ * ONBOARDING defaults off, so /home reaches Dashboard/Index; the Onboarding
+ * record below keeps it passing even if onboarding is enabled.
+ *
+ * Factory-name guessing for the seatplus packages is set for the whole Browser
+ * suite in core's tests/Pest.php.
  */
 
 uses(RefreshDatabase::class);
 
-/*
- * Core (a plain Laravel app) has none of the web package's Testbench factory-name
- * guessing, so User::factory() and the related factories it invokes (CharacterInfo,
- * …) can't be resolved by default. Map the seatplus model namespaces to their
- * package factory namespaces, mirroring the web TestCase.
- */
-beforeEach(function () {
-    Factory::guessFactoryNamesUsing(fn (string $model) => match (true) {
-        Str::startsWith($model, 'Seatplus\\Auth') => 'Seatplus\\Auth\\Database\\Factories\\'.class_basename($model).'Factory',
-        Str::startsWith($model, 'Seatplus\\Eveapi') => 'Seatplus\\Eveapi\\Database\\Factories\\'.class_basename($model).'Factory',
-        Str::startsWith($model, 'Seatplus\\Web') => 'Seatplus\\Web\\Database\\Factories\\'.class_basename($model).'Factory',
-        default => 'Database\\Factories\\'.class_basename($model).'Factory',
-    });
-});
-
-it('renders an authenticated page without errors', function () {
+it('renders the dashboard for an authenticated user', function () {
     $user = User::factory()->create();
+
+    Onboarding::create(['user_id' => $user->getKey()]);
 
     $this->actingAs($user);
 
     $page = visit('/home');
 
     $page->assertNoSmoke();
-    $page->screenshot(true, 'authenticated');
+    $page->assertSee('Home');
+    $page->screenshot(true, 'dashboard');
 
     $this->assertAuthenticated();
 });

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -61,22 +61,25 @@ it('renders the dashboard for an authenticated user', function () {
 it('wires the character portrait to the EVE image server', function () {
     $character = provisionAuthenticatedUser();
 
-    // EveImage lazy-loads the portrait via an IntersectionObserver, so we need an
-    // assertion that waits for the <img> to mount — assertAttributeContains does
-    // (getAttribute retries until the element is attached); a plain snapshot count
-    // races the observer and finds nothing.
-    //
+    $page = visit('/home');
+
+    // EveImage lazy-loads the portrait via an IntersectionObserver with
+    // threshold [1] — the <img> only mounts once the element is 100% within the
+    // viewport. Use a tall viewport so the dashboard character card is fully
+    // visible and the observer fires deterministically; otherwise the portrait may
+    // never mount in a short window and the assertion times out.
+    $page->resize(1280, 2400);
+    $page->waitForText('Characters');
+
     // Scope to the dashboard character-card portrait (h-12 w-12) so the locator
     // resolves to exactly one element — the character also appears as the sidebar
     // avatar (h-9 w-9), and a multi-match locator trips Playwright's strict mode.
+    // assertAttributeContains waits for the (lazy) element to attach.
     //
     // We assert the *URL wiring* (correct CCP images.evetech.net portrait endpoint),
     // not that the bytes load — the factory character id has no real portrait on
     // Tranquility, so assertNoBrokenImages would be a false negative here.
     $selector = "img.h-12.w-12[src*='characters/{$character->character_id}/portrait']";
-
-    $page = visit('/home');
-    $page->waitForText('Characters');
 
     $page->assertAttributeContains(
         $selector,

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -1,33 +1,43 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Queue;
+use Seatplus\Auth\Models\CharacterUser;
 use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Web\Models\Onboarding;
 
 /*
  * Authenticated dashboard smoke test — runs against the real assembled core app.
  *
- * Logs in a user and loads /home, asserting the Dashboard actually renders
- * (the visible "Characters" heading) with no JS/console errors — not just that
- * some page came back.
+ * Provisions a user with a single controlled character and loads /home, asserting
+ * the Dashboard actually renders (visible "Characters" heading) with no JS/console
+ * errors — mirroring a real logged-in user.
  *
- * The user is created minimally (no characters) on purpose: User::factory()
- * builds a multi-character graph whose CharacterInfo affiliations occasionally
- * collide on character_affiliations (random ids), which is flaky here. A
- * characterless user is deterministic and still reaches Dashboard/Index (an
- * empty character list). In testing CheckRequiredScopes is skipped
- * (non-production) and ONBOARDING defaults off; the Onboarding record keeps it
- * passing even if onboarding is enabled.
+ * We create ONE CharacterInfo (its factory builds the affiliation/refresh-token/
+ * role) and link it as the main character, rather than User::factory() — that
+ * builds a two-character graph whose CharacterAffiliation ids intermittently
+ * collide, and a characterless user renders the dashboard blank. Queue is faked so
+ * character-creation model events don't dispatch real ESI jobs. Factory-name
+ * guessing for the seatplus packages is set in core's tests/TestCase::setUp.
  */
 
 uses(RefreshDatabase::class);
 
 it('renders the dashboard for an authenticated user', function () {
+    Queue::fake();
+
+    $character = CharacterInfo::factory()->create();
+
     $user = new User();
-    $user->active = true;
-    $user->remember_token = Str::random(10);
+    $user->main_character_id = $character->character_id;
     $user->save();
+
+    CharacterUser::create([
+        'user_id' => $user->getKey(),
+        'character_id' => $character->character_id,
+        'character_owner_hash' => sha1((string) $character->character_id),
+    ]);
 
     Onboarding::create(['user_id' => $user->getKey()]);
 

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -29,7 +29,9 @@ it('renders the dashboard for an authenticated user', function () {
     $page = visit('/home');
 
     $page->assertNoSmoke();
-    $page->assertSee('Home');
+    // "Characters" is the visible <h3> on the dashboard (Dashboard/Characters.vue);
+    // "Home" is only the document <title>, so assert on real page content.
+    $page->assertSee('Characters');
     $page->screenshot(true, 'dashboard');
 
     $this->assertAuthenticated();

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seatplus\Auth\Database\Factories\UserFactory;
+
+/*
+ * Authenticated browser smoke test — runs against the real assembled core app.
+ *
+ * Logs in a factory user and hits an authed route. A fresh user has no SSO
+ * scopes yet, so the auth + CheckRequiredScopes + Onboarding middleware chain
+ * routes them through the onboarding/scopes flow rather than the dashboard —
+ * which is exactly what we want to smoke: that an authenticated page renders
+ * with no JS/console errors and styled. (A scoped-user dashboard test is a
+ * follow-up once the scope/character setup is factored out.)
+ *
+ * We instantiate the auth UserFactory directly rather than User::factory(),
+ * because core has no Testbench factory-name guessing.
+ */
+uses(RefreshDatabase::class);
+
+it('renders an authenticated page without errors', function () {
+    $user = UserFactory::new()->create();
+
+    $this->actingAs($user);
+
+    $page = visit('/home');
+
+    $page->assertNoSmoke();
+    $page->screenshot(true, 'authenticated');
+
+    $this->assertAuthenticated();
+});

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -67,14 +67,10 @@ it('wires the character portrait to the EVE image server', function () {
 
     $page = visit('/home');
 
-    // EveImage lazy-loads the portrait via an IntersectionObserver with
-    // threshold [1] — the <img> only mounts once the element is 100% within the
-    // viewport. Use a tall viewport so the dashboard character card is fully
-    // visible and the observer fires deterministically; otherwise the portrait may
-    // never mount in a short window and the assertion times out.
-    $page->resize(1280, 2400);
+    // EveImage lazy-loads the portrait via an IntersectionObserver, mounting the
+    // <img> a beat after the page settles — wait for it before asserting.
     $page->waitForText('Characters');
-    $page->wait(1); // give the observer + <img> mount a beat to settle
+    $page->wait(1);
 
     // Scope to the dashboard character-card portrait (h-12 w-12) so the locator
     // resolves to exactly one element — the character also appears as the sidebar

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -50,4 +50,4 @@ it('renders the dashboard for an authenticated user', function () {
     $page->screenshot(true, 'dashboard');
 
     $this->assertAuthenticated();
-});
+})->skip('Authenticated persistent-layout pages mount an empty #app under the pest-browser in-process server (renders fine in a real browser) — see seatplus/web#1530.');

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -66,14 +66,14 @@ it('wires the character portrait to the EVE image server', function () {
     // (correct CCP images.evetech.net portrait endpoint), not that the bytes load —
     // the factory character id has no real portrait on Tranquility, so
     // assertNoBrokenImages would be a false negative here.
-    $selector = "img[src*='characters/{$character->character_id}/portrait']";
+    //
+    // The selector encodes the assertion (host + character + portrait variant) and
+    // assertPresent counts matches, so it tolerates the character appearing more
+    // than once (e.g. the sidebar avatar at size=64 and the dashboard card at 512).
+    $selector = "img[src*='images.evetech.net/characters/{$character->character_id}/portrait']";
 
     $page = visit('/home');
     $page->waitForText('Characters');
 
-    $page->assertAttributeContains(
-        $selector,
-        'src',
-        "images.evetech.net/characters/{$character->character_id}/portrait",
-    );
+    $page->assertPresent($selector);
 });

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -8,11 +8,10 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Web\Models\Onboarding;
 
 /*
- * Authenticated dashboard smoke test — runs against the real assembled core app.
+ * Authenticated dashboard smoke tests — run against the real assembled core app.
  *
- * Provisions a user with a single controlled character and loads /home, asserting
- * the Dashboard actually renders (visible "Characters" heading) with no JS/console
- * errors — mirroring a real logged-in user.
+ * Provisions a user with a single controlled character and loads /home, mirroring
+ * a real logged-in user.
  *
  * We create ONE CharacterInfo (its factory builds the affiliation/refresh-token/
  * role) and link it as the main character, rather than User::factory() — that
@@ -24,7 +23,8 @@ use Seatplus\Web\Models\Onboarding;
 
 uses(RefreshDatabase::class);
 
-it('renders the dashboard for an authenticated user', function () {
+function provisionAuthenticatedUser(): CharacterInfo
+{
     Queue::fake();
 
     $character = CharacterInfo::factory()->create();
@@ -41,7 +41,13 @@ it('renders the dashboard for an authenticated user', function () {
 
     Onboarding::create(['user_id' => $user->getKey()]);
 
-    $this->actingAs($user);
+    test()->actingAs($user);
+
+    return $character;
+}
+
+it('renders the dashboard for an authenticated user', function () {
+    provisionAuthenticatedUser();
 
     $page = visit('/home');
 
@@ -49,5 +55,25 @@ it('renders the dashboard for an authenticated user', function () {
     $page->assertSee('Characters');
     $page->screenshot(true, 'dashboard');
 
-    $this->assertAuthenticated();
+    test()->assertAuthenticated();
+});
+
+it('wires the character portrait to the EVE image server', function () {
+    $character = provisionAuthenticatedUser();
+
+    // EveImage lazy-loads the portrait via an IntersectionObserver, so wait for the
+    // dashboard to render before inspecting the <img>. We assert the *URL wiring*
+    // (correct CCP images.evetech.net portrait endpoint), not that the bytes load —
+    // the factory character id has no real portrait on Tranquility, so
+    // assertNoBrokenImages would be a false negative here.
+    $selector = "img[src*='characters/{$character->character_id}/portrait']";
+
+    $page = visit('/home');
+    $page->waitForText('Characters');
+
+    $page->assertAttributeContains(
+        $selector,
+        'src',
+        "images.evetech.net/characters/{$character->character_id}/portrait",
+    );
 });

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -1,26 +1,33 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Seatplus\Auth\Models\User;
 use Seatplus\Web\Models\Onboarding;
 
 /*
  * Authenticated dashboard smoke test — runs against the real assembled core app.
  *
- * Logs in a factory user and loads /home, asserting the actual Dashboard renders
- * (PageHeader "Home") with no JS/console errors and styled — not just that some
- * page came back. In testing CheckRequiredScopes is skipped (non-production) and
- * ONBOARDING defaults off, so /home reaches Dashboard/Index; the Onboarding
- * record below keeps it passing even if onboarding is enabled.
+ * Logs in a user and loads /home, asserting the Dashboard actually renders
+ * (the visible "Characters" heading) with no JS/console errors — not just that
+ * some page came back.
  *
- * Factory-name guessing for the seatplus packages is set for the whole Browser
- * suite in core's tests/Pest.php.
+ * The user is created minimally (no characters) on purpose: User::factory()
+ * builds a multi-character graph whose CharacterInfo affiliations occasionally
+ * collide on character_affiliations (random ids), which is flaky here. A
+ * characterless user is deterministic and still reaches Dashboard/Index (an
+ * empty character list). In testing CheckRequiredScopes is skipped
+ * (non-production) and ONBOARDING defaults off; the Onboarding record keeps it
+ * passing even if onboarding is enabled.
  */
 
 uses(RefreshDatabase::class);
 
 it('renders the dashboard for an authenticated user', function () {
-    $user = User::factory()->create();
+    $user = new User();
+    $user->active = true;
+    $user->remember_token = Str::random(10);
+    $user->save();
 
     Onboarding::create(['user_id' => $user->getKey()]);
 
@@ -28,13 +35,7 @@ it('renders the dashboard for an authenticated user', function () {
 
     $page = visit('/home');
 
-    // TEMP DIAGNOSTIC: dump the rendered HTML so CI shows what Inertia resolved,
-    // which props are present, and whether Vue mounted anything into #app.
-    dump($page->content());
-
     $page->assertNoSmoke();
-    // "Characters" is the visible <h3> on the dashboard (Dashboard/Characters.vue);
-    // "Home" is only the document <title>, so assert on real page content.
     $page->assertSee('Characters');
     $page->screenshot(true, 'dashboard');
 

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -28,6 +28,10 @@ it('renders the dashboard for an authenticated user', function () {
 
     $page = visit('/home');
 
+    // TEMP DIAGNOSTIC: dump the rendered HTML so CI shows what Inertia resolved,
+    // which props are present, and whether Vue mounted anything into #app.
+    dump($page->content());
+
     $page->assertNoSmoke();
     // "Characters" is the visible <h3> on the dashboard (Dashboard/Characters.vue);
     // "Home" is only the document <title>, so assert on real page content.

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -53,6 +53,10 @@ it('renders the dashboard for an authenticated user', function () {
 
     $page->assertNoSmoke();
     $page->assertSee('Characters');
+
+    // Let the lazy-loaded portraits (EveImage IntersectionObserver) settle so the
+    // screenshot captures them rather than the placeholder SVGs.
+    $page->wait(1);
     $page->screenshot(true, 'dashboard');
 
     test()->assertAuthenticated();
@@ -70,6 +74,7 @@ it('wires the character portrait to the EVE image server', function () {
     // never mount in a short window and the assertion times out.
     $page->resize(1280, 2400);
     $page->waitForText('Characters');
+    $page->wait(1); // give the observer + <img> mount a beat to settle
 
     // Scope to the dashboard character-card portrait (h-12 w-12) so the locator
     // resolves to exactly one element — the character also appears as the sidebar

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -29,7 +29,7 @@ it('renders the dashboard for an authenticated user', function () {
 
     $character = CharacterInfo::factory()->create();
 
-    $user = new User();
+    $user = new User;
     $user->main_character_id = $character->character_id;
     $user->save();
 

--- a/tests/Browser/AuthenticatedSmokeTest.php
+++ b/tests/Browser/AuthenticatedSmokeTest.php
@@ -50,4 +50,4 @@ it('renders the dashboard for an authenticated user', function () {
     $page->screenshot(true, 'dashboard');
 
     $this->assertAuthenticated();
-})->skip('Authenticated persistent-layout pages mount an empty #app under the pest-browser in-process server (renders fine in a real browser) — see seatplus/web#1530.');
+});


### PR DESCRIPTION
Adds an authenticated browser test alongside the guest `LoginSmokeTest` (the browser harness merged in #1528).

- `tests/Browser/AuthenticatedSmokeTest.php`: logs in a factory user (`UserFactory::new()->create()` directly — core has no Testbench factory guessing), `actingAs` + `visit('/home')` with `RefreshDatabase`, asserts `assertNoSmoke` + `assertAuthenticated` + captures a screenshot.

A fresh user has no SSO scopes, so the `auth` + `CheckRequiredScopes` + `Onboarding` chain routes them through the onboarding/scopes flow — this smokes that an **authenticated** page renders without JS/console errors and styled. A dashboard (`/home`) test needs a scoped user with characters/tokens — a follow-up.

**First run to watch:** `RefreshDatabase` migrating core's full schema in the browser job, and `actingAs` authenticating through the in-process pest-browser server. The `authenticated` screenshot artifact shows what renders.