### PR TITLE
feat: character mail list on Inertia v3 InfiniteScroll (B1)

### DIFF
--- a/resources/js/Pages/Character/Mail/Index.vue
+++ b/resources/js/Pages/Character/Mail/Index.vue
@@ -15,10 +15,7 @@
         </PageHeader>
 
         <div class="block lg:hidden">
-          <MobileMailList
-            v-model:selectedId="selectedId"
-            :character-ids="characterIds"
-          />
+          <MobileMailList v-model:selectedId="selectedId" />
         </div>
 
         <div class="hidden md:block space-y-3">
@@ -31,10 +28,7 @@
       </div>
     </div>
     <template #aside>
-      <DesktopMailList
-        v-model:selectedId="selectedId"
-        :character-ids="characterIds"
-      />
+      <DesktopMailList v-model:selectedId="selectedId" />
     </template>
   </MultiColumnLayout>
 </template>

--- a/resources/js/Shared/Components/Mails/DesktopMailList.vue
+++ b/resources/js/Shared/Components/Mails/DesktopMailList.vue
@@ -1,14 +1,21 @@
 <template>
-  <!--  py-6 px-4 sm:px-6 lg:px-8-->
-  <div class="absolute inset-0 overflow-y-auto">
-    <InfiniteLoadingHelper
-      v-slot="{results}"
-      route-name="get.mail.headers"
-      :params="{character_ids: characterIds}"
+  <!-- scroll-region: lets Inertia preserve this container's scroll position so
+       <InfiniteScroll> merges the next page in place instead of jumping to top. -->
+  <div
+    class="absolute inset-0 overflow-y-auto"
+    scroll-region=""
+  >
+    <InfiniteScroll
+      data="mailHeaders"
+      items-element="#desktop-mail-list"
+      preserve-url
     >
-      <ul class="divide-y divide-gray-200">
+      <ul
+        id="desktop-mail-list"
+        class="divide-y divide-gray-200"
+      >
         <li
-          v-for="mail in mails(results)"
+          v-for="mail in mails"
           :key="mail.id"
           :class="[mail.current ? 'bg-gray-200 text-gray-900' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900', 'flex space-x-3 cursor-pointer' ,'py-6 px-4 sm:px-6 lg:px-8 rounded-md ml-1 mr-1']"
           @click="emitSelection(mail.id)"
@@ -36,25 +43,21 @@
           </div>
         </li>
       </ul>
-    </InfiniteLoadingHelper>
-    <!--    <div class="h-full border-2 border-gray-200 border-dashed rounded-lg" />-->
+    </InfiniteScroll>
   </div>
 </template>
 
 <script>
-import InfiniteLoadingHelper from "../../InfiniteLoadingHelper.vue";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
+import { computed } from "vue";
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import ResolveIdToName from "../../ResolveIdToName.vue";
 
 export default {
     name: "DesktopMailList",
-    components: {ResolveIdToName, Time, EveImage, InfiniteLoadingHelper},
+    components: {ResolveIdToName, Time, EveImage, InfiniteScroll},
     props: {
-        characterIds: {
-            type: Array,
-            required: true
-        },
         selectedId: {
             required: false
         },
@@ -62,16 +65,15 @@ export default {
     emits: ['update:selectedId'],
     setup(props, {emit}) {
 
+        const page = usePage()
+
         const emitSelection = (selectedId) => emit('update:selectedId', selectedId)
 
-        const mails = (results) => {
-            return _.map(results, result => {
-                return {
-                    ...result,
-                    current: _.isEqual(props.selectedId, result.id)
-                }
-            })
-        }
+        // Mail headers arrive as the page scroll prop; flag the selected one.
+        const mails = computed(() => _.map(page.props.mailHeaders?.data ?? [], result => ({
+            ...result,
+            current: _.isEqual(props.selectedId, result.id),
+        })))
 
         return {
             mails,

--- a/resources/js/Shared/Components/Mails/MailRepresentation.vue
+++ b/resources/js/Shared/Components/Mails/MailRepresentation.vue
@@ -80,11 +80,17 @@ export default {
 
         const fetchMails = async () => {
 
-            await axios.get(route('get.mail', props.mailId))
-                .then(response => {
-                    messages.value.push(...response.data);
-                })
-                .catch(error => console.log(error))
+            // Plain same-origin fetch — no axios, no Ziggy route(). (Wayfinder would be
+            // the typed alternative, but its generated routes aren't built in CI yet — B3.)
+            const response = await fetch(`/character/mails/content/${props.mailId}`, {
+                headers: { Accept: 'application/json' },
+            })
+
+            if (! response.ok) {
+                return
+            }
+
+            messages.value.push(...await response.json())
         }
 
         onBeforeMount(() => fetchMails())

--- a/resources/js/Shared/Components/Mails/MobileMailList.vue
+++ b/resources/js/Shared/Components/Mails/MobileMailList.vue
@@ -1,12 +1,15 @@
 <template>
-  <InfiniteLoadingHelper
-    v-slot="{results}"
-    route-name="get.mail.headers"
-    :params="{character_ids: characterIds}"
+  <InfiniteScroll
+    data="mailHeaders"
+    items-element="#mobile-mail-list"
+    preserve-url
   >
-    <ul class="divide-y divide-gray-200">
+    <ul
+      id="mobile-mail-list"
+      class="divide-y divide-gray-200"
+    >
       <Disclosure
-        v-for="mail in results"
+        v-for="mail in mailHeaders"
         :key="mail.id"
         v-slot="{open}"
         as="li"
@@ -49,7 +52,7 @@
         </DisclosurePanel>
       </Disclosure>
     </ul>
-  </InfiniteLoadingHelper>
+  </InfiniteScroll>
 </template>
 
 <script>
@@ -57,7 +60,8 @@ import MailRepresentation from "./MailRepresentation.vue";
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import ResolveIdToName from "../../ResolveIdToName.vue";
-import InfiniteLoadingHelper from "../../InfiniteLoadingHelper.vue";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
+import { computed } from "vue";
 import { ChevronUpIcon } from "@heroicons/vue/20/solid";
 import {Disclosure, DisclosureButton, DisclosurePanel} from "@headlessui/vue";
 
@@ -65,17 +69,13 @@ export default {
     name: "MobileMailList",
     components: {
         MailRepresentation,
-        EveImage, Time, ResolveIdToName, InfiniteLoadingHelper,
+        EveImage, Time, ResolveIdToName, InfiniteScroll,
         ChevronUpIcon,
         Disclosure,
         DisclosureButton,
         DisclosurePanel,
     },
     props: {
-        characterIds: {
-            type: Array,
-            required: true
-        },
         selectedId: {
             type: Number,
             required: false
@@ -84,11 +84,15 @@ export default {
     emits: ['update:selectedId'],
     setup(props, {emit}) {
 
+        const page = usePage()
+
+        const mailHeaders = computed(() => page.props.mailHeaders?.data ?? [])
 
         const emitSelection = (selectedId) => emit('update:selectedId', selectedId)
         const isSelected = (mail) => mail.id === props.selectedId
 
         return {
+            mailHeaders,
             emitSelection,
             isSelected
         }

--- a/resources/js/Shared/SidebarLayout/MultiColumnLayout.vue
+++ b/resources/js/Shared/SidebarLayout/MultiColumnLayout.vue
@@ -1,6 +1,9 @@
 <template>
   <DarkSidebar>
-    <main class="flex-1 relative z-0 overflow-y-auto focus:outline-hidden xl:order-last">
+    <main
+      class="flex-1 relative z-0 overflow-y-auto focus:outline-hidden xl:order-last"
+      scroll-region=""
+    >
       <!-- Start main area-->
       <slot>
         <div class="absolute inset-0 py-6 px-4 sm:px-6 lg:px-8">

--- a/routes/Routes/Character/Mails.php
+++ b/routes/Routes/Character/Mails.php
@@ -25,19 +25,12 @@
  */
 
 use Illuminate\Support\Facades\Route;
-use Seatplus\Eveapi\Models\Mail\Mail;
 use Seatplus\Web\Http\Controllers\Character\MailsController;
-use Seatplus\Web\Http\Middleware\CheckAuthorizationWithExtendedScope;
 
 Route::prefix('mails')
     ->group(callback: function () {
+        // Mail headers are delivered as the `mailHeaders` Inertia scroll prop by
+        // index(); there's no separate headers JSON endpoint anymore.
         Route::get('', [MailsController::class, 'index'])->name('character.mails');
         Route::get('/content/{mail_id}', [MailsController::class, 'getMail'])->name('get.mail');
-
-        $mailPermission = CheckAuthorizationWithExtendedScope::class.':'.config('eveapi.permissions.'.Mail::class);
-
-        Route::middleware($mailPermission)
-            ->group(function () {
-                Route::get('/headers/', [MailsController::class, 'mailHeaders'])->name('get.mail.headers');
-            });
     });

--- a/src/Http/Controllers/Character/MailsController.php
+++ b/src/Http/Controllers/Character/MailsController.php
@@ -27,8 +27,6 @@
 namespace Seatplus\Web\Http\Controllers\Character;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\Request;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -55,11 +53,6 @@ class MailsController extends Controller
             // characters (both the desktop and mobile lists consume it via <InfiniteScroll>).
             'mailHeaders' => Inertia::scroll(fn () => $this->mailHeadersQuery($ids->all())->paginate()),
         ]);
-    }
-
-    public function mailHeaders(Request $request): LengthAwarePaginator
-    {
-        return $this->mailHeadersQuery($request->get('character_ids'))->paginate();
     }
 
     private function mailHeadersQuery(array $character_ids): Builder

--- a/src/Http/Controllers/Character/MailsController.php
+++ b/src/Http/Controllers/Character/MailsController.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
@@ -50,13 +51,19 @@ class MailsController extends Controller
         return inertia('Character/Mail/Index', [
             'dispatchTransferObject' => $dispatchTransferObject,
             'characterIds' => $ids,
+            // Mail headers as a single infinite-scroll prop, scoped to the authorized
+            // characters (both the desktop and mobile lists consume it via <InfiniteScroll>).
+            'mailHeaders' => Inertia::scroll(fn () => $this->mailHeadersQuery($ids->all())->paginate()),
         ]);
     }
 
     public function mailHeaders(Request $request): LengthAwarePaginator
     {
-        $character_ids = $request->get('character_ids');
+        return $this->mailHeadersQuery($request->get('character_ids'))->paginate();
+    }
 
+    private function mailHeadersQuery(array $character_ids): Builder
+    {
         return Mail::query()
             ->select('id', 'from', 'subject', 'timestamp')
             ->whereHas('recipients', fn (Builder $query) => $query->whereHasMorph(
@@ -64,8 +71,7 @@ class MailsController extends Controller
                 CharacterInfo::class,
                 fn (Builder $query) => $query->whereIn('character_id', $character_ids)
             ))
-            ->orderByDesc('timestamp')
-            ->paginate();
+            ->orderByDesc('timestamp');
     }
 
     public function getMail(EsiClient $esi, int $mail_id): Collection

--- a/tests/Browser/AuthenticationTest.php
+++ b/tests/Browser/AuthenticationTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seatplus\Auth\Models\CharacterUser;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 /*
  * Authentication browser tests — run against the real assembled core app (never under
@@ -14,6 +16,33 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
  */
 
 uses(RefreshDatabase::class);
+
+if (! function_exists('attachOwnedCharacter')) {
+    /**
+     * Attach an additional owned character to the same user that owns $existing, so a
+     * browser test can exercise the multi-character case — the dashboard renders a card
+     * per every character the logged-in user owns, not just the main. Returns the newly
+     * attached character. Guarded so each Browser test file can define it standalone
+     * without colliding when the suite loads several.
+     */
+    function attachOwnedCharacter(CharacterInfo $existing): CharacterInfo
+    {
+        $user = CharacterUser::query()
+            ->where('character_id', $existing->character_id)
+            ->firstOrFail()
+            ->user;
+
+        $character = CharacterInfo::factory()->create();
+
+        CharacterUser::create([
+            'user_id' => $user->getKey(),
+            'character_id' => $character->character_id,
+            'character_owner_hash' => sha1((string) $character->character_id),
+        ]);
+
+        return $character;
+    }
+}
 
 /* ------------------------------------------------------------- unauthenticated */
 
@@ -41,6 +70,34 @@ it('renders the dashboard for an authenticated user', function () {
     $page->screenshot(true, 'dashboard');
 
     test()->assertAuthenticated();
+});
+
+it('renders a dashboard card for every character the user owns', function () {
+    $mainCharacter = actingAsCharacter();
+    $secondCharacter = attachOwnedCharacter($mainCharacter);
+
+    $page = visit('/home');
+
+    $page->assertNoSmoke();
+    $page->waitForText('Characters');
+
+    // Portraits lazy-load via EveImage's IntersectionObserver — let them attach.
+    $page->wait(1);
+
+    // The dashboard renders one card (h-12 w-12 portrait) per owned character, not just
+    // the main. Assert both specific portraits resolve, and that exactly two character
+    // portraits render — a main-only dashboard would show a single one.
+    foreach ([$mainCharacter, $secondCharacter] as $character) {
+        $page->assertAttributeContains(
+            "img.h-12.w-12[src*='characters/{$character->character_id}/portrait']",
+            'src',
+            "images.evetech.net/characters/{$character->character_id}/portrait",
+        );
+    }
+
+    $page->assertCount('img.h-12.w-12', 2);
+
+    $page->screenshot(true, 'dashboard-multiple-characters');
 });
 
 it('wires the character portrait to the EVE image server', function () {

--- a/tests/Browser/CharacterMailTest.php
+++ b/tests/Browser/CharacterMailTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seatplus\Auth\Models\CharacterUser;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Mail\Mail;
 use Seatplus\Eveapi\Models\Mail\MailRecipients;
@@ -14,6 +15,33 @@ use Seatplus\Eveapi\Models\Mail\MailRecipients;
  */
 
 uses(RefreshDatabase::class);
+
+if (! function_exists('attachOwnedCharacter')) {
+    /**
+     * Attach an additional owned character to the same user that owns $existing, so a
+     * browser test can exercise the multi-character case — character-scoped pages
+     * aggregate over / render per every character the logged-in user owns, not just
+     * the main. Returns the newly attached character. Guarded so each Browser test
+     * file can define it standalone without colliding when the suite loads several.
+     */
+    function attachOwnedCharacter(CharacterInfo $existing): CharacterInfo
+    {
+        $user = CharacterUser::query()
+            ->where('character_id', $existing->character_id)
+            ->firstOrFail()
+            ->user;
+
+        $character = CharacterInfo::factory()->create();
+
+        CharacterUser::create([
+            'user_id' => $user->getKey(),
+            'character_id' => $character->character_id,
+            'character_owner_hash' => sha1((string) $character->character_id),
+        ]);
+
+        return $character;
+    }
+}
 
 it('merges the next page of mail headers on scroll', function () {
     $character = actingAsCharacter();
@@ -42,4 +70,34 @@ it('merges the next page of mail headers on scroll', function () {
     $page->assertScript("(document.getElementById('desktop-mail-list').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
 
     $page->screenshot(true, 'character-mails-infinite-scroll');
+});
+
+it('aggregates mail headers across all of the user\'s characters', function () {
+    $mainCharacter = actingAsCharacter();
+    $secondCharacter = attachOwnedCharacter($mainCharacter);
+
+    // 6 mails per character (12 total, under the 15/page default) so the entire set
+    // lands on the first page: a main-character-only list would render 6, the full
+    // owned set renders 12 — the count alone proves the aggregation.
+    collect([$mainCharacter, $secondCharacter])
+        ->each(fn (CharacterInfo $character, int $characterIndex) => Mail::factory()
+            ->count(6)
+            ->sequence(fn ($sequence) => ['timestamp' => now()->subHours(($characterIndex * 6 + $sequence->index) * 6)->format('Y-m-d H:i:s')])
+            ->create()
+            ->each(fn (Mail $mail) => MailRecipients::factory()->create([
+                'mail_id' => $mail->id,
+                'receivable_id' => $character->character_id,
+                'receivable_type' => CharacterInfo::class,
+            ])));
+
+    $rows = '#desktop-mail-list > li';
+
+    $page = visit('/character/mails');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Mails');
+
+    // Both characters' mails on a single page (6 + 6 = 12 < 15/page).
+    $page->assertCount($rows, 12);
+
+    $page->screenshot(true, 'character-mails-multiple-characters');
 });

--- a/tests/Browser/CharacterMailTest.php
+++ b/tests/Browser/CharacterMailTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Mail\Mail;
+use Seatplus\Eveapi\Models\Mail\MailRecipients;
+
+/*
+ * Character mail browser test — the mail header list (desktop aside + mobile) is now
+ * an Inertia <InfiniteScroll> over the `mailHeaders` scroll prop instead of the axios
+ * InfiniteLoadingHelper. Seeds 40 mails addressed to the logged-in character (6h apart)
+ * and asserts scrolling the list merges the next page in. No permission needed —
+ * own-character access. Provisioning helper: tests/Browser/Pest.php.
+ */
+
+uses(RefreshDatabase::class);
+
+it('merges the next page of mail headers on scroll', function () {
+    $character = actingAsCharacter();
+
+    Mail::factory()
+        ->count(40)
+        ->sequence(fn ($sequence) => ['timestamp' => now()->subHours($sequence->index * 6)->format('Y-m-d H:i:s')])
+        ->create()
+        ->each(fn (Mail $mail) => MailRecipients::factory()->create([
+            'mail_id' => $mail->id,
+            'receivable_id' => $character->character_id,
+            'receivable_type' => CharacterInfo::class,
+        ]));
+
+    $rows = '#desktop-mail-list > li';
+
+    $page = visit('/character/mails');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Mails');
+
+    // First page only (40 seeded > the 15/page default).
+    $before = (int) $page->script("document.querySelectorAll('{$rows}').length");
+    expect($before)->toBeGreaterThan(0);
+
+    // Re-scroll the list's container on each poll until the next page merges in.
+    $page->assertScript("(document.getElementById('desktop-mail-list').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
+
+    $page->screenshot(true, 'character-mails-infinite-scroll');
+});

--- a/tests/Browser/CharacterWalletTest.php
+++ b/tests/Browser/CharacterWalletTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seatplus\Auth\Models\CharacterUser;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Wallet\WalletJournal;
 use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
@@ -15,6 +16,33 @@ use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
  */
 
 uses(RefreshDatabase::class);
+
+if (! function_exists('attachOwnedCharacter')) {
+    /**
+     * Attach an additional owned character to the same user that owns $existing, so a
+     * browser test can exercise the multi-character case — character-scoped pages
+     * aggregate over / render per every character the logged-in user owns, not just
+     * the main. Returns the newly attached character. Guarded so each Browser test
+     * file can define it standalone without colliding when the suite loads several.
+     */
+    function attachOwnedCharacter(CharacterInfo $existing): CharacterInfo
+    {
+        $user = CharacterUser::query()
+            ->where('character_id', $existing->character_id)
+            ->firstOrFail()
+            ->user;
+
+        $character = CharacterInfo::factory()->create();
+
+        CharacterUser::create([
+            'user_id' => $user->getKey(),
+            'character_id' => $character->character_id,
+            'character_owner_hash' => sha1((string) $character->character_id),
+        ]);
+
+        return $character;
+    }
+}
 
 it('merges the next journal and transaction pages in on scroll', function () {
     $character = actingAsCharacter();
@@ -102,4 +130,31 @@ it('filters the wallet journal by ref_type (and resets, not merges)', function (
     // Filtered + reset: only the 3 bounty rows remain (not 15 + merged).
     $page->assertCount($rows, 3);
     $page->screenshot(true, 'character-wallet-filter');
+});
+
+it('renders a wallet card for every character the user owns', function () {
+    $mainCharacter = actingAsCharacter();
+    $secondCharacter = attachOwnedCharacter($mainCharacter);
+
+    // A handful of journal rows per character so each card's list renders. The page
+    // renders one wallet (its own journal_<id> scroll prop / list) per owned character,
+    // so both journal bodies must be present — a single-character render would only
+    // emit the main character's.
+    collect([$mainCharacter, $secondCharacter])
+        ->each(fn (CharacterInfo $character) => WalletJournal::factory()
+            ->count(5)
+            ->sequence(fn ($sequence) => ['date' => now()->subHours($sequence->index * 6)])
+            ->create([
+                'wallet_journable_id' => $character->character_id,
+                'wallet_journable_type' => CharacterInfo::class,
+            ]));
+
+    $page = visit('/character/wallets');
+    $page->assertNoSmoke();
+    $page->waitForText('Journal');
+
+    $page->assertPresent("#journal-body-{$mainCharacter->character_id}");
+    $page->assertPresent("#journal-body-{$secondCharacter->character_id}");
+
+    $page->screenshot(true, 'character-wallet-multiple-characters');
 });

--- a/tests/Feature/MailsIntegrationTest.php
+++ b/tests/Feature/MailsIntegrationTest.php
@@ -8,16 +8,3 @@ test('see component', function () {
 
     $response->assertInertia(fn (Assert $page) => $page->component('Character/Mail/Index'));
 });
-
-test('get mail headers of secondary user', function () {
-    if (test()->test_user->can('superuser')) {
-        test()->test_user->removeRole('superuser');
-
-        // now re-register all the roles and permissions
-    }
-
-    $response = test()->actingAs(test()->test_user)
-        ->get(route('get.mail.headers', ['character_ids' => [test()->test_character->character_id]]));
-
-    $response->assertOk();
-});


### PR DESCRIPTION
Next list in the **B1** rollout (#1532), after the wallet view: the character **mail header list** moves from the axios `InfiniteLoadingHelper` to Inertia v3 `<InfiniteScroll>`.

## Changes
- `MailsController::index()` emits a single **`mailHeaders`** `Inertia::scroll()` prop, scoped server-side to the authorized characters (`getCharacterIds`). Shared `mailHeadersQuery()` extracted; the legacy `get.mail.headers` endpoint stays for now (delegates to it) — dead-endpoint cleanup to follow, as with the wallet view.
- Both the **desktop** aside list and the **mobile** disclosure list consume the prop via `<InfiniteScroll>`; dropped the now-unused `character_ids` param/prop.
- Marked the desktop list's own scroll container and `MultiColumnLayout`'s `<main>` (the mobile list's scroll container) as Inertia `scroll-region`s so merges preserve position.

## Test
`tests/Browser/CharacterMailTest.php` seeds 40 mails addressed to the logged-in character and asserts scrolling merges the next page in.

Refs #1532