### PR TITLE
fix: return alliance name (not the name object) for character entities

### DIFF
--- a/src/Services/GetEntityFromId.php
+++ b/src/Services/GetEntityFromId.php
@@ -214,7 +214,7 @@ class GetEntityFromId
         if ($character_affiliation->alliance_id) {
             /** @var AllianceInfo|null $alliance_model */
             $alliance_model = $character_affiliation->alliance;
-            $character['alliance'] = ['name' => $alliance_model->name ?? $this->names->first(fn (object $name) => $name->id === $character_affiliation->alliance_id)];
+            $character['alliance'] = ['name' => $alliance_model->name ?? $this->names->first(fn (object $name) => $name->id === $character_affiliation->alliance_id)->name];
         }
 
         return $character;


### PR DESCRIPTION
`GetEntityFromId::buildCharacterResponse` built the alliance fallback without the `->name` accessor that the corporation branch (and `buildCorporationResponse`) already have. When a character's alliance isn't in the DB, the whole name **object** was returned instead of the string, so `EntityByIdBlock`'s `subText` rendered `"CorpName | [object Object]"`.

One-line fix: append `->name` to the alliance name-collection fallback, matching the corporation branch.

Split out of #1542 (which merged before this commit landed).