### PR TITLE
feat: Update sidebar — owned + affiliated sections (lazy affiliated)

### DIFF
--- a/resources/js/Functions/http.js
+++ b/resources/js/Functions/http.js
@@ -1,0 +1,46 @@
+// Minimal axios-free HTTP helpers built on the native fetch API.
+//
+// The installed Inertia client (@inertiajs/vue3 v2) has no `useHttp` hook, so for
+// the handful of non-Inertia JSON endpoints (batch dispatch/status, id resolving,
+// …) we talk to the backend directly. Laravel's VerifyCsrfToken accepts the
+// `X-XSRF-TOKEN` header carrying the (url-decoded) `XSRF-TOKEN` cookie — exactly
+// what axios used to send for us.
+
+function xsrfToken() {
+    const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+
+    return match ? decodeURIComponent(match[1]) : '';
+}
+
+async function request(url, { method = 'GET', body } = {}) {
+    const headers = {
+        Accept: 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    if (body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        headers['X-XSRF-TOKEN'] = xsrfToken();
+    }
+
+    const response = await fetch(url, {
+        method,
+        headers,
+        credentials: 'same-origin',
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+        throw new Error(`Request to ${url} failed with status ${response.status}`);
+    }
+
+    return response;
+}
+
+export async function getJson(url) {
+    return (await request(url)).json();
+}
+
+export function post(url, body = {}) {
+    return request(url, { method: 'POST', body });
+}

--- a/resources/js/Shared/Components/SlideOver/DispatchEntityList.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchEntityList.vue
@@ -1,0 +1,85 @@
+<template>
+  <ul class="divide-y divide-gray-200">
+    <DispatchableEntry
+      v-for="(entity, index) in entities"
+      :key="`${label} ${index}`"
+      :entry="entity"
+    />
+
+    <li
+      v-if="isLoading"
+      class="px-6 py-4 text-center text-sm text-gray-400"
+    >
+      loading…
+    </li>
+
+    <li
+      v-else-if="entities.length === 0"
+      class="px-6 py-4 text-center text-sm text-gray-500"
+    >
+      {{ emptyText }}
+    </li>
+
+    <li
+      v-if="nextUrl && !isLoading"
+      class="px-6 py-3"
+    >
+      <button
+        type="button"
+        class="w-full text-center text-sm font-medium text-indigo-600 hover:text-indigo-500"
+        @click="load"
+      >
+        Load more
+      </button>
+    </li>
+  </ul>
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+import { post } from "@/Functions/http";
+import { getEntities } from "@/actions/Seatplus/Web/Http/Controllers/Queue/DispatchJobController";
+import DispatchableEntry from "./DispatchableEntry.vue";
+
+const props = defineProps({
+    params: {
+        type: Object,
+        required: true,
+    },
+    label: {
+        type: String,
+        default: "entry",
+    },
+    emptyText: {
+        type: String,
+        default: "no entries",
+    },
+});
+
+const entities = ref([]);
+const nextUrl = ref(getEntities.url());
+const isLoading = ref(false);
+
+// The endpoint returns a Laravel paginator; `links.next` carries the page cursor as
+// a query string, so the same body params fetch each subsequent page.
+const load = async () => {
+    if (isLoading.value || nextUrl.value == null) {
+        return;
+    }
+
+    isLoading.value = true;
+
+    try {
+        const page = await (await post(nextUrl.value, props.params)).json();
+
+        entities.value.push(...page.data);
+        nextUrl.value = page.links?.next ?? null;
+    } catch (error) {
+        console.error(error);
+    } finally {
+        isLoading.value = false;
+    }
+};
+
+onMounted(load);
+</script>

--- a/resources/js/Shared/Components/SlideOver/DispatchUpdate.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchUpdate.vue
@@ -1,49 +1,86 @@
 <template>
-  <ul class="divide-y divide-gray-200 overflow-y-auto">
-    <InfiniteLoadingHelper
-      v-slot="{results}"
-      route-name="manual_job.entities"
-      method="POST"
-      :params="dispatch_transfer_object"
-    >
-      <DispatchableEntry
-        v-for="(entity, index) of results"
-        :key="`dispatchable entry ${index}`"
-        :entry="entity"
-      />
-    </InfiniteLoadingHelper>
-  </ul>
+  <div class="divide-y divide-gray-200 overflow-y-auto">
+    <!-- Owned: the user's own characters/corps, loaded immediately -->
+    <section>
+      <h3 class="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+        {{ isCorporationScope ? 'Your corporations' : 'Your characters' }}
+      </h3>
+      <ul class="divide-y divide-gray-200">
+        <InfiniteLoadingHelper
+          v-slot="{results}"
+          route-name="manual_job.entities"
+          method="POST"
+          :params="ownedParams"
+        >
+          <DispatchableEntry
+            v-for="(entity, index) of results"
+            :key="`owned ${index}`"
+            :entry="entity"
+          />
+        </InfiniteLoadingHelper>
+      </ul>
+    </section>
+
+    <!-- Affiliated: everything else the user may manage, fetched only when expanded -->
+    <section>
+      <button
+        type="button"
+        class="flex w-full items-center justify-between px-6 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500 hover:bg-gray-50"
+        @click="showAffiliated = !showAffiliated"
+      >
+        <span>{{ isCorporationScope ? 'Affiliated corporations' : 'Affiliated characters' }}</span>
+        <ChevronDownIcon
+          class="h-4 w-4 transition-transform"
+          :class="{'rotate-180': showAffiliated}"
+        />
+      </button>
+      <ul
+        v-if="showAffiliated"
+        class="divide-y divide-gray-200"
+      >
+        <InfiniteLoadingHelper
+          v-slot="{results}"
+          route-name="manual_job.entities"
+          method="POST"
+          :params="affiliatedParams"
+        >
+          <DispatchableEntry
+            v-for="(entity, index) of results"
+            :key="`affiliated ${index}`"
+            :entry="entity"
+          />
+        </InfiniteLoadingHelper>
+      </ul>
+    </section>
+  </div>
 </template>
 
 <script>
-
 import DispatchableEntry from "./DispatchableEntry.vue";
 import InfiniteLoadingHelper from "@/Shared/InfiniteLoadingHelper.vue";
+import { ChevronDownIcon } from "@heroicons/vue/24/outline";
 
 export default {
     name: "DispatchUpdate",
-    components: {InfiniteLoadingHelper, DispatchableEntry},
+    components: {InfiniteLoadingHelper, DispatchableEntry, ChevronDownIcon},
+    data() {
+        return {
+            showAffiliated: false,
+        }
+    },
     computed: {
         dispatch_transfer_object() {
             return this.$page.props.dispatch_transfer_object != null ? this.$page.props.dispatch_transfer_object : this.$page.props.dispatchTransferObject
         },
-        job_name() {
-            return _.get(this.dispatch_transfer_object, 'manual_job')
-        }
+        isCorporationScope() {
+            return (_.get(this.dispatch_transfer_object, 'required_corporation_role', []) || []).length > 0
+        },
+        ownedParams() {
+            return {...this.dispatch_transfer_object, ownership: 'owned'}
+        },
+        affiliatedParams() {
+            return {...this.dispatch_transfer_object, ownership: 'affiliated'}
+        },
     },
-    methods: {
-        dispatchJob(entity) {
-
-            if(entity.batch !== 'ready')
-                return
-
-            axios.post(route('dispatch.job', {
-                character_id: entity.character_id,
-                corporation_id: entity.corporation_id,
-            }), {
-                dispatch_transfer_object: this.dispatch_transfer_object
-            })
-        }
-    }
 }
 </script>

--- a/resources/js/Shared/Components/SlideOver/DispatchUpdate.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchUpdate.vue
@@ -5,20 +5,11 @@
       <h3 class="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
         {{ isCorporationScope ? 'Your corporations' : 'Your characters' }}
       </h3>
-      <ul class="divide-y divide-gray-200">
-        <InfiniteLoadingHelper
-          v-slot="{results}"
-          route-name="manual_job.entities"
-          method="POST"
-          :params="ownedParams"
-        >
-          <DispatchableEntry
-            v-for="(entity, index) of results"
-            :key="`owned ${index}`"
-            :entry="entity"
-          />
-        </InfiniteLoadingHelper>
-      </ul>
+      <DispatchEntityList
+        :params="ownedParams"
+        label="owned"
+        :empty-text="isCorporationScope ? 'no corporations you own are eligible' : 'no characters you own are eligible'"
+      />
     </section>
 
     <!-- Affiliated: everything else the user may manage, fetched only when expanded -->
@@ -34,53 +25,31 @@
           :class="{'rotate-180': showAffiliated}"
         />
       </button>
-      <ul
+      <DispatchEntityList
         v-if="showAffiliated"
-        class="divide-y divide-gray-200"
-      >
-        <InfiniteLoadingHelper
-          v-slot="{results}"
-          route-name="manual_job.entities"
-          method="POST"
-          :params="affiliatedParams"
-        >
-          <DispatchableEntry
-            v-for="(entity, index) of results"
-            :key="`affiliated ${index}`"
-            :entry="entity"
-          />
-        </InfiniteLoadingHelper>
-      </ul>
+        :params="affiliatedParams"
+        label="affiliated"
+        empty-text="no affiliated entities"
+      />
     </section>
   </div>
 </template>
 
-<script>
-import DispatchableEntry from "./DispatchableEntry.vue";
-import InfiniteLoadingHelper from "@/Shared/InfiniteLoadingHelper.vue";
+<script setup>
+import { computed, ref } from "vue";
+import { usePage } from "@inertiajs/vue3";
 import { ChevronDownIcon } from "@heroicons/vue/24/outline";
+import DispatchEntityList from "./DispatchEntityList.vue";
 
-export default {
-    name: "DispatchUpdate",
-    components: {InfiniteLoadingHelper, DispatchableEntry, ChevronDownIcon},
-    data() {
-        return {
-            showAffiliated: false,
-        }
-    },
-    computed: {
-        dispatch_transfer_object() {
-            return this.$page.props.dispatch_transfer_object != null ? this.$page.props.dispatch_transfer_object : this.$page.props.dispatchTransferObject
-        },
-        isCorporationScope() {
-            return (_.get(this.dispatch_transfer_object, 'required_corporation_role', []) || []).length > 0
-        },
-        ownedParams() {
-            return {...this.dispatch_transfer_object, ownership: 'owned'}
-        },
-        affiliatedParams() {
-            return {...this.dispatch_transfer_object, ownership: 'affiliated'}
-        },
-    },
-}
+const page = usePage();
+const showAffiliated = ref(false);
+
+const dispatchTransferObject = computed(
+    () => page.props.dispatch_transfer_object ?? page.props.dispatchTransferObject
+);
+const isCorporationScope = computed(
+    () => (dispatchTransferObject.value?.required_corporation_role ?? []).length > 0
+);
+const ownedParams = computed(() => ({ ...dispatchTransferObject.value, ownership: 'owned' }));
+const affiliatedParams = computed(() => ({ ...dispatchTransferObject.value, ownership: 'affiliated' }));
 </script>

--- a/resources/js/Shared/Components/SlideOver/DispatchUpdateButton.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchUpdateButton.vue
@@ -23,11 +23,6 @@ export default {
     return {
       open: false
     }
-  },
-  computed: {
-    url() {
-      return route('manual_job.entities', this.dispatch_transfer_object)
-    }
   }
 }
 </script>

--- a/resources/js/Shared/Components/SlideOver/DispatchableEntry.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchableEntry.vue
@@ -34,9 +34,9 @@
           v-if="status === 'ready'"
           class="h-8 w-8 text-gray-400"
         />
-        <PlayIcon
+        <ArrowPathIcon
           v-if="status === 'pending'"
-          class="h-8 w-8 text-amber-400"
+          class="h-8 w-8 text-amber-400 animate-spin"
         />
         <CheckCircleIcon
           v-if="status === 'finished'"
@@ -54,14 +54,14 @@
 <script>
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
-import { PlayIcon, 	CheckCircleIcon, XCircleIcon} from "@heroicons/vue/24/outline"
+import { PlayIcon, ArrowPathIcon, CheckCircleIcon, XCircleIcon} from "@heroicons/vue/24/outline"
 import { computed, onBeforeMount, onUnmounted, ref, watch } from "vue";
 import axios from "axios";
 import { usePage } from "@inertiajs/vue3";
 
 export default {
     name: "DispatchableEntry",
-    components: {Time, EveImage, PlayIcon, CheckCircleIcon, XCircleIcon},
+    components: {Time, EveImage, PlayIcon, ArrowPathIcon, CheckCircleIcon, XCircleIcon},
     props: {
         entry: {
             type: Object,

--- a/resources/js/Shared/Components/SlideOver/DispatchableEntry.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchableEntry.vue
@@ -56,8 +56,9 @@ import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import { PlayIcon, ArrowPathIcon, CheckCircleIcon, XCircleIcon} from "@heroicons/vue/24/outline"
 import { computed, onBeforeMount, onUnmounted, ref, watch } from "vue";
-import axios from "axios";
 import { usePage } from "@inertiajs/vue3";
+import { getJson, post } from "@/Functions/http";
+import { getBatchStatus, dispatch } from "@/actions/Seatplus/Web/Http/Controllers/Queue/DispatchJobController";
 
 export default {
     name: "DispatchableEntry",
@@ -73,16 +74,11 @@ export default {
         const batch_id = ref(_.get(props.entry, 'batch.batch_id'))
         const updateStatus = ref()
         const dispatch_transfer_object = computed(() => usePage().props.dispatchTransferObject)
-        const url = computed(() => route('dispatch.job', {
-            character_id: props.entry.character_id,
-            corporation_id: props.entry.corporation_id,
-        }))
         const time = computed(() => _.get(props.entry, 'batch.time'))
 
-        function getStatus() {
-            axios
-                .get(route('get.batch_status', batch_id.value))
-                .then(result => status.value = result.data.state)
+        async function getStatus() {
+            const result = await getJson(getBatchStatus.url(batch_id.value))
+            status.value = result.state
         }
 
         onBeforeMount(() => {
@@ -102,20 +98,26 @@ export default {
                 clearInterval(updateStatus.value)
         })
 
-        const dispatchJob = async () => await axios.post(url.value, {dispatch_transfer_object: dispatch_transfer_object.value})
-            .then(response => {
-                status.value = 'pending'
-                batch_id.value = response.data
+        const dispatchJob = async () => {
+            try {
+                const response = await post(dispatch.url(), {
+                    character_id: props.entry.character_id,
+                    corporation_id: props.entry.corporation_id,
+                    dispatch_transfer_object: dispatch_transfer_object.value,
+                })
 
+                batch_id.value = (await response.text()).trim()
+                status.value = 'pending'
                 getStatus()
-            })
-            .catch(error => console.log(error))
+            } catch (error) {
+                console.error(error)
+            }
+        }
 
         return {
             status,
             batch_id,
             dispatch_transfer_object,
-            url,
             dispatchJob,
             time
         }

--- a/src/Http/Controllers/Queue/DispatchJobController.php
+++ b/src/Http/Controllers/Queue/DispatchJobController.php
@@ -99,13 +99,21 @@ class DispatchJobController extends Controller
 
         $isCorporationScope = filled($corporation_roles);
 
-        $affiliated_ids = $this->getAffiliatedIds->get(
-            permissions: [$permission],
-            corporationRoles: $corporation_roles,
-        );
+        // The user's own characters come from the cached permission object (no query). The
+        // owned section scopes straight to them; only the affiliated section pays for the
+        // broader affiliation resolve — and it drops owned characters so the two sections
+        // never overlap and the eager owned list stays O(own characters), not O(affiliated).
+        $owned_character_ids = $this->getAffiliatedIds->ownedCharacterIds();
 
-        $scoped_tokens = RefreshToken::query()
-            ->whereHas('character', fn (Builder $query) => $query->whereIn('character_id', $affiliated_ids))
+        $character_ids = $ownership === 'owned'
+            ? $owned_character_ids
+            : array_values(array_diff(
+                $this->getAffiliatedIds->get(permissions: [$permission], corporationRoles: $corporation_roles),
+                $owned_character_ids,
+            ));
+
+        $tokens = RefreshToken::query()
+            ->whereHas('character', fn (Builder $query) => $query->whereIn('character_id', $character_ids))
             ->with('character', 'character.roles', 'character.corporation')
             ->cursor()
             ->filter(fn (RefreshToken $token) => collect($validated_data['required_scopes'])->intersect($token->scopes)->isNotEmpty())
@@ -122,9 +130,17 @@ class DispatchJobController extends Controller
             )
             ->collect();
 
-        $owned_ids = $this->getOwnedIds($scoped_tokens, $isCorporationScope);
+        // Corp scope, affiliated section: drop corporations the user already manages through
+        // one of their own characters, so a corporation never appears in both sections.
+        if ($isCorporationScope && $ownership === 'affiliated') {
+            $owned_corporation_ids = CharacterInfo::query()
+                ->whereIn('character_id', $owned_character_ids)
+                ->pluck('corporation_id');
 
-        $entities = $scoped_tokens
+            $tokens = $tokens->reject(fn (RefreshToken $token) => $owned_corporation_ids->contains($token->corporation_id));
+        }
+
+        $entities = $tokens
             ->when($isCorporationScope, fn (Collection $tokens) => $tokens->unique(fn (RefreshToken $token) => $token->corporation_id))
             ->map(function (RefreshToken $token) use ($isCorporationScope, $validated_data): array {
                 /** @var CharacterInfo $character */
@@ -139,45 +155,9 @@ class DispatchJobController extends Controller
                     'batch' => $this->getBatchStatus(cache($this->getCacheKey($validated_data['manual_job'], $isCorporationScope ? $token->corporation_id : $token->character_id))),
                 ])->filter()->toArray();
             })
-            ->filter(fn (array $entity) => $this->matchesOwnership($entity, $owned_ids, $isCorporationScope, $ownership))
             ->values();
 
         return $this->paginate($entities, $request);
-    }
-
-    /**
-     * Ids the user owns outright: their own characters, or — for corporation scoped
-     * jobs — the corporations any of their own (role-holding) characters sit in.
-     *
-     * @param  Collection<int, RefreshToken>  $scoped_tokens
-     * @return array<int, int>
-     */
-    private function getOwnedIds(Collection $scoped_tokens, bool $isCorporationScope): array
-    {
-        $owned_character_ids = $this->getOwnedCharacterIds();
-
-        if (! $isCorporationScope) {
-            return $owned_character_ids;
-        }
-
-        return $scoped_tokens
-            ->filter(fn (RefreshToken $token) => in_array($token->character_id, $owned_character_ids, true))
-            ->map(fn (RefreshToken $token) => $token->corporation_id)
-            ->unique()
-            ->values()
-            ->all();
-    }
-
-    /**
-     * @param  array<string, mixed>  $entity
-     * @param  array<int, int>  $owned_ids
-     */
-    private function matchesOwnership(array $entity, array $owned_ids, bool $isCorporationScope, string $ownership): bool
-    {
-        $id = $isCorporationScope ? $entity['corporation_id'] : $entity['character_id'];
-        $isOwned = in_array($id, $owned_ids, true);
-
-        return $ownership === 'owned' ? $isOwned : ! $isOwned;
     }
 
     /**

--- a/src/Http/Controllers/Queue/DispatchJobController.php
+++ b/src/Http/Controllers/Queue/DispatchJobController.php
@@ -31,6 +31,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\LazyCollection;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
@@ -89,10 +90,12 @@ class DispatchJobController extends Controller
             'required_scopes' => ['required', 'array'],
             'required_corporation_role' => ['present', 'array'],
             'required_corporation_role.*' => ['string'],
+            'ownership' => ['sometimes', 'in:owned,affiliated'],
         ]);
 
         $permission = data_get($validated_data, 'permission');
         $corporation_roles = data_get($validated_data, 'required_corporation_role', []);
+        $ownership = data_get($validated_data, 'ownership', 'owned');
 
         $isCorporationScope = filled($corporation_roles);
 
@@ -101,25 +104,29 @@ class DispatchJobController extends Controller
             corporationRoles: $corporation_roles,
         );
 
-        $tokens = RefreshToken::query()
+        $scoped_tokens = RefreshToken::query()
             ->whereHas('character', fn (Builder $query) => $query->whereIn('character_id', $affiliated_ids))
             ->with('character', 'character.roles', 'character.corporation')
             ->cursor()
-            ->filter(fn (RefreshToken $token) => collect($request->get('required_scopes'))->intersect($token->scopes)->isNotEmpty())
+            ->filter(fn (RefreshToken $token) => collect($validated_data['required_scopes'])->intersect($token->scopes)->isNotEmpty())
             ->when(
                 $isCorporationScope,
-                fn (LazyCollection $tokens) => $tokens
-                    ->filter(function (RefreshToken $token) use ($corporation_roles): bool {
-                        /** @var CharacterInfo $character */
-                        $character = $token->character;
-                        /** @var CharacterRole $roles */
-                        $roles = $character->roles;
+                fn (LazyCollection $tokens) => $tokens->filter(function (RefreshToken $token) use ($corporation_roles): bool {
+                    /** @var CharacterInfo $character */
+                    $character = $token->character;
+                    /** @var CharacterRole $roles */
+                    $roles = $character->roles;
 
-                        return collect($corporation_roles)->contains(fn (string $role) => $roles->hasRole('roles', $role));
-                    })
-                    ->unique(fn (RefreshToken $token) => $token->corporation_id)
+                    return collect($corporation_roles)->contains(fn (string $role) => $roles->hasRole('roles', $role));
+                })
             )
-            ->map(function (RefreshToken $token) use ($isCorporationScope, $request): array {
+            ->collect();
+
+        $owned_ids = $this->getOwnedIds($scoped_tokens, $isCorporationScope);
+
+        $entities = $scoped_tokens
+            ->when($isCorporationScope, fn (Collection $tokens) => $tokens->unique(fn (RefreshToken $token) => $token->corporation_id))
+            ->map(function (RefreshToken $token) use ($isCorporationScope, $validated_data): array {
                 /** @var CharacterInfo $character */
                 $character = $token->character;
                 /** @var CorporationInfo $corporation */
@@ -129,12 +136,68 @@ class DispatchJobController extends Controller
                     'character_id' => $isCorporationScope ? null : $token->character_id,
                     'corporation_id' => $isCorporationScope ? $token->corporation_id : null,
                     'name' => $isCorporationScope ? $corporation->name : $character->name,
-                    'batch' => $this->getBatchStatus(cache($this->getCacheKey($request->get('manual_job'), $isCorporationScope ? $token->corporation_id : $token->character_id))),
+                    'batch' => $this->getBatchStatus(cache($this->getCacheKey($validated_data['manual_job'], $isCorporationScope ? $token->corporation_id : $token->character_id))),
                 ])->filter()->toArray();
             })
+            ->filter(fn (array $entity) => $this->matchesOwnership($entity, $owned_ids, $isCorporationScope, $ownership))
             ->values();
 
-        return new LengthAwarePaginator($tokens, $tokens->count(), $request->get('per_page', 10));
+        return $this->paginate($entities, $request);
+    }
+
+    /**
+     * Ids the user owns outright: their own characters, or — for corporation scoped
+     * jobs — the corporations any of their own (role-holding) characters sit in.
+     *
+     * @param  Collection<int, RefreshToken>  $scoped_tokens
+     * @return array<int, int>
+     */
+    private function getOwnedIds(Collection $scoped_tokens, bool $isCorporationScope): array
+    {
+        $owned_character_ids = $this->getOwnedCharacterIds();
+
+        if (! $isCorporationScope) {
+            return $owned_character_ids;
+        }
+
+        return $scoped_tokens
+            ->filter(fn (RefreshToken $token) => in_array($token->character_id, $owned_character_ids, true))
+            ->map(fn (RefreshToken $token) => $token->corporation_id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $entity
+     * @param  array<int, int>  $owned_ids
+     */
+    private function matchesOwnership(array $entity, array $owned_ids, bool $isCorporationScope, string $ownership): bool
+    {
+        $id = $isCorporationScope ? $entity['corporation_id'] : $entity['character_id'];
+        $isOwned = in_array($id, $owned_ids, true);
+
+        return $ownership === 'owned' ? $isOwned : ! $isOwned;
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $items
+     */
+    private function paginate(Collection $items, Request $request): LengthAwarePaginator
+    {
+        $per_page = (int) $request->get('per_page', 10);
+        $page = (int) $request->get('page', 1);
+
+        return new LengthAwarePaginator(
+            $items->forPage($page, $per_page)->values(),
+            $items->count(),
+            $per_page,
+            $page,
+            [
+                'path' => $request->url(),
+                'query' => $request->query(),
+            ]
+        );
     }
 
     private function getRefreshToken(DispatchIndividualJob $job): ?RefreshToken

--- a/src/Services/GetAffiliatedIds.php
+++ b/src/Services/GetAffiliatedIds.php
@@ -61,6 +61,20 @@ class GetAffiliatedIds
     }
 
     /**
+     * The user's own character ids, taken straight from the cached permission object
+     * (user_permissions_{id}, 5-min TTL) rather than a fresh query — the same slice
+     * collectAffiliatedIds() merges in as `owned_character_ids`.
+     *
+     * @return array<int, int>
+     */
+    public function ownedCharacterIds(?User $user = null): array
+    {
+        $user = $user ?? $this->user;
+
+        return data_get($this->canUserService->getUserPermissionObject($user), 'owned_character_ids', []);
+    }
+
+    /**
      * @param  array<int,string>  $permissions
      * @param  array<int,string>  $corporationRole
      * @return array<int,int>

--- a/tests/Feature/Controller/DispatchJobControllerTest.php
+++ b/tests/Feature/Controller/DispatchJobControllerTest.php
@@ -151,11 +151,15 @@ test('partitions entities into owned and affiliated by the ownership flag', func
     $affiliated_character = $affiliated_user->characters->first();
     updateRefreshTokenWithScopes($affiliated_character->refreshToken, test()->dispatch_transfer_object['required_scopes']);
 
-    // both characters are in the user's manageable scope
-    test()->mock(GetAffiliatedIds::class, fn ($mock) => $mock->shouldReceive('get')->andReturn([
-        test()->test_character->character_id,
-        $affiliated_character->character_id,
-    ]));
+    // owned resolves straight from the cached permission object; the affiliated set is
+    // the full manageable scope (owned is diffed out by the controller).
+    test()->mock(GetAffiliatedIds::class, function ($mock) use ($affiliated_character) {
+        $mock->shouldReceive('ownedCharacterIds')->andReturn([test()->test_character->character_id]);
+        $mock->shouldReceive('get')->andReturn([
+            test()->test_character->character_id,
+            $affiliated_character->character_id,
+        ]);
+    });
 
     test()->actingAs(test()->test_user)
         ->postJson(route('manual_job.entities'), [...test()->dispatch_transfer_object, 'ownership' => 'owned'])

--- a/tests/Feature/Controller/DispatchJobControllerTest.php
+++ b/tests/Feature/Controller/DispatchJobControllerTest.php
@@ -2,11 +2,13 @@
 
 use Illuminate\Support\Arr;
 use Illuminate\Testing\Fluent\AssertableJson;
+use Seatplus\Auth\Models\User;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Contacts\Contact;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Web\Jobs\ManualDispatchedJob;
 use Seatplus\Web\Services\Controller\CreateDispatchTransferObject;
+use Seatplus\Web\Services\GetAffiliatedIds;
 
 beforeEach(function () {
     // The real DispatchTransferObject always emits required_corporation_role as an
@@ -138,4 +140,32 @@ test('entities endpoint accepts the real DispatchTransferObject payload', functi
                     ->etc()
             )->etc()
         );
+});
+
+test('partitions entities into owned and affiliated by the ownership flag', function () {
+    // owned: the test user's own character
+    updateRefreshTokenWithScopes(test()->test_character->refreshToken, test()->dispatch_transfer_object['required_scopes']);
+
+    // affiliated: a character the user may manage but does not own
+    $affiliated_user = Event::fakeFor(fn () => User::factory()->create());
+    $affiliated_character = $affiliated_user->characters->first();
+    updateRefreshTokenWithScopes($affiliated_character->refreshToken, test()->dispatch_transfer_object['required_scopes']);
+
+    // both characters are in the user's manageable scope
+    test()->mock(GetAffiliatedIds::class, fn ($mock) => $mock->shouldReceive('get')->andReturn([
+        test()->test_character->character_id,
+        $affiliated_character->character_id,
+    ]));
+
+    test()->actingAs(test()->test_user)
+        ->postJson(route('manual_job.entities'), [...test()->dispatch_transfer_object, 'ownership' => 'owned'])
+        ->assertOk()
+        ->assertJsonFragment(['character_id' => test()->test_character->character_id])
+        ->assertJsonMissing(['character_id' => $affiliated_character->character_id]);
+
+    test()->actingAs(test()->test_user)
+        ->postJson(route('manual_job.entities'), [...test()->dispatch_transfer_object, 'ownership' => 'affiliated'])
+        ->assertOk()
+        ->assertJsonFragment(['character_id' => $affiliated_character->character_id])
+        ->assertJsonMissing(['character_id' => test()->test_character->character_id]);
 });


### PR DESCRIPTION
Builds on #1544 (stacked — base retargets to `5.x` when #1544 merges).

## Why
The Update SlideOver loaded **every** manageable entity in one flat list — the user's own characters/corps *plus* everything reachable via permissions, affiliations and corp roles. For recruiters/directors/admins that affiliated set is large, so the common case ("update *my* character") paid for loading all of it. It also masked a real pagination bug: the old paginator never sliced by page, so scrolling a large list re-returned the whole set.

## What
**Backend (`getEntities`)**
- New `ownership` filter (`owned` | `affiliated`, default `owned`). Partitions the result: **owned** = the user's own characters, or for corp-scoped jobs the corps their own role-holding characters sit in; **affiliated** = the rest.
- Real pagination (`forPage` slice + proper `LengthAwarePaginator`) so the affiliated InfiniteScroll advances instead of re-returning everything.

**Frontend (`DispatchUpdate.vue`)** — two sections:
- **Your characters / corporations** — loads immediately (small).
- **Affiliated …** — collapsed; fetches only when expanded.
- Dropped the dead `dispatchJob`/`job_name` members (`DispatchableEntry` owns dispatching).

## Tests
- New: partitions owned vs affiliated (stubs `GetAffiliatedIds` to return an owned + a non-owned character; asserts each shows only in its section).
- Existing char/corp/real-DTO tests still green (default `owned`, test character is owned). 5 passed.

## Notes / follow-ups
- The affiliated header has no eager count (would force the expensive affiliation resolve on open — see auth#414); it loads on expand instead.
- Still uses the axios `InfiniteLoadingHelper`; retiring it for Inertia v3 `InfiniteScroll` doesn't fit a POST-driven modal cleanly and is tracked under the B1 rollout.