### PR TITLE
chore: remove unused doctrine/dbal dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "laravel/socialite": "^5.0",
         "seatplus/eveapi": "^4.1.4",
         "seatplus/auth": "^4.1.3",
-        "doctrine/dbal": "^3.0",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/wayfinder": "^0.1.16",
         "tightenco/ziggy": "^2.6"


### PR DESCRIPTION
`doctrine/dbal` was declared only in web's `composer.json` and is used nowhere — no `Doctrine\DBAL` references, no `->change()` migrations. It was added by the Compliance Tracking feature (`e99f40b`) back when column changes required it; Laravel 11+ (we're on 13) does that natively.

Supersedes the dependabot bump #1503 (bumping a dead dependency) — closing that in favour of removal.