### PR TITLE
test: guard against running the suite on the dev database

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,6 +37,15 @@ abstract class TestCase extends OrchestraTestCase
 
     protected function setUp(): void
     {
+        // Hard stop: never run the suite against the dev database. The phpunit
+        // <env DB_DATABASE="laravel" force="true"> override has been observed to be bypassed
+        // in the local dev container (the shell exports DB_DATABASE=seatplus), in which case
+        // LazilyRefreshDatabase would migrate:fresh the dev DB and wipe it. Abort loudly
+        // before parent::setUp() boots anything or a factory touches the connection.
+        if (env('DB_DATABASE') === 'seatplus') {
+            throw new \RuntimeException('Test suite resolved DB_DATABASE=seatplus (the dev database) — aborting to avoid wiping dev data. The phpunit force override did not hold.');
+        }
+
         parent::setUp();
 
         Model::shouldBeStrict();


### PR DESCRIPTION
## Summary

Adds a hard stop at the top of `TestCase::setUp()` (before `parent::setUp()`) that aborts if `env('DB_DATABASE') === 'seatplus'`.

In the local dev container the phpunit `<env DB_DATABASE="laravel" force="true">` override does **not** win over the shell's exported `DB_DATABASE=seatplus`, so a local `vendor/bin/pest` run silently targeted the dev database and `LazilyRefreshDatabase` migrate:fresh'd (wiped) it. This guard prevents that and surfaces the force-bypass loudly. Run locally with `DB_DATABASE=laravel` prefixed; CI is unaffected (no such export).

Companion guards in eveapi (#695) and auth (#416).

🤖 Generated with [Claude Code](https://claude.com/claude-code)