### PR TITLE
fix: pass page as a slot function in EmptyLayout persistent layouts

### DIFF
--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -67,7 +67,7 @@ import { localeName } from "@/i18n/localeName";
 export default {
     name: "Login",
     components: {AppHead},
-    layout: (h, page) => h(EmptyLayout, [page]),
+    layout: (h, page) => h(EmptyLayout, () => page),
     data() {
         return {
             selectedLocale: this.$page.props.locale,

--- a/resources/js/Pages/Auth/MissingRequiredScopes.vue
+++ b/resources/js/Pages/Auth/MissingRequiredScopes.vue
@@ -88,7 +88,7 @@
     export default {
         name: "MissingRequiredScopes",
         components: {AppHead, ImpersonatingBanner, EveImage},
-        layout: (h, page) => h(EmptyLayout, [page]),
+        layout: (h, page) => h(EmptyLayout, () => page),
         props: {
             characters: {
                 required: true


### PR DESCRIPTION
`Auth/Login.vue` and `Auth/MissingRequiredScopes.vue` defined their persistent layout as `layout: (h, page) => h(EmptyLayout, [page])`. Passing the page as an array (a non-function default slot) triggers Vue's warning:

> [Vue warn]: Non-function value encountered for default slot. Prefer function slots for better performance.

Fixed by passing a slot function: `() => page`.