### PR TITLE
fix: getCharacterIds returns scalar character_ids (fixes wallets/assets/skills/mails crash + 403)

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -59,7 +59,13 @@ class Controller extends BaseController
     protected function fetchAffiliatedCharacterIdsWithRelation(
         array $characterIds,
         ?string $characterRelation = null
-    ): \Illuminate\Database\Eloquent\Collection {
+    ): Collection {
+        // The frontend iterates this as a list of scalar character_ids
+        // (`:id="character_id"`, typed Number). Returning full CharacterInfo models
+        // made each element an object, so pages built route('…', ['character_id' =>
+        // <object>]) and Ziggy threw "object passed as 'character_id' parameter …",
+        // crashing the setup() of components that resolve a route on mount (e.g.
+        // WalletJournalBalanceChart) and taking the page down. Pluck plain ids.
         return CharacterInfo::query()
             ->select('character_id')
             ->whereIn('character_id', $characterIds)
@@ -67,7 +73,7 @@ class Controller extends BaseController
                 $characterRelation,
                 fn (Builder $query) => $query->with($characterRelation),
             )
-            ->get();
+            ->pluck('character_id');
     }
 
     protected function getAffiliatedIds(DispatchTransferObject $dispatchTransferObject): array


### PR DESCRIPTION
## Problem
`/character/wallets` (and assets, skills, mails) crashed on load — blank/broken page — with, in the console:

```
Ziggy error: object passed as 'character_id' parameter is missing route model binding key 'undefined'
  at useLoadCompleteResource.js:6
  at setup (WalletJournalBalanceChart.vue)
```
plus `Invalid prop: type check failed for prop "id". Expected Number … got Object` and **403**s on the journal/transaction/balance requests.

## Root cause
`Controller::fetchAffiliatedCharacterIdsWithRelation()` used `->get()`, returning a collection of **`CharacterInfo` models**. The `character_ids` / `characterIds` prop therefore reached the frontend as `[{character_id: N}, …]`. Every consumer iterates it as **scalar ids** (`v-for … :id="character_id"`, prop typed `Number`), so each element was an object:

- components built `route('character.balance', {character_id: <object>})` → Ziggy threw → the on-mount resource loader's `setup()` crashed → page down;
- the axios URL became `/character/wallets/[object Object]/journal`, which `CheckAuthorizationWithExtendedScope` couldn't match → **403**.

## Fix
`->pluck('character_id')` so the prop is a list of scalar ids. No change to *which* characters are returned.

Affects all four callers: wallets, skills, assets, mails.

## Verification
- `/character/wallets` renders with no console errors; journal/transaction requests no longer 403 (confirmed on Herd with real data).
- `/home`, `/character/assets` consoles clean.