### PR TITLE
fix: manual Update batch tolerates a single job's failure (allowFailures)

### DIFF
--- a/src/Jobs/ManualDispatchedJob.php
+++ b/src/Jobs/ManualDispatchedJob.php
@@ -49,6 +49,9 @@ class ManualDispatchedJob
             ->then(fn () => logger()->info($success_message))
             ->name($this->name)
             ->onQueue('high')
+            // One member failing (e.g. a genuine ESI error on a single character/scope)
+            // must not cancel the rest of the update — like CharacterBatchJob does.
+            ->allowFailures()
             ->dispatch();
 
         return $batch->id;

--- a/tests/Unit/Jobs/ManualDispatchedJobTest.php
+++ b/tests/Unit/Jobs/ManualDispatchedJobTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+use Seatplus\Eveapi\Jobs\Wallet\CharacterBalanceJob;
+use Seatplus\Web\Jobs\ManualDispatchedJob;
+
+it('dispatches the manual update batch with allowFailures so one failing job does not cancel the rest', function () {
+    Bus::fake();
+
+    (new ManualDispatchedJob)
+        ->setJobs([new CharacterBalanceJob(1234)])
+        ->setName('Manual batch update of wallet:1234')
+        ->handle();
+
+    Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->allowsFailures()
+        && $batch->name === 'Manual batch update of wallet:1234');
+});


### PR DESCRIPTION
The **Update** sidebar dispatches `ManualDispatchedJob`, whose `Bus::batch(...)` had **no `->allowFailures()`**. So if one member job failed, the whole batch was **cancelled** — the remaining update jobs (wallet journal/transaction, etc.) silently didn't run. `CharacterBatchJob` already uses `->allowFailures()` for exactly this reason.

Add `->allowFailures()` so a genuine failure in one character/scope no longer drops the rest of the update. The success log stays on `->then()` (fires only when every job succeeds).

Companion to eveapi #690 (throttling no longer fails a job) — together they mean the Update sidebar completes reliably even when one job is throttled or errors.

Test: `Bus::fake()` + `assertBatched(fn ($batch) => $batch->allowsFailures())`.