### PR TITLE
feat: character contracts on Inertia v3 InfiniteScroll (B1) + axios/Ziggy removal (B2/B3)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,6 +57,31 @@ Reuse the existing `AclTypes/` building blocks (Affiliations, Members, Moderator
 
 ---
 
+## Frontend modernization — Inertia v3 (in progress)
+
+Rolling the frontend onto native Inertia v3 primitives and off the legacy axios/Ziggy stack.
+Three parallel tracks:
+
+- **B1 — InfiniteScroll rollout.** Replace the custom axios-based `InfiniteLoadingHelper`
+  with page-level `Inertia::scroll()` props rendered by `<InfiniteScroll>`. Pattern: one
+  scroll prop per character/entity, each with a distinct `pageName`, streamed into an
+  `items-element` inside a `scroll-region` container.
+  - ✅ Character + corporation wallet journals ([#1536](https://github.com/seatplus/web/pull/1536), [#1537](https://github.com/seatplus/web/pull/1537))
+  - ✅ Mail ([#1541](https://github.com/seatplus/web/pull/1541))
+  - 🔷 Contracts ([#1547](https://github.com/seatplus/web/pull/1547)) — dual-mode `ContractComponent`:
+    `scroll-key` prop on the character page, `InfiniteLoadingHelper` fallback kept for the
+    recruitment/watchlist endpoint (which still needs the details route).
+  - ⏭️ Remaining axios-fed lists (assets, transactions, …) to migrate as the pattern proves out.
+- **B2 — Remove axios.** Native `fetch` wrapper at `resources/js/Functions/http.js`
+  (`getJson`/`post`, `X-XSRF-TOKEN` from the `XSRF-TOKEN` cookie). Done for the dispatch/update
+  sidebar; retire per surface alongside B1.
+- **B3 — Remove Ziggy** ([#1462](https://github.com/seatplus/web/issues/1462)). Replace
+  `route()` calls with Wayfinder imports from `@/actions/` (controllers) / `@/routes/` (named).
+  Wayfinder output is gitignored and generated in CI (`php artisan wayfinder:generate` in
+  core's browser job; package "Frontend Lint" is lint-only).
+
+---
+
 ## Older open issues (lower priority)
 
 | Issue | Title |
@@ -72,6 +97,12 @@ Reuse the existing `AclTypes/` building blocks (Affiliations, Members, Moderator
 
 | PR | Description |
 |----|-------------|
+| [#1546](https://github.com/seatplus/web/pull/1546) | `ManualDispatchedJob` `->allowFailures()` — one job's failure no longer cancels the Update batch |
+| [#1545](https://github.com/seatplus/web/pull/1545) | Dispatch/update sidebar — owned vs affiliated sections, axios→fetch + Wayfinder, cached `getEntities` |
+| [#1544](https://github.com/seatplus/web/pull/1544) | Dispatch sidebar fix (`required_corporation_role` array validation) + owned/affiliated partition + browser tests |
+| [#1542](https://github.com/seatplus/web/pull/1542), [#1543](https://github.com/seatplus/web/pull/1543) | `GetEntityFromId` — resolve-id 404 fallback + alliance `[object Object]` name fix |
+| [#1541](https://github.com/seatplus/web/pull/1541) | Mail → InfiniteScroll; axios/Ziggy→fetch; fix `app.js` `layout:null` double-sidebar |
+| [#1537](https://github.com/seatplus/web/pull/1537), [#1536](https://github.com/seatplus/web/pull/1536) | Wallet journals (char + corp) → Inertia InfiniteScroll |
 | [#1476](https://github.com/seatplus/web/pull/1476) | ACL typed controllers — SOLID single-action controllers, new routes, feature tests |
 | [#1473](https://github.com/seatplus/web/pull/1473) | Controllers, actions, services, resources refactor (1-C) |
 | [#1472](https://github.com/seatplus/web/pull/1472) | Middleware overhaul — remove dead pipeline middleware, fix auth routing (1-B) |

--- a/resources/js/Functions/http.js
+++ b/resources/js/Functions/http.js
@@ -12,10 +12,11 @@ function xsrfToken() {
     return match ? decodeURIComponent(match[1]) : '';
 }
 
-async function request(url, { method = 'GET', body } = {}) {
+async function request(url, { method = 'GET', body, headers: extraHeaders } = {}) {
     const headers = {
         Accept: 'application/json',
         'X-Requested-With': 'XMLHttpRequest',
+        ...extraHeaders,
     };
 
     if (body !== undefined) {
@@ -37,8 +38,8 @@ async function request(url, { method = 'GET', body } = {}) {
     return response;
 }
 
-export async function getJson(url) {
-    return (await request(url)).json();
+export async function getJson(url, headers) {
+    return (await request(url, { headers })).json();
 }
 
 export function post(url, body = {}) {

--- a/resources/js/Pages/Character/Contract/ContractDetails.vue
+++ b/resources/js/Pages/Character/Contract/ContractDetails.vue
@@ -12,6 +12,7 @@
 <script>
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import ContractDetailsComponent from "@/Shared/Components/Contracts/ContractDetailsComponent.vue";
+import { index as characterContracts } from "@/actions/Seatplus/Web/Http/Controllers/Character/ContractsController";
 export default {
     name: "ContractDetails",
     components: {
@@ -34,7 +35,7 @@ export default {
             breadcrumbs: [
                 {
                     name: 'Character Contracts',
-                    route: route('character.contracts')
+                    route: characterContracts.url()
                 }
             ]
         }

--- a/resources/js/Pages/Character/Contract/Index.vue
+++ b/resources/js/Pages/Character/Contract/Index.vue
@@ -16,6 +16,7 @@
         v-for="character in characters"
         :id="character.character_id"
         :key="character.character_id"
+        :scroll-key="`contracts_${character.character_id}`"
       />
     </div>
   </div>

--- a/resources/js/Pages/Character/Contract/Index.vue
+++ b/resources/js/Pages/Character/Contract/Index.vue
@@ -51,11 +51,6 @@ export default {
       return {
         pageTitle: 'Character Contracts'
       }
-  },
-  methods: {
-    getUrl(character_id) {
-      return route('character.contracts.details', character_id)
-    }
   }
 }
 </script>

--- a/resources/js/Shared/Components/Contracts/ContractComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ContractComponent.vue
@@ -11,61 +11,54 @@
         </div>
       </div>
     </template>
-    <!-- This example requires Tailwind CSS v2.0+ -->
-    <div class="relative max-h-96 overflow-y-auto">
+
+    <!-- scroll-region lets Inertia track/restore this custom scroll container so
+         <InfiniteScroll> merges the next page without jumping to top. -->
+    <div
+      class="relative max-h-96 overflow-y-auto"
+      :scroll-region="scrollKey ? '' : null"
+    >
+      <!-- Character page: contracts delivered as a page scroll prop → Inertia InfiniteScroll. -->
+      <InfiniteScroll
+        v-if="scrollKey"
+        :data="scrollKey"
+        :items-element="`#${scrollBodyId}`"
+        preserve-url
+      >
+        <StickyHeaderTable
+          :header-titles="headerTitles"
+          :body-id="scrollBodyId"
+        >
+          <template #default="slotProps">
+            <ContractRowComponent
+              v-for="contract in scrollEntries"
+              :key="contract.contract_id"
+              :contract="contract"
+              :columns="slotProps.columns"
+              :count-columns="slotProps.countColumns"
+              :character-id="id"
+            />
+          </template>
+        </StickyHeaderTable>
+      </InfiniteScroll>
+
+      <!-- Recruitment (watchlist): still the axios helper against the details endpoint. -->
       <InfiniteLoadingHelper
+        v-else
         v-slot="{results}"
         route-name="character.contracts.details"
         :params="parameters"
       >
-        <StickyHeaderTable
-          :header-titles="[{title: 'Issuer', columnSpan: 2}, {title: 'Assignee', columnSpan: 2}, {title: 'Type', columnSpan: 2}, {title: 'Details', columnSpan: 4}, {title: 'Content', columnSpan: 1, srOnly: true}]"
-        >
+        <StickyHeaderTable :header-titles="headerTitles">
           <template #default="slotProps">
-            <StickyHeaderTableRow
+            <ContractRowComponent
               v-for="contract in results"
               :key="contract.contract_id"
-              :number-columns="slotProps.countColumns"
-            >
-              <!--  Issuer-->
-              <StickyHeaderCell
-                :cell="slotProps.columns[0]"
-                class="self-center truncate"
-              >
-                <IssuerComponent :contract="contract" />
-              </StickyHeaderCell>
-              <!--  Assignee-->
-              <StickyHeaderCell
-                :cell="slotProps.columns[1]"
-                class="self-center truncate"
-              >
-                <AssigneeComponent :contract="contract" />
-              </StickyHeaderCell>
-              <!-- Contract type-->
-              <StickyHeaderCell
-                :cell="slotProps.columns[2]"
-                class="flex flex-wrap text-sm font-medium text-gray-500 sm:self-center truncate"
-              >
-                <ContractTypeComponent :contract="contract" />
-              </StickyHeaderCell>
-              <StickyHeaderCell
-                :cell="slotProps.columns[3]"
-                class="flex flex-wrap gap-x-2 text-sm font-medium text-gray-500 sm:self-center"
-              >
-                <DetailsComponent :contract="contract" />
-              </StickyHeaderCell>
-              <StickyHeaderCell
-                :cell="slotProps.columns[4]"
-                class="sm:self-center sm:place-self-end"
-              >
-                <ExpandContractComponent
-                  v-if="contract.items > 0"
-                  :character-id="id"
-                  :contract="contract"
-                />
-              </StickyHeaderCell>
-            </StickyHeaderTableRow>
-            <div ref="scrollComponent" />
+              :contract="contract"
+              :columns="slotProps.columns"
+              :count-columns="slotProps.countColumns"
+              :character-id="id"
+            />
           </template>
         </StickyHeaderTable>
       </InfiniteLoadingHelper>
@@ -74,32 +67,22 @@
 </template>
 
 <script>
-
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
-import StickyHeaderTable from "../../Layout/Table/StickyHeaderTable.vue";
-import StickyHeaderTableRow from "../../Layout/Table/StickyHeaderTableRow.vue";
-import StickyHeaderCell from "../../Layout/Table/StickyHeaderCell.vue";
-import InfiniteLoadingHelper from "../../InfiniteLoadingHelper.vue";
-import {ref} from "vue";
-import ExpandContractComponent from "./ExpandContractComponent.vue";
-import IssuerComponent from "./Cells/IssuerComponent.vue";
-import AssigneeComponent from "./Cells/AssigneeComponent.vue";
-import ContractTypeComponent from "./Cells/ContractTypeComponent.vue";
-import DetailsComponent from "./Cells/DetailsComponent.vue";
- 
+import StickyHeaderTable from "@/Shared/Layout/Table/StickyHeaderTable.vue";
+import InfiniteLoadingHelper from "@/Shared/InfiniteLoadingHelper.vue";
+import { InfiniteScroll } from "@inertiajs/vue3";
+import ContractRowComponent from "./ContractRowComponent.vue";
+
 export default {
     name: "ContractComponent",
     components: {
-        DetailsComponent,
-        ContractTypeComponent,
-        AssigneeComponent,
-        IssuerComponent,
-        ExpandContractComponent,
+        InfiniteScroll,
+        ContractRowComponent,
         InfiniteLoadingHelper,
-        StickyHeaderCell,
-        StickyHeaderTableRow,
-        StickyHeaderTable, CardWithHeader, EntityByIdBlock,
+        StickyHeaderTable,
+        CardWithHeader,
+        EntityByIdBlock,
     },
     props: {
         id: {
@@ -115,29 +98,30 @@ export default {
             required: false,
             type: Object,
             default: () => new Object()
-        }
-    },
-    setup() {
-
-        const contracts = ref([])
-
-        const getStartLocation = (contract) => _.get(contract, 'start_location.name', _.get(contract, 'start_location.locatable.name', 'unknown'))
-        const getEndLocation = (contract) => _.get(contract, 'end_location.name', _.get(contract, 'end_location.locatable.name', 'unknown'))
-
-        return {
-            contracts,
-            getStartLocation,
-            getEndLocation
-        }
-
+        },
+        // When set (character page) contracts come from this page scroll prop via
+        // <InfiniteScroll>. When null (recruitment) the axios helper + watchlist is used.
+        scrollKey: {
+            required: false,
+            type: String,
+            default: null,
+        },
     },
     computed: {
-        entity() {
-            return {
-                type: this.type,
-                character_id: this.type === 'character' ? this.id : null,
-                corporation_id: this.type === 'corporation' ? this.id : null
-            }
+        headerTitles() {
+            return [
+                {title: 'Issuer', columnSpan: 2},
+                {title: 'Assignee', columnSpan: 2},
+                {title: 'Type', columnSpan: 2},
+                {title: 'Details', columnSpan: 4},
+                {title: 'Content', columnSpan: 1, srOnly: true},
+            ]
+        },
+        scrollBodyId() {
+            return `contracts-body-${this.id}`
+        },
+        scrollEntries() {
+            return this.$page.props[this.scrollKey]?.data ?? []
         },
         parameters() {
             return {...this.watchlist, character_id: this.id}

--- a/resources/js/Shared/Components/Contracts/ContractRowComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ContractRowComponent.vue
@@ -1,0 +1,84 @@
+<template>
+  <StickyHeaderTableRow :number-columns="countColumns">
+    <!-- Issuer -->
+    <StickyHeaderCell
+      :cell="columns[0]"
+      class="self-center truncate"
+    >
+      <IssuerComponent :contract="contract" />
+    </StickyHeaderCell>
+    <!-- Assignee -->
+    <StickyHeaderCell
+      :cell="columns[1]"
+      class="self-center truncate"
+    >
+      <AssigneeComponent :contract="contract" />
+    </StickyHeaderCell>
+    <!-- Contract type -->
+    <StickyHeaderCell
+      :cell="columns[2]"
+      class="flex flex-wrap text-sm font-medium text-gray-500 sm:self-center truncate"
+    >
+      <ContractTypeComponent :contract="contract" />
+    </StickyHeaderCell>
+    <StickyHeaderCell
+      :cell="columns[3]"
+      class="flex flex-wrap gap-x-2 text-sm font-medium text-gray-500 sm:self-center"
+    >
+      <DetailsComponent :contract="contract" />
+    </StickyHeaderCell>
+    <StickyHeaderCell
+      :cell="columns[4]"
+      class="sm:self-center sm:place-self-end"
+    >
+      <ExpandContractComponent
+        v-if="contract.items > 0"
+        :character-id="characterId"
+        :contract="contract"
+      />
+    </StickyHeaderCell>
+  </StickyHeaderTableRow>
+</template>
+
+<script>
+import StickyHeaderTableRow from "@/Shared/Layout/Table/StickyHeaderTableRow.vue";
+import StickyHeaderCell from "@/Shared/Layout/Table/StickyHeaderCell.vue";
+import ExpandContractComponent from "./ExpandContractComponent.vue";
+import IssuerComponent from "./Cells/IssuerComponent.vue";
+import AssigneeComponent from "./Cells/AssigneeComponent.vue";
+import ContractTypeComponent from "./Cells/ContractTypeComponent.vue";
+import DetailsComponent from "./Cells/DetailsComponent.vue";
+
+export default {
+    name: "ContractRowComponent",
+    components: {
+        StickyHeaderTableRow,
+        StickyHeaderCell,
+        ExpandContractComponent,
+        IssuerComponent,
+        AssigneeComponent,
+        ContractTypeComponent,
+        DetailsComponent,
+    },
+    props: {
+        contract: {
+            required: true,
+            type: Object,
+        },
+        // The StickyHeaderTable slot's column definitions + count, threaded through so
+        // the cells lay out identically whether fed by InfiniteScroll or the helper.
+        columns: {
+            required: true,
+            type: Array,
+        },
+        countColumns: {
+            required: true,
+            type: Number,
+        },
+        characterId: {
+            required: true,
+            type: Number,
+        },
+    },
+}
+</script>

--- a/resources/js/Shared/Components/Contracts/ExpandContractComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ExpandContractComponent.vue
@@ -33,6 +33,8 @@ import {ref} from "vue";
 import WithDismissButtonModal from "@/Shared/Modals/WithDismissButtonModal.vue";
 import {DialogTitle} from "@headlessui/vue";
 import ContractDetailsComponent from "./ContractDetailsComponent.vue";
+import { getJson } from "@/Functions/http";
+import { getContractDetails } from "@/actions/Seatplus/Web/Http/Controllers/Character/ContractsController";
 
 export default {
     name: "ExpandContractComponent",
@@ -53,10 +55,11 @@ export default {
         const openModal = ref(false)
         const contractDetails = ref()
 
-        const url = route('contract.details', {character_id: props.characterId, contract_id: props.contract.contract_id})
+        const url = getContractDetails.url({character_id: props.characterId, contract_id: props.contract.contract_id})
 
         const fetchDetails = async () => {
-            await axios.get(url, {headers: {'X-Modal': true}}).then(response => contractDetails.value = response.data[0])
+            const details = await getJson(url, {'X-Modal': true})
+            contractDetails.value = details[0]
         }
 
         const open = () => {

--- a/resources/js/Shared/EveImage.vue
+++ b/resources/js/Shared/EveImage.vue
@@ -25,6 +25,8 @@
 
 <script>
 import {computed, onMounted, onUnmounted, ref, watch} from "vue";
+import { getJson } from "@/Functions/http";
+import { getResourceVariants } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
 
     export default {
         name: "EveImage",
@@ -58,26 +60,36 @@ import {computed, onMounted, onUnmounted, ref, watch} from "vue";
             const eveImageComponent = ref(null)
 
             const getImageVariant = async () => {
+                // Guard against a non-object (e.g. an unresolved "" entity) so the `in`
+                // checks below never throw.
+                if (!props.object || typeof props.object !== 'object')
+                    return;
+
                 if ('character_id' in props.object)
                     return resourceVariant.value = 'portrait';
 
                 if ('corporation_id' in props.object || 'alliance_id' in props.object)
                     return resourceVariant.value = 'logo';
 
-                await axios.get(route('get.resource.variants', {
+                // No recognizable EVE resource type (e.g. an unresolved/unknown entity, or a
+                // location/station) — bail before requesting variants, which would otherwise
+                // build a URL without a resource_type and throw.
+                if (!resourceType.value || !resourceId.value)
+                    return;
+
+                const variants = await getJson(getResourceVariants.url({
                     resource_type: resourceType.value,
-                    resource_id: resourceId.value
-                })).then(result => {
+                    resource_id: resourceId.value,
+                }))
 
-                    function getVariant() {
-                        if(props.bpo && _.has(_.invert(result.data), 'bp'))
-                            return 'bp'
+                function getVariant() {
+                    if (props.bpo && _.has(_.invert(variants), 'bp'))
+                        return 'bp'
 
-                        return result.data[0]
-                    }
+                    return variants[0]
+                }
 
-                    resourceVariant.value = getVariant()
-                })
+                resourceVariant.value = getVariant()
             }
 
             const resourceSize = computed(() => {

--- a/resources/js/Shared/Layout/Eve/EntityByIdBlock.vue
+++ b/resources/js/Shared/Layout/Eve/EntityByIdBlock.vue
@@ -29,8 +29,9 @@
 
 <script>
 import EveImage from "@/Shared/EveImage.vue"
-import axios from "axios";
 import {onMounted, onUnmounted, ref} from "vue";
+import { getJson } from "@/Functions/http";
+import { getEntityFromId } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
 
 export default {
     name: "EntityByIdBlock",
@@ -62,14 +63,18 @@ export default {
         const entity = ref(null)
 
         const getEntity = async () => {
-            await axios.get(route('resolve.id', props.id))
-                .then((response) => {
+            try {
+                const data = await getJson(getEntityFromId.url(props.id))
 
-                    entity.value = response.data
-
-                   isReady.value = true
-                })
-                .catch(error => console.log(error))
+                // resolve.id returns an empty payload ("") for ids it cannot resolve;
+                // only render once we actually have an entity object.
+                if (data && typeof data === 'object' && Object.keys(data).length > 0) {
+                    entity.value = data
+                    isReady.value = true
+                }
+            } catch (error) {
+                console.log(error)
+            }
         }
 
         const observer = new IntersectionObserver(function(entries) {

--- a/resources/js/Shared/Layout/Table/StickyHeaderTable.vue
+++ b/resources/js/Shared/Layout/Table/StickyHeaderTable.vue
@@ -12,7 +12,10 @@
       <span :class="{'sr-only' : title.srOnly}">{{ title.label }}</span>
     </div>
   </div>
-  <ul class="divide-y divide-gray-200">
+  <ul
+    :id="bodyId"
+    class="divide-y divide-gray-200"
+  >
     <slot
       :columns="columns"
       :count-columns="countColumns"
@@ -45,6 +48,12 @@ export default {
                 .filter()
                 .value()
                 .length> 0
+        },
+        // Optional id for the row <ul> so an <InfiniteScroll items-element> can target it.
+        bodyId: {
+            required: false,
+            type: String,
+            default: null,
         }
     },
     setup(props) {

--- a/src/Http/Controllers/Character/ContractsController.php
+++ b/src/Http/Controllers/Character/ContractsController.php
@@ -29,6 +29,7 @@ namespace Seatplus\Web\Http\Controllers\Character;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
 use Seatplus\Eveapi\Models\Contracts\Contract;
@@ -53,16 +54,39 @@ class ContractsController extends Controller
             ->with(['character.corporation', 'character.alliance'])
             ->get();
 
+        // One InfiniteScroll prop per character (mirrors the wallet migration). Each
+        // paginator carries the ContractRessource shape and its own pageName so the
+        // per-character scroll state never collides.
+        $contracts = $characters->mapWithKeys(fn (CharacterAffiliation $affiliation): array => [
+            "contracts_{$affiliation->character_id}" => Inertia::scroll(
+                fn () => $this->contractsQuery($affiliation->character_id)
+                    ->paginate(pageName: "contracts_{$affiliation->character_id}")
+                    ->through(fn (Contract $contract) => (new ContractRessource($contract))->resolve()),
+            ),
+        ])->all();
+
         return inertia('Character/Contract/Index', [
             'dispatchTransferObject' => $dispatchTransferObject,
             'characters' => $characters,
+            ...$contracts,
         ]);
+    }
+
+    /**
+     * Base query for a character's contracts with everything the row cells render.
+     * The watchlist scopes are applied only on the recruitment endpoint below.
+     *
+     * @return Builder<Contract>
+     */
+    private function contractsQuery(int $character_id): Builder
+    {
+        return Contract::whereHas('characters', fn (Builder $query) => $query->where('character_id', $character_id))
+            ->with(['items', 'items.type', 'items.type.group', 'startLocation.locatable', 'endLocation.locatable', 'assigneeCharacter', 'assigneeCorporation', 'issuerCharacter', 'issuerCorporation']);
     }
 
     public function getCharacterContractsDetails(int $character_id, Request $request): AnonymousResourceCollection
     {
-        $query = Contract::whereHas('characters', fn (Builder $query) => $query->where('character_id', $character_id))
-            ->with(['items', 'items.type', 'items.type.group', 'startLocation', 'endLocation', 'assigneeCharacter', 'assigneeCorporation', 'issuerCharacter', 'issuerCorporation'])
+        $query = $this->contractsQuery($character_id)
             ->tap(new LocationWatchListScope($request->all()))
             ->tap(new TypeWatchListScope($request->all()));
 

--- a/tests/Browser/CharacterContractTest.php
+++ b/tests/Browser/CharacterContractTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Seatplus\Auth\Models\CharacterUser;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Contracts\Contract;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\Universe\Location;
+
+/*
+ * Character contracts browser tests — run against the real assembled core app.
+ *
+ * Covers the modernized contracts view: per-character Inertia <InfiniteScroll> over a
+ * scroll prop (contracts_<id>), and the assignee/acceptor entity blocks that resolve
+ * asynchronously via the (axios/Ziggy-free) resolve.id + EveImage fetch path. A user
+ * always sees their OWN characters' contracts, so no permission is granted.
+ * Provisioning comes from the suite helper actingAsCharacter() (core tests/Pest.php).
+ */
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('makeCharacterContracts')) {
+    /**
+     * Create $count contracts owned by (attached to) $character and return them. Defaults
+     * model a personal, unaccepted (outstanding) contract issued to and assigned to the
+     * character itself, so every id the row renders (issuer/assignee) resolves offline
+     * from the DB. Override e.g. acceptor_id/status for the accepted case. Guarded so each
+     * Browser file can define it standalone without colliding when the suite loads several.
+     *
+     * @param  array<string, mixed>  $overrides
+     * @return Collection<int, Contract>
+     */
+    function makeCharacterContracts(CharacterInfo $character, int $count, array $overrides = []): Collection
+    {
+        // Share supporting records across the whole batch. Left to its defaults the Contract
+        // factory spins up a fresh Location→Station→System and a CorporationInfo per contract,
+        // and those random universe/corp ids collide (e.g. universe_systems_pkey) once enough
+        // rows are created. Create them once and reuse the ids.
+        $contracts = Contract::factory()->count($count)->create(array_merge([
+            'issuer_id' => $character->character_id,
+            'assignee_id' => $character->character_id,
+            'for_corporation' => false,
+            'acceptor_id' => 0,
+            'status' => 'outstanding',
+            'issuer_corporation_id' => CorporationInfo::factory()->create()->corporation_id,
+            'start_location_id' => Location::factory()->withStation()->create()->location_id,
+            'end_location_id' => Location::factory()->withStation()->create()->location_id,
+        ], $overrides));
+
+        $character->contracts()->syncWithoutDetaching($contracts->pluck('contract_id')->all());
+
+        return $contracts;
+    }
+}
+
+if (! function_exists('attachOwnedCharacter')) {
+    /**
+     * Attach an additional owned character to the same user that owns $existing, so a
+     * browser test can exercise the multi-character case — character-scoped pages render
+     * one list per every character the logged-in user owns, not just the main. Returns the
+     * newly attached character. Guarded so each Browser file can define it standalone
+     * without colliding when the suite loads several.
+     */
+    function attachOwnedCharacter(CharacterInfo $existing): CharacterInfo
+    {
+        $user = CharacterUser::query()
+            ->where('character_id', $existing->character_id)
+            ->firstOrFail()
+            ->user;
+
+        $character = CharacterInfo::factory()->create();
+
+        CharacterUser::create([
+            'user_id' => $user->getKey(),
+            'character_id' => $character->character_id,
+            'character_owner_hash' => sha1((string) $character->character_id),
+        ]);
+
+        return $character;
+    }
+}
+
+it('merges the next contracts page in on scroll', function () {
+    $character = actingAsCharacter();
+
+    // 40 contracts → several paginator pages (default 15/page) for the contracts_<id> prop.
+    makeCharacterContracts($character, 40);
+
+    $rows = "#contracts-body-{$character->character_id} > *";
+
+    $page = visit('/character/contracts');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Contracts');
+
+    // Row <div>s come straight from the scroll prop data (no async needed to exist), so
+    // the first page is present immediately.
+    $before = (int) $page->script("document.querySelectorAll('{$rows}').length");
+    expect($before)->toBeGreaterThan(0);
+
+    // Re-scroll the list's own container to the bottom on every poll (comma expression)
+    // so InfiniteScroll's end trigger fires; passes once the next page has merged in.
+    $page->assertScript("(document.getElementById('contracts-body-{$character->character_id}').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
+
+    $page->screenshot(true, 'character-contracts-infinite-scroll');
+});
+
+it('renders both the assignee and the acceptor for an accepted contract', function () {
+    $character = actingAsCharacter();
+
+    // A second, distinct character to act as the acceptor. A factory character carries its
+    // own CharacterAffiliation, so resolve.id returns it offline (no ESI in the browser).
+    $acceptor = CharacterInfo::factory()->create();
+
+    // Accepted contracts assigned to the main character but accepted by someone else — the
+    // AssigneeComponent then renders a second entity block (acceptor_id !== 0 and != assignee).
+    makeCharacterContracts($character, 3, [
+        'acceptor_id' => $acceptor->character_id,
+        'status' => 'in_progress',
+    ]);
+
+    $page = visit('/character/contracts');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Contracts');
+
+    // The row entity blocks resolve asynchronously (IntersectionObserver → resolve.id →
+    // EveImage). waitForText polls until both the assignee (the character itself) and the
+    // acceptor blocks have loaded and rendered their names/images — i.e. give the images a
+    // moment before asserting/screenshotting.
+    $page->waitForText($character->name);
+    $page->waitForText($acceptor->name);
+
+    $page->screenshot(true, 'character-contracts-assignee-acceptor');
+});
+
+it('renders a contracts list for every character the user owns', function () {
+    $mainCharacter = actingAsCharacter();
+    $secondCharacter = attachOwnedCharacter($mainCharacter);
+
+    // A handful of contracts per owned character so each list renders. The page emits one
+    // contracts_<id> scroll prop / list per owned character, so both bodies must be present
+    // — a single-character render would only emit the main character's.
+    collect([$mainCharacter, $secondCharacter])
+        ->each(fn (CharacterInfo $character) => makeCharacterContracts($character, 5));
+
+    $page = visit('/character/contracts');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Contracts');
+
+    $page->assertPresent("#contracts-body-{$mainCharacter->character_id}");
+    $page->assertPresent("#contracts-body-{$secondCharacter->character_id}");
+
+    $page->screenshot(true, 'character-contracts-multiple-characters');
+});


### PR DESCRIPTION
## Summary

Migrates the character **contracts** list to native Inertia v3 `<InfiniteScroll>` (roadmap **B1**) and removes `axios` + Ziggy `route()` from the contracts render path (roadmap **B2/B3**).

### B1 — InfiniteScroll
- `ContractsController@index` now returns one `Inertia::scroll()` prop per owned character (`contracts_<id>`, each with its own `pageName`), mirroring the wallet/mail migrations. Extracted a private `contractsQuery()` reused by the recruitment details endpoint (which keeps its watchlist scopes).
- `ContractComponent` is **dual-mode**: a `scroll-key` prop drives `<InfiniteScroll>` on the character page; the legacy `InfiniteLoadingHelper` fallback is preserved for the recruitment/watchlist endpoint. Row markup extracted to `ContractRowComponent`; `StickyHeaderTable` gained an optional `bodyId` so `<InfiniteScroll items-element>` can target the row list.
- Eager-loads `startLocation.locatable` / `endLocation.locatable` so the resource resolves without a (disabled) lazy load.

### B2/B3 — axios + Ziggy removal
The controller and `ContractComponent` were clean, but the rendered rows dragged both in through shared children. Moved to the native fetch wrapper (`Functions/http.js`) + Wayfinder:
- `EntityByIdBlock`: `resolve.id` → `getJson(getEntityFromId.url(id))`, and only renders once a real entity object comes back (guards the empty-payload case).
- `EveImage`: `get.resource.variants` → `getJson(getResourceVariants.url(...))`, and guards entities with no recognizable resource type so it degrades gracefully instead of throwing.
- `ExpandContractComponent`: `contract.details` → `getJson(getContractDetails.url(...), {'X-Modal': true})` (`getJson` now forwards optional headers).
- `ContractDetails` breadcrumb → `index.url()`; removed a dead `getUrl()` in `Index.vue`.

`EntityByIdBlock` and `EveImage` are app-wide shared components, so this also removes axios/Ziggy from every other list that renders entity blocks/images.

The only axios left in the contracts tree is the recruitment `InfiniteLoadingHelper` fallback — the shared legacy helper being retired list-by-list per the roadmap.

## Tests
`tests/Browser/CharacterContractTest.php` (pest-plugin-browser, green on macOS):
- infinite scroll merges the next page on scroll;
- an accepted contract renders both the assignee and a distinct acceptor entity block (waits for the async `resolve.id` + `EveImage` load);
- one contracts list per owned character (multi-character case).

## Notes
- Wayfinder `@/actions` are gitignored + generated in CI (core browser job).
- 0 ESLint errors; Pint passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)