### PR TITLE
feat: character assets InfiniteScroll + axios/Ziggy removal + nesting perf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.5",
         "laravel/framework": "^13.0",
         "laravel/socialite": "^5.0",
-        "seatplus/eveapi": "^4.1.4",
+        "seatplus/eveapi": "^4.2.0",
         "seatplus/auth": "^4.1.3",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/wayfinder": "^0.1.16",

--- a/resources/js/Functions/http.js
+++ b/resources/js/Functions/http.js
@@ -39,7 +39,12 @@ async function request(url, { method = 'GET', body, headers: extraHeaders } = {}
 }
 
 export async function getJson(url, headers) {
-    return (await request(url, { headers })).json();
+    const response = await request(url, { headers });
+    const text = await response.text();
+
+    // An empty body (e.g. a controller returning null) is valid "no content" — return null
+    // instead of letting JSON.parse('') throw "unexpected end of data".
+    return text.length ? JSON.parse(text) : null;
 }
 
 export function post(url, body = {}) {

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -151,7 +151,7 @@ export default {
             preserveScroll: true,
         })
 
-        const debouncedReload = _.debounce(reload, 350)
+        const debouncedReload = _.debounce(reload, 500)
 
         // Search reloads on 3+ chars or when cleared; region/system selections reload immediately.
         watch(search, (newValue) => {

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -78,10 +78,7 @@
         </div>
       </div>
 
-      <AssetsComponent
-        :parameters="cleanParams"
-        :compact="switchValue"
-      />
+      <AssetsComponent :compact="switchValue" />
     </div>
   </div>
 </template>
@@ -93,6 +90,7 @@ import AssetsComponent from "@/Shared/Components/Assets/AssetsComponent.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import {computed, ref, watch} from 'vue'
+import { router } from "@inertiajs/vue3";
 import { SwitchGroup, Switch, SwitchLabel } from '@headlessui/vue'
 import SelectedEntity from "@/Shared/Components/SelectedEntity.vue";
 import EsiMultiselect from "@/Shared/Components/EsiMultiselect.vue";
@@ -125,7 +123,6 @@ export default {
     },
     setup(props) {
         const switchValue = ref(false)
-        const infiniteId = ref(+new Date())
         const search = ref(null)
         const regions = ref([])
         const systems = ref([])
@@ -139,18 +136,28 @@ export default {
             }
         })
 
-        const debounceInfiniteId = _.debounce(() => infiniteId.value++, 250)
+        // Reload only the `assets` scroll prop with the current filters; reset so
+        // <InfiniteScroll> replaces the list with the filtered first page instead of merging.
+        const reload = () => router.reload({
+            only: ['assets'],
+            reset: ['assets'],
+            data: cleanParams.value,
+            preserveState: true,
+            preserveScroll: true,
+        })
 
-        watch(() => search.value, (newValue) => {
-            if(_.size(newValue)>=3) {
-                debounceInfiniteId()
+        const debouncedReload = _.debounce(reload, 350)
+
+        // Search reloads on 3+ chars or when cleared; region/system selections reload immediately.
+        watch(search, (newValue) => {
+            if (! newValue || _.size(newValue) >= 3) {
+                debouncedReload()
             }
         })
 
-        watch([regions.value, systems.value], () => infiniteId.value++)
+        watch([regions, systems], () => reload(), { deep: true })
 
         return {
-            infiniteId,
             search,
             regions,
             systems,

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -155,6 +155,8 @@ export default {
             data: cleanParams.value,
             preserveState: true,
             preserveScroll: true,
+            // Filters are sent to the server but kept out of the browser URL (stays /character/assets).
+            preserveUrl: true,
             onStart: () => { searching.value = true },
             onFinish: () => { searching.value = false },
         })

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -128,7 +128,8 @@ export default {
     },
     setup(props) {
         const switchValue = ref(ls.get(COMPACT_VIEW_KEY) ?? false)
-        const search = ref(null)
+        // Hydrate the search box from the URL so a shared/reloaded ?search=… link shows its term.
+        const search = ref(new URLSearchParams(window.location.search).get('search'))
         const regions = ref([])
         const systems = ref([])
 

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -94,6 +94,11 @@ import { router } from "@inertiajs/vue3";
 import { SwitchGroup, Switch, SwitchLabel } from '@headlessui/vue'
 import SelectedEntity from "@/Shared/Components/SelectedEntity.vue";
 import EsiMultiselect from "@/Shared/Components/EsiMultiselect.vue";
+import { ls } from "@/Functions/useLocalStorage";
+
+// Remember the compact/wide choice across visits (persisted for a year, refreshed on each toggle).
+const COMPACT_VIEW_KEY = 'assets.compactView'
+const COMPACT_VIEW_TTL = 365 * 24 * 60 * 60 * 1000
 
 export default {
     name: "Assets",
@@ -122,7 +127,7 @@ export default {
         },
     },
     setup(props) {
-        const switchValue = ref(false)
+        const switchValue = ref(ls.get(COMPACT_VIEW_KEY) ?? false)
         const search = ref(null)
         const regions = ref([])
         const systems = ref([])
@@ -156,6 +161,8 @@ export default {
         })
 
         watch([regions, systems], () => reload(), { deep: true })
+
+        watch(switchValue, (value) => ls.set(COMPACT_VIEW_KEY, value, COMPACT_VIEW_TTL))
 
         return {
             search,

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -78,7 +78,10 @@
         </div>
       </div>
 
-      <AssetsComponent :compact="switchValue" />
+      <AssetsComponent
+        :compact="switchValue"
+        :loading="searching"
+      />
     </div>
   </div>
 </template>
@@ -130,6 +133,8 @@ export default {
         const switchValue = ref(ls.get(COMPACT_VIEW_KEY) ?? false)
         // Hydrate the search box from the URL so a shared/reloaded ?search=… link shows its term.
         const search = ref(new URLSearchParams(window.location.search).get('search'))
+        // True while a filter reload is in flight, so the list can show it's updating.
+        const searching = ref(false)
         const regions = ref([])
         const systems = ref([])
 
@@ -150,6 +155,8 @@ export default {
             data: cleanParams.value,
             preserveState: true,
             preserveScroll: true,
+            onStart: () => { searching.value = true },
+            onFinish: () => { searching.value = false },
         })
 
         const debouncedReload = _.debounce(reload, 500)
@@ -170,6 +177,7 @@ export default {
             regions,
             systems,
             switchValue,
+            searching,
             cleanParams,
             pageTitle: 'Character Assets',
         }

--- a/resources/js/Pages/Character/ItemDetails.vue
+++ b/resources/js/Pages/Character/ItemDetails.vue
@@ -28,6 +28,7 @@ import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import ItemLayout from "@/Shared/Components/ItemLayout.vue";
 import { prefix } from "metric-prefix";
 import AppHead from "@/Shared/AppHead.vue";
+import { index as assetsRoute, item as itemRoute } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
 
 export default {
     name: "ItemDetails",
@@ -44,7 +45,7 @@ export default {
             breadcrumbs: [
                 {
                     name: 'Character Assets',
-                    route: route('character.assets')
+                    route: assetsRoute.url()
                 }
             ]
         }
@@ -53,7 +54,7 @@ export default {
         if(this.object.container)
             this.breadcrumbs.push({
                 name: this.object.container.name,
-                route: route('character.item', this.object.container.item_id)
+                route: itemRoute.url({character_id: this.object.owner_id, item_id: this.object.container.item_id})
             })
     },
     methods: {
@@ -63,7 +64,7 @@ export default {
         },
         url(asset) {
 
-            return _.isEmpty(asset.content) ? '' : route('character.item', {'item_id': asset.item_id, 'character_id': asset.owner.character_id})
+            return _.isEmpty(asset.content) ? '' : itemRoute.url({character_id: asset.owner_id, item_id: asset.item_id})
         },
         hasContent(content) {
             return !_.isEmpty(content)

--- a/resources/js/Shared/Components/Assets/AddManualLocationModal.vue
+++ b/resources/js/Shared/Components/Assets/AddManualLocationModal.vue
@@ -108,6 +108,7 @@
 import ModalWithFooter from "@/Shared/Modals/ModalWithFooter.vue";
 import EsiAutosuggest from "@/Shared/Components/EsiAutosuggest.vue";
 import {useForm} from "@inertiajs/vue3";
+import { create as createManualLocation } from "@/actions/Seatplus/Web/Http/Controllers/Shared/ManualLocationController";
 
 export default {
     name: "AddManualLocationModal",
@@ -150,7 +151,7 @@ emits: ['update:modelValue'],
             this.form.transform((data) => ({
                 ...data,
                 location_id: this.location_id
-            })).post(route('post.manual_location'), {
+            })).post(createManualLocation.url(), {
                 onSuccess: () => {
                     self.form.reset()
                     self.suggestions = []

--- a/resources/js/Shared/Components/Assets/AssetContentsLink.vue
+++ b/resources/js/Shared/Components/Assets/AssetContentsLink.vue
@@ -1,11 +1,17 @@
 <template>
   <!-- "Both": clicking opens the contents in a modal (fetched on demand); the href is the
-       shareable character.item deep link that renders the full ItemDetails page on direct visit. -->
+       shareable character.item deep link that renders the full ItemDetails page on direct visit.
+       With a slot it wraps that content (e.g. the compact row); without one it renders a
+       stretched-link overlay that fills the nearest positioned ancestor, so the whole row is
+       clickable without nesting a block element inside the anchor. -->
   <a
     :href="itemUrl"
+    :class="$slots.default ? undefined : 'absolute inset-0 z-10 focus:outline-hidden'"
     @click.stop.prevent="open"
   >
-    <slot />
+    <slot>
+      <span class="sr-only">Open contents</span>
+    </slot>
   </a>
   <teleport to="#destination">
     <WithDismissButtonModal

--- a/resources/js/Shared/Components/Assets/AssetContentsLink.vue
+++ b/resources/js/Shared/Components/Assets/AssetContentsLink.vue
@@ -52,6 +52,8 @@ import { item as itemAction } from "@/actions/Seatplus/Web/Http/Controllers/Char
 export default {
     name: "AssetContentsLink",
     components: { WithDismissButtonModal, DialogTitle, ItemList },
+    // Renders <a> + <teleport> (two roots), so it can't auto-inherit fallthrough attrs.
+    inheritAttrs: false,
     props: {
         characterId: {
             type: Number,

--- a/resources/js/Shared/Components/Assets/AssetContentsLink.vue
+++ b/resources/js/Shared/Components/Assets/AssetContentsLink.vue
@@ -36,16 +36,12 @@
 </template>
 
 <script>
-import { ref, defineAsyncComponent } from "vue";
+import { ref } from "vue";
 import { DialogTitle } from "@headlessui/vue";
 import WithDismissButtonModal from "@/Shared/Modals/WithDismissButtonModal.vue";
+import ItemList from "./ItemList.vue";
 import { getJson } from "@/Functions/http";
 import { item as itemAction } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
-
-// Lazily resolved to break the ItemList ↔ AssetContentsLink import cycle (a container's
-// contents render another ItemList, which can drill again). A static import deadlocks at
-// module init ("can't access 'ItemList' before initialization").
-const ItemList = defineAsyncComponent(() => import("./ItemList.vue"));
 
 export default {
     name: "AssetContentsLink",

--- a/resources/js/Shared/Components/Assets/AssetContentsLink.vue
+++ b/resources/js/Shared/Components/Assets/AssetContentsLink.vue
@@ -1,0 +1,78 @@
+<template>
+  <!-- "Both": clicking opens the contents in a modal (fetched on demand); the href is the
+       shareable character.item deep link that renders the full ItemDetails page on direct visit. -->
+  <a
+    :href="itemUrl"
+    @click.stop.prevent="open"
+  >
+    <slot />
+  </a>
+  <teleport to="#destination">
+    <WithDismissButtonModal
+      v-model="openModal"
+      width="4xl"
+    >
+      <DialogTitle
+        as="h3"
+        class="text-lg leading-6 font-medium text-gray-900"
+      >
+        Contents
+      </DialogTitle>
+
+      <ItemList
+        v-if="contents.length"
+        :items="contents"
+        :compact="false"
+        class="mt-4"
+      />
+      <p
+        v-else
+        class="mt-4 text-sm text-gray-500"
+      >
+        Loading…
+      </p>
+    </WithDismissButtonModal>
+  </teleport>
+</template>
+
+<script>
+import { ref } from "vue";
+import { DialogTitle } from "@headlessui/vue";
+import WithDismissButtonModal from "@/Shared/Modals/WithDismissButtonModal.vue";
+import ItemList from "./ItemList.vue";
+import { getJson } from "@/Functions/http";
+import { item as itemAction } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
+
+export default {
+    name: "AssetContentsLink",
+    components: { WithDismissButtonModal, DialogTitle, ItemList },
+    props: {
+        characterId: {
+            type: Number,
+            required: true,
+        },
+        itemId: {
+            type: Number,
+            required: true,
+        },
+    },
+    setup(props) {
+        const openModal = ref(false)
+        const contents = ref([])
+
+        const itemUrl = itemAction.url({ character_id: props.characterId, item_id: props.itemId })
+
+        const open = async () => {
+            if (! contents.value.length) {
+                // X-Modal returns [the container]; its `content` is the one level of contents.
+                const data = await getJson(itemUrl, { 'X-Modal': true })
+                contents.value = data[0]?.content ?? []
+            }
+
+            openModal.value = true
+        }
+
+        return { openModal, contents, itemUrl, open }
+    }
+}
+</script>

--- a/resources/js/Shared/Components/Assets/AssetContentsLink.vue
+++ b/resources/js/Shared/Components/Assets/AssetContentsLink.vue
@@ -36,12 +36,16 @@
 </template>
 
 <script>
-import { ref } from "vue";
+import { ref, defineAsyncComponent } from "vue";
 import { DialogTitle } from "@headlessui/vue";
 import WithDismissButtonModal from "@/Shared/Modals/WithDismissButtonModal.vue";
-import ItemList from "./ItemList.vue";
 import { getJson } from "@/Functions/http";
 import { item as itemAction } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
+
+// Lazily resolved to break the ItemList ↔ AssetContentsLink import cycle (a container's
+// contents render another ItemList, which can drill again). A static import deadlocks at
+// module init ("can't access 'ItemList' before initialization").
+const ItemList = defineAsyncComponent(() => import("./ItemList.vue"));
 
 export default {
     name: "AssetContentsLink",

--- a/resources/js/Shared/Components/Assets/AssetsComponent.vue
+++ b/resources/js/Shared/Components/Assets/AssetsComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="relative">
     <!-- Native Inertia v3 infinite scroll over the page-level `assets` scroll prop
          (locations paginated with pageName 'assets'). Replaces the axios/Ziggy
          InfiniteLoadingHelper + useInfinityScrolling loader. -->
@@ -11,7 +11,8 @@
     >
       <div
         id="assets-body"
-        class="space-y-2 sm:space-y-6"
+        class="space-y-2 sm:space-y-6 transition-opacity duration-150"
+        :class="{ 'opacity-40': loading }"
       >
         <LocationComponent
           v-for="location in locations"
@@ -51,6 +52,36 @@
         </div>
       </template>
     </InfiniteScroll>
+
+    <!-- Filter/search in flight: overlay a small "updating" pill above the dimmed list. -->
+    <div
+      v-if="loading"
+      class="pointer-events-none absolute inset-x-0 top-0 flex justify-center pt-6"
+    >
+      <div class="inline-flex items-center gap-x-2 rounded-full bg-white/90 px-4 py-2 shadow-sm ring-1 ring-black/5">
+        <svg
+          class="animate-spin h-5 w-5 text-gray-400"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            class="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            stroke-width="4"
+          />
+          <path
+            class="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+        <span class="text-sm font-medium text-gray-500">updating…</span>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -71,6 +102,11 @@ export default {
             default: 'character'
         },
         compact: {
+            required: false,
+            default: false,
+            type: Boolean
+        },
+        loading: {
             required: false,
             default: false,
             type: Boolean

--- a/resources/js/Shared/Components/Assets/AssetsComponent.vue
+++ b/resources/js/Shared/Components/Assets/AssetsComponent.vue
@@ -6,6 +6,7 @@
     <InfiniteScroll
       data="assets"
       items-element="#assets-body"
+      :buffer="750"
       preserve-url
     >
       <div
@@ -20,6 +21,35 @@
           :compact="compact"
         />
       </div>
+
+      <!-- Shown in whichever trigger is fetching the next/previous page. -->
+      <template #loading>
+        <div class="relative block w-full py-6 text-center">
+          <svg
+            class="animate-spin mx-auto h-8 w-8 text-gray-400"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          <span class="mt-2 block text-sm font-medium text-gray-500">
+            loading more locations…
+          </span>
+        </div>
+      </template>
     </InfiniteScroll>
   </div>
 </template>

--- a/resources/js/Shared/Components/Assets/AssetsComponent.vue
+++ b/resources/js/Shared/Components/Assets/AssetsComponent.vue
@@ -1,38 +1,40 @@
 <template>
   <div>
-    <InfiniteLoadingHelper
-      :key="loadingHelperKey"
-      v-slot="{results}"
-      :params="parameters"
-      route-name="get.character.assets.locations"
+    <!-- Native Inertia v3 infinite scroll over the page-level `assets` scroll prop
+         (locations paginated with pageName 'assets'). Replaces the axios/Ziggy
+         InfiniteLoadingHelper + useInfinityScrolling loader. -->
+    <InfiniteScroll
+      data="assets"
+      items-element="#assets-body"
+      preserve-url
     >
-      <div class="space-y-2 sm:space-y-6">
+      <div
+        id="assets-body"
+        class="space-y-2 sm:space-y-6"
+      >
         <LocationComponent
-          v-for="location in results"
+          v-for="location in locations"
           :key="location.location_id"
           :location="location"
           :context="context"
           :compact="compact"
         />
       </div>
-    </InfiniteLoadingHelper>
+    </InfiniteScroll>
   </div>
 </template>
 
 <script>
 import LocationComponent from "./LocationComponent.vue";
-import InfiniteLoadingHelper from "../../InfiniteLoadingHelper.vue";
-import { ref, watch } from "vue";
+import { InfiniteScroll } from "@inertiajs/vue3";
+
 export default {
     name: "AssetsComponent",
     components: {
-        InfiniteLoadingHelper, LocationComponent,
+        InfiniteScroll,
+        LocationComponent,
     },
     props: {
-        parameters: {
-            type: Object,
-            required: true
-        },
         context: {
             required: false,
             type: String,
@@ -44,25 +46,10 @@ export default {
             type: Boolean
         }
     },
-    setup(props) {
-
-        const locations = ref([])
-        const loadingHelperKey = ref(+new Date() )
-
-        const debounce = _.debounce(() => loadingHelperKey.value++ , 350)
-
-        watch(() => props.parameters, () => debounce())
-
-        return {
-            locations,
-            loadingHelperKey
+    computed: {
+        locations() {
+            return this.$page.props.assets?.data ?? []
         }
-    },
-    data() {
-        return {
-            openModal: false,
-            modal_location_id: 0
-        }
-    },
+    }
 }
 </script>

--- a/resources/js/Shared/Components/Assets/CompactAssetListComponent.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListComponent.vue
@@ -41,13 +41,8 @@ export default {
             return _.uniqBy(this.items, 'item_id')
         },
         hasOwnerPicture() {
-
-            let selectedCharacterIds = _.get(route().params, 'character_ids', null)
-
-            if (_.size(selectedCharacterIds) > 1)
-                return true
-
-            return !selectedCharacterIds && this.$page.props.user.data.characters.length > 1;
+            // Show the owner avatar when the user has more than one character.
+            return this.$page.props.user.data.characters.length > 1
         }
     }
 }

--- a/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
@@ -1,16 +1,15 @@
 <template>
-  <Link
+  <AssetContentsLink
     v-if="hasContent"
     class="justify-self-end"
-    :href="route('character.item', {item_id: entry.item_id, character_id: entry.owner_id})"
-    preserve-state
-    preserve-scroll
+    :character-id="entry.owner_id"
+    :item-id="entry.item_id"
   >
     <CompactAssetListTemplate
       :entry="entry"
       :even="even"
     />
-  </Link>
+  </AssetContentsLink>
   <CompactAssetListTemplate
     v-else
     :entry="entry"
@@ -20,10 +19,10 @@
 
 <script>
 import CompactAssetListTemplate from "./CompactAssetListTemplate.vue";
-import { Link } from '@inertiajs/vue3';
+import AssetContentsLink from "./AssetContentsLink.vue";
 export default {
     name: "CompactAssetListElement",
-    components: {CompactAssetListTemplate, Link},
+    components: { CompactAssetListTemplate, AssetContentsLink },
     props: {
         entry: {
             required: true,
@@ -36,7 +35,7 @@ export default {
     },
     computed: {
         hasContent() {
-            return _.size(this.entry.content) > 0
+            return (this.entry.content_count ?? _.size(this.entry.content)) > 0
         },
     }
 }

--- a/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
@@ -18,11 +18,13 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from "vue";
 import CompactAssetListTemplate from "./CompactAssetListTemplate.vue";
-import AssetContentsLink from "./AssetContentsLink.vue";
+
 export default {
     name: "CompactAssetListElement",
-    components: { CompactAssetListTemplate, AssetContentsLink },
+    // AssetContentsLink is async to break the ItemList ↔ AssetContentsLink import cycle.
+    components: { CompactAssetListTemplate, AssetContentsLink: defineAsyncComponent(() => import("./AssetContentsLink.vue")) },
     props: {
         entry: {
             required: true,

--- a/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
@@ -1,30 +1,16 @@
 <template>
-  <AssetContentsLink
-    v-if="hasContent"
-    class="justify-self-end"
-    :character-id="entry.owner_id"
-    :item-id="entry.item_id"
-  >
-    <CompactAssetListTemplate
-      :entry="entry"
-      :even="even"
-    />
-  </AssetContentsLink>
   <CompactAssetListTemplate
-    v-else
     :entry="entry"
     :even="even"
   />
 </template>
 
 <script>
-import { defineAsyncComponent } from "vue";
 import CompactAssetListTemplate from "./CompactAssetListTemplate.vue";
 
 export default {
     name: "CompactAssetListElement",
-    // AssetContentsLink is async to break the ItemList ↔ AssetContentsLink import cycle.
-    components: { CompactAssetListTemplate, AssetContentsLink: defineAsyncComponent(() => import("./AssetContentsLink.vue")) },
+    components: { CompactAssetListTemplate },
     props: {
         entry: {
             required: true,
@@ -34,11 +20,6 @@ export default {
             required: true,
             type: Number
         }
-    },
-    computed: {
-        hasContent() {
-            return (this.entry.content_count ?? _.size(this.entry.content)) > 0
-        },
     }
 }
 </script>

--- a/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
@@ -1,7 +1,7 @@
 <template>
   <li
     :class="[even ? 'bg-gray-50' : 'bg-white', {'cursor-pointer': hasContent}]"
-    class="grid grid-cols-2 sm:grid-cols-8 sm:gap-x-0 sm:gap-y-1 grid-flow-row justify-items-auto text-sm text-gray-500 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+    class="list-none grid grid-cols-2 sm:grid-cols-8 sm:gap-x-0 sm:gap-y-1 grid-flow-row justify-items-auto text-sm text-gray-500 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
   >
     <div class="px-6 sm:px-3 py-4 sm:py-1 self-center whitespace-normal sm:col-span-1">
       <label class="block text-sm font-medium text-gray-700 sm:hidden">

--- a/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
@@ -64,7 +64,6 @@
 import {prefix} from "metric-prefix";
 import { ChevronRightIcon } from '@heroicons/vue/20/solid'
 import EveImage from "@/Shared/EveImage.vue"
-import {get} from "lodash";
 import {computed} from "vue";
 import {usePage} from "@inertiajs/vue3";
 
@@ -79,7 +78,7 @@ const props = defineProps({
     }
 })
 
-const type_name = get(props.entry, 'type.name', 'missing type information')
+const type_name = _.get(props.entry, 'type.name', 'missing type information')
 const name = props.entry.name ? `${props.entry.name} (${type_name})` : type_name
 const type = {
     ...props.entry.type,
@@ -88,7 +87,7 @@ const type = {
 
 
 const group = computed(() => {
-    let group_name =  get(props.entry, 'type.group.name', 'missing group information')
+    let group_name =  _.get(props.entry, 'type.group.name', 'missing group information')
 
     return props.entry.is_singleton ? group_name : `${group_name} (packaged)`
 })
@@ -97,15 +96,8 @@ const hasContent = computed(() => {
     return _.size(props.entry.content) > 0
 })
 
-const hasOwnerPicture = computed(() => {
-
-    let selectedCharacterIds = get(route().params, 'character_ids', null)
-
-    if (_.size(selectedCharacterIds) > 1)
-        return true
-
-    return !selectedCharacterIds && usePage().props.user.data.characters.length > 1;
-})
+// Show the owner avatar when the user has more than one character.
+const hasOwnerPicture = computed(() => usePage().props.user.data.characters.length > 1)
 
 // Methods
 const getMetricPrefix = function (numeric_value) {

--- a/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
@@ -50,7 +50,7 @@
       <label class="block text-sm font-medium text-gray-700 sm:hidden">
         Volume
       </label>
-      {{ getMetricPrefix(entry.volume) }}
+      <span v-if="entry.volume">{{ getMetricPrefix(entry.volume) }}</span>
     </div>
 
     <div class="px-6 sm:px-3 py-4 sm:py-1 self-center whitespace-normal sm:col-span-2">
@@ -115,6 +115,12 @@ const hasOwnerPicture = computed(() => usePage().props.user.data.characters.leng
 
 // Methods
 const getMetricPrefix = function (numeric_value) {
+    // An asset whose type is unresolved has no volume; metric-prefix/big.js throws
+    // "Invalid number" on null/NaN, which would crash the whole render. Guard defensively
+    // (the template also v-if's on volume).
+    if (numeric_value === null || numeric_value === undefined || isNaN(numeric_value)) {
+        return ''
+    }
 
     return prefix(numeric_value, {precision: 3, unit: 'm³'})
 }

--- a/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
@@ -1,8 +1,14 @@
 <template>
   <li
     :class="[even ? 'bg-gray-50' : 'bg-white', {'cursor-pointer': hasContent}]"
-    class="list-none grid grid-cols-2 sm:grid-cols-8 sm:gap-x-0 sm:gap-y-1 grid-flow-row justify-items-auto text-sm text-gray-500 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+    class="relative list-none grid grid-cols-2 sm:grid-cols-8 sm:gap-x-0 sm:gap-y-1 grid-flow-row justify-items-auto text-sm text-gray-500 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
   >
+    <!-- Whole-row drill-in: stretched-link overlay fills the (relative) row. -->
+    <AssetContentsLink
+      v-if="hasContent"
+      :character-id="entry.owner_id"
+      :item-id="entry.item_id"
+    />
     <div class="px-6 sm:px-3 py-4 sm:py-1 self-center whitespace-normal sm:col-span-1">
       <label class="block text-sm font-medium text-gray-700 sm:hidden">
         Quantity
@@ -29,7 +35,11 @@
           />
         </div>
         <div class="ml-4">
-          <h3 class="text-sm leading-6 font-medium text-gray-900">
+          <!-- Purple name signals the row is expandable (has contents). -->
+          <h3
+            class="text-sm leading-6 font-medium"
+            :class="hasContent ? 'text-purple-600' : 'text-gray-900'"
+          >
             {{ type.name }}
           </h3>
         </div>
@@ -54,7 +64,7 @@
       <span class="sr-only">Expand</span>
       <ChevronRightIcon
         v-if="hasContent"
-        class="text-gray-400 h-5 w-5 justify-self-end"
+        class="text-purple-500 h-5 w-5 justify-self-end"
       />
     </div>
   </li>
@@ -64,8 +74,11 @@
 import {prefix} from "metric-prefix";
 import { ChevronRightIcon } from '@heroicons/vue/20/solid'
 import EveImage from "@/Shared/EveImage.vue"
-import {computed} from "vue";
+import {computed, defineAsyncComponent} from "vue";
 import {usePage} from "@inertiajs/vue3";
+
+// Async to break the ItemList <-> AssetContentsLink import cycle (drilling renders another ItemList).
+const AssetContentsLink = defineAsyncComponent(() => import("./AssetContentsLink.vue"));
 
 const props = defineProps({
     entry: {
@@ -93,7 +106,8 @@ const group = computed(() => {
 })
 
 const hasContent = computed(() => {
-    return _.size(props.entry.content) > 0
+    // Unfiltered list sends content_count; the filtered path sends the loaded content array.
+    return (props.entry.content_count ?? _.size(props.entry.content)) > 0
 })
 
 // Show the owner avatar when the user has more than one character.

--- a/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListTemplate.vue
@@ -35,10 +35,10 @@
           />
         </div>
         <div class="ml-4">
-          <!-- Purple name signals the row is expandable (has contents). -->
+          <!-- Indigo name signals the row is expandable (has contents). -->
           <h3
             class="text-sm leading-6 font-medium"
-            :class="hasContent ? 'text-purple-600' : 'text-gray-900'"
+            :class="hasContent ? 'text-indigo-600' : 'text-gray-900'"
           >
             {{ type.name }}
           </h3>
@@ -64,7 +64,7 @@
       <span class="sr-only">Expand</span>
       <ChevronRightIcon
         v-if="hasContent"
-        class="text-purple-500 h-5 w-5 justify-self-end"
+        class="text-indigo-500 h-5 w-5 justify-self-end"
       />
     </div>
   </li>

--- a/resources/js/Shared/Components/Assets/LocationComponent.vue
+++ b/resources/js/Shared/Components/Assets/LocationComponent.vue
@@ -1,13 +1,22 @@
 <template>
   <WideLists>
     <template #header>
-      <div class="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
+      <div
+        class="bg-white px-4 border-b border-gray-200 sm:px-6"
+        :class="compact ? 'py-2' : 'py-5'"
+      >
         <div class="-ml-4 -mt-4 flex justify-between items-center flex-wrap sm:flex-nowrap">
           <div class="ml-4 mt-4">
-            <h3 class="text-lg leading-6 font-medium text-gray-900">
+            <h3
+              class="leading-6 font-medium text-gray-900"
+              :class="compact ? 'text-sm' : 'text-lg'"
+            >
               {{ location.name ?? 'Unknown Location' }}
             </h3>
-            <p class="mt-1 text-sm text-gray-500">
+            <p
+              class="text-sm text-gray-500"
+              :class="compact ? 'mt-0' : 'mt-1'"
+            >
               {{ `${volume} volume and ${numberOfItems} items` }}
             </p>
           </div>
@@ -29,11 +38,11 @@
       </div>
     </template>
     <template #elements>
-        <ItemList
-            :key="location.assets.length"
-            :items="location.assets"
-            :compact="compact"
-        />
+      <ItemList
+        :key="location.assets.length"
+        :items="location.assets"
+        :compact="compact"
+      />
     </template>
   </WideLists>
   <teleport to="#destination">

--- a/resources/js/Shared/Components/Assets/LocationName.vue
+++ b/resources/js/Shared/Components/Assets/LocationName.vue
@@ -5,6 +5,9 @@
 </template>
 
 <script>
+import { getJson } from "@/Functions/http";
+import { getLocation } from "@/actions/Seatplus/Web/Http/Controllers/Shared/ManualLocationController";
+
 export default {
     name: "LocationName",
     props: {
@@ -27,11 +30,12 @@ export default {
         }
     },
     created() {
-        if(_.isNull(this.location.location))
-            axios.get(route('get.manual_location', this.location.location_id))
-                .then((result) => {
-                        this.result = result.data
+        if (_.isNull(this.location.location)) {
+            getJson(getLocation.url(this.location.location_id))
+                .then((data) => {
+                    this.result = data
                 })
+        }
     }
 }
 </script>

--- a/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
+++ b/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
@@ -58,16 +58,17 @@
     </template>
 
     <template #navigation>
+      <!-- Chevron is purely a visual affordance; the whole row is the click target via the
+           stretched-link overlay below (kept transparent when the row has no contents so the
+           layout stays aligned). -->
+      <ChevronRightIcon
+        class="h-5 w-5"
+        :class="hasContent(asset) ? 'text-gray-400' : 'text-transparent'"
+      />
       <AssetContentsLink
         v-if="hasContent(asset)"
         :character-id="asset.owner_id"
         :item-id="asset.item_id"
-      >
-        <ChevronRightIcon class="h-5 w-5 text-gray-400" />
-      </AssetContentsLink>
-      <ChevronRightIcon
-        v-else
-        class="h-5 w-5 text-transparent"
       />
     </template>
   </WideListElement>

--- a/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
+++ b/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
@@ -39,9 +39,16 @@
     </template>
 
     <template #lower_left>
-      <TagIcon class="shrink-0 mr-1.5 h-5 w-5 text-gray-400" />
+      <TagIcon
+        class="shrink-0 mr-1.5 h-5 w-5"
+        :class="hasContent(asset) ? 'text-indigo-400' : 'text-gray-400'"
+      />
 
-      <span class="truncate">{{ getType(asset).name }}</span>
+      <!-- Indigo type name signals the row is expandable (has contents). -->
+      <span
+        class="truncate"
+        :class="{ 'text-indigo-600': hasContent(asset) }"
+      >{{ getType(asset).name }}</span>
     </template>
 
     <template #upper_right>
@@ -63,7 +70,7 @@
            layout stays aligned). -->
       <ChevronRightIcon
         class="h-5 w-5"
-        :class="hasContent(asset) ? 'text-gray-400' : 'text-transparent'"
+        :class="hasContent(asset) ? 'text-indigo-500' : 'text-transparent'"
       />
       <AssetContentsLink
         v-if="hasContent(asset)"

--- a/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
+++ b/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
@@ -78,9 +78,13 @@
 import WideListElement from "@/Shared/WideListElement.vue";
 import EveImage from "@/Shared/EveImage.vue";
 import { usePage } from '@inertiajs/vue3';
-import AssetContentsLink from "./AssetContentsLink.vue";
 import { prefix } from 'metric-prefix'
-import {computed} from "vue";
+import {computed, defineAsyncComponent} from "vue";
+
+// Lazily resolved to break the ItemList ↔ AssetContentsLink import cycle (drilling a container
+// renders another ItemList). Async on the list-side chevron — not on the modal's ItemList — so
+// modal content still renders instantly at full size.
+const AssetContentsLink = defineAsyncComponent(() => import("./AssetContentsLink.vue"));
 import {TagIcon, ScaleIcon, ChevronRightIcon} from "@heroicons/vue/20/solid";
 
 defineProps({

--- a/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
+++ b/resources/js/Shared/Components/Assets/WideAssetListComponent.vue
@@ -2,7 +2,7 @@
   <WideListElement
     v-for="asset in items"
     :key="asset.item_id"
-    :url="url(asset)"
+    :url="''"
   >
     <template #avatar>
       <span class="inline-block relative">
@@ -12,9 +12,12 @@
           :object="asset.type"
           :size="128"
         />
-          <span v-else class="inline-flex items-center justify-center h-12 w-12 shrink-0 mx-auto rounded-full bg-gray-500">
-              <span class="text-xl font-medium leading-none text-white">N/A</span>
-          </span>
+        <span
+          v-else
+          class="inline-flex items-center justify-center h-12 w-12 shrink-0 mx-auto rounded-full bg-gray-500"
+        >
+          <span class="text-xl font-medium leading-none text-white">N/A</span>
+        </span>
 
         <span
           v-if="asset.quantity > 1"
@@ -55,18 +58,17 @@
     </template>
 
     <template #navigation>
-      <Link
-        v-if="asset.content[0]"
-        :href="asset.url"
-        preserve-state
-        preserve-scroll
+      <AssetContentsLink
+        v-if="hasContent(asset)"
+        :character-id="asset.owner_id"
+        :item-id="asset.item_id"
       >
-          <ChevronRightIcon class="h-5 w-5 text-gray-400" />
-      </Link>
-        <ChevronRightIcon
-          v-else
-          class="h-5 w-5 text-transparent"
-        />
+        <ChevronRightIcon class="h-5 w-5 text-gray-400" />
+      </AssetContentsLink>
+      <ChevronRightIcon
+        v-else
+        class="h-5 w-5 text-transparent"
+      />
     </template>
   </WideListElement>
 </template>
@@ -75,7 +77,8 @@
 
 import WideListElement from "@/Shared/WideListElement.vue";
 import EveImage from "@/Shared/EveImage.vue";
-import {Link, usePage} from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
+import AssetContentsLink from "./AssetContentsLink.vue";
 import { prefix } from 'metric-prefix'
 import {computed} from "vue";
 import {TagIcon, ScaleIcon, ChevronRightIcon} from "@heroicons/vue/20/solid";
@@ -87,29 +90,23 @@ defineProps({
   },
 });
 
-const hasOwnerPicture = computed(() => {
-
-  let selectedCharacterIds = _.get(route().params, 'character_ids', null)
-
-  if (_.size(selectedCharacterIds) > 1)
-    return true
-
-  return !selectedCharacterIds && usePage().props.user.data.characters.length > 1;
-})
+// Show the owner avatar when the user has more than one character (helps attribute assets).
+const hasOwnerPicture = computed(() => usePage().props.user.data.characters.length > 1)
 
 const getMetricPrefix = function (numeric_value) {
     return prefix(numeric_value, {precision: 3, unit: 'm³'})
 }
 
-const url = function (asset) {
-    return asset.content[0] ? route('character.item', {item_id: asset.item_id, character_id: asset.owner_id}) : ''
+// content_count on the (unfiltered) list path; the loaded content array on the filtered path.
+const hasContent = function (asset) {
+    return (asset.content_count ?? _.size(asset.content)) > 0
 }
 
 const getType = function (asset) {
 
   let type = asset.type
 
-  // if type is not set we createa a dummy type
+  // if type is not set we create a dummy type
   if (!type) {
     type = {
       name: 'Unknown',

--- a/resources/js/Shared/Components/EsiMultiselect.vue
+++ b/resources/js/Shared/Components/EsiMultiselect.vue
@@ -5,7 +5,7 @@
       :label="label"
       :placeholder="placeholder"
       :categories="categories"
-      @selected-object="(obj) => selections.push(obj)"
+      @selected-object="(obj) => { if (obj) { selections.push(obj) } }"
     />
     <DismissibleButton
       v-for="selection in selections"

--- a/resources/js/Shared/Components/LocationSlot.vue
+++ b/resources/js/Shared/Components/LocationSlot.vue
@@ -96,6 +96,7 @@ import WideListElement from "../WideListElement.vue";
 import EveImage from "../EveImage.vue"
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import { prefix } from "metric-prefix";
+import { item as itemRoute } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
 
 export default {
     name: "LocationSlot",
@@ -129,7 +130,7 @@ export default {
         },
         url(asset) {
 
-            return _.isEmpty(asset.content) ? '' : route('character.item', {'item_id': asset.item_id, 'character_id': asset.owner.character_id})
+            return _.isEmpty(asset.content) ? '' : itemRoute.url({character_id: asset.owner_id, item_id: asset.item_id})
         },
         hasContent(content) {
             return !_.isEmpty(content)

--- a/resources/js/Shared/EveImage.vue
+++ b/resources/js/Shared/EveImage.vue
@@ -82,6 +82,11 @@ import { getResourceVariants } from "@/actions/Seatplus/Web/Http/Controllers/Sha
                     resource_id: resourceId.value,
                 }))
 
+                // No variants for this resource (endpoint returned null/empty) — keep the default.
+                if (! variants) {
+                    return
+                }
+
                 function getVariant() {
                     if (props.bpo && _.has(_.invert(variants), 'bp'))
                         return 'bp'

--- a/resources/js/Shared/Modals/WithDismissButtonModal.vue
+++ b/resources/js/Shared/Modals/WithDismissButtonModal.vue
@@ -38,7 +38,7 @@
         >
           <div
             :class="{'sm:max-w-lg': width === 'lg', 'sm:max-w-xl': width === 'xl', 'sm:max-w-2xl': width === '2xl', 'sm:max-w-3xl': width === '3xl', 'sm:max-w-4xl': width === '4xl', 'sm:max-w-5xl': width === '5xl' }"
-            class="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full sm:p-6"
+            class="relative inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full sm:p-6"
           >
             <div class="hidden sm:block absolute top-0 right-0 pt-4 pr-4">
               <button

--- a/resources/js/Shared/Modals/WithDismissButtonModal.vue
+++ b/resources/js/Shared/Modals/WithDismissButtonModal.vue
@@ -19,7 +19,7 @@
           leave-from="opacity-100"
           leave-to="opacity-0"
         >
-          <DialogOverlay class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+          <DialogOverlay class="fixed inset-0 bg-gray-500/75 transition-opacity" />
         </TransitionChild>
 
         <!-- This element is to trick the browser into centering the modal contents. -->

--- a/resources/js/Shared/SidebarLayout/RequiredScopesWarning.vue
+++ b/resources/js/Shared/SidebarLayout/RequiredScopesWarning.vue
@@ -49,7 +49,7 @@
               <div class="mt-4 sm:mt-0 sm:ml-6 sm:shrink-0">
                 <span class="inline-flex rounded-md shadow-xs">
                   <a
-                    :href="route('auth.eve.step_up', { character_id: character.character_id, add_scopes: getMissingScopeString(character.missing_scopes)})"
+                    :href="route('auth.eve.step_up', { character_id: character.character_id, add_scopes: getMissingScopeString(character.missing_scopes), redirect: currentUrl })"
                     class="inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md text-gray-700 bg-white hover:text-gray-500 focus:outline-hidden focus:border-blue-300 focus:ring-blue active:text-gray-800 active:bg-gray-50 transition ease-in-out duration-150"
                   >
                     Fix
@@ -90,6 +90,9 @@ const props = defineProps({
 
 const requiredScopes = _.get(props.dispatchTransferObject, 'required_scopes', [])
 const characters = usePage().props.user.data.characters
+
+// Explicit origin for the step-up return url (the callback stores this, validated, as `rurl`).
+const currentUrl = computed(() => usePage().url)
 
 const globalState = useGlobalState()
 const state = globalState.openScopeWarning

--- a/resources/js/Shared/WideListElement.vue
+++ b/resources/js/Shared/WideListElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <li>
+  <li class="list-none">
     <Link
       v-if="url"
       :href="url"
@@ -38,7 +38,7 @@
     </Link>
     <div
       v-else
-      class="block hover:bg-gray-50 focus:outline-hidden focus:bg-gray-50 transition duration-150 ease-in-out"
+      class="relative block hover:bg-gray-50 focus:outline-hidden focus:bg-gray-50 transition duration-150 ease-in-out"
     >
       <div class="flex items-center px-4 py-4 sm:px-6">
         <div class="min-w-0 flex-1 flex items-center">

--- a/routes/Routes/Character/Assets.php
+++ b/routes/Routes/Character/Assets.php
@@ -32,14 +32,15 @@ use Seatplus\Web\Http\Middleware\CheckAuthorizationWithExtendedScope;
 Route::prefix('assets')
     ->controller(AssetsController::class)
     ->group(function () {
+        // index stays ungated (no character_id in the initial request for the permission
+        // middleware to authorise); the scroll-prop data is instead scoped to the authorised
+        // set via getCharacterIds()/the character_ids intersection in the controller.
         Route::get('', 'index')->name('character.assets');
 
         $assetPermission = CheckAuthorizationWithExtendedScope::class.':'.config('eveapi.permissions.'.Asset::class);
 
         Route::middleware($assetPermission)
             ->group(function () {
-                Route::get('locations', 'getLocations')->name('get.character.assets.locations');
                 Route::get('/{character_id}/item/{item_id}', 'item')->name('character.item');
             });
-
     });

--- a/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
+++ b/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
@@ -51,10 +51,6 @@ class GetCharacterAssetLocationAction
         // Prune to matching branches only when an asset-level filter is active; unfiltered loads
         // top-level items only (no content relation) so there is nothing to prune.
         if ($this->isFiltered()) {
-            // The filtered path flat-loads every descendant in one indexed query (root_location_id)
-            // instead of a recursive content.content eager-load. Rebuild the nested tree in PHP
-            // (O(n)) so the existing prune + the frontend render still see `assets` → `content`.
-            $locationCollection->each(fn (Location $location) => $this->nestDescendantAssets($location));
             $locationCollection = $this->filterLocationAssets($locationCollection);
         }
 
@@ -76,37 +72,6 @@ class GetCharacterAssetLocationAction
             ->where('assetable_type', CharacterInfo::class)
             ->tap(new AssetSearchScope($this->validated))
             ->tap(new TypeWatchListScope($this->validated));
-    }
-
-    /**
-     * Rebuild the nested asset tree from the flat descendantAssets relation (keyed on
-     * root_location_id). A child's parent is the asset whose item_id equals the child's
-     * location_id; a top-level item's parent is the location itself. O(n), single pass.
-     */
-    private function nestDescendantAssets(Location $location): void
-    {
-        // The asset-safety location is synthetic (its `assets` are set directly, no descendants).
-        if (! $location->relationLoaded('descendantAssets')) {
-            return;
-        }
-
-        $byParent = $location->descendantAssets->groupBy('location_id');
-
-        // Relations must be Eloquent Collections (filterContent + the resource expect them), so
-        // wrap each parent's children explicitly rather than using the base collection groupBy yields.
-        $childrenOf = fn (int $parentId): Collection => new Collection($byParent->get($parentId)?->all() ?? []);
-
-        $attachContent = function (Asset $asset) use (&$attachContent, $childrenOf): void {
-            $children = $childrenOf($asset->item_id);
-            $children->each($attachContent);
-            $asset->setRelation('content', $children);
-        };
-
-        $topLevel = $childrenOf($location->location_id);
-        $topLevel->each($attachContent);
-
-        $location->setRelation('assets', $topLevel);
-        $location->unsetRelation('descendantAssets');
     }
 
     private function filterAsset(Collection|Asset|null $asset): bool
@@ -199,11 +164,10 @@ class GetCharacterAssetLocationAction
             ->with(['locatable' => ['system']])
             ->when(
                 $this->isFiltered(),
-                // Filtered: flat-load every descendant in one indexed query on root_location_id
-                // (no recursive content.content eager-load, no depth limit). execute() rebuilds the
-                // tree in PHP and prunes it to matching branches.
+                // Filtered: load the nested tree so a matched location can be pruned to only the
+                // top-level items that are, or contain, a match (filterLocationAssets in execute()).
                 fn (Builder $query) => $query->with([
-                    'descendantAssets' => fn (Relation $q) => $assetScope($q)->with('type.group'),
+                    'assets' => fn (Relation $q) => $assetScope($q)->with(self::ASSETRELATIONS),
                 ]),
                 // Unfiltered (the common case): only top-level items + a contents count for the
                 // chevron. No content.content eager-load, no PHP tree recursion.

--- a/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
+++ b/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
@@ -85,15 +85,24 @@ class GetCharacterAssetLocationAction
      */
     private function nestDescendantAssets(Location $location): void
     {
+        // The asset-safety location is synthetic (its `assets` are set directly, no descendants).
+        if (! $location->relationLoaded('descendantAssets')) {
+            return;
+        }
+
         $byParent = $location->descendantAssets->groupBy('location_id');
 
-        $attachContent = function (Asset $asset) use (&$attachContent, $byParent): void {
-            $children = $byParent->get($asset->item_id, collect())->values();
+        // Relations must be Eloquent Collections (filterContent + the resource expect them), so
+        // wrap each parent's children explicitly rather than using the base collection groupBy yields.
+        $childrenOf = fn (int $parentId): Collection => new Collection($byParent->get($parentId)?->all() ?? []);
+
+        $attachContent = function (Asset $asset) use (&$attachContent, $childrenOf): void {
+            $children = $childrenOf($asset->item_id);
             $children->each($attachContent);
             $asset->setRelation('content', $children);
         };
 
-        $topLevel = $byParent->get($location->location_id, collect())->values();
+        $topLevel = $childrenOf($location->location_id);
         $topLevel->each($attachContent);
 
         $location->setRelation('assets', $topLevel);

--- a/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
+++ b/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
@@ -48,16 +48,19 @@ class GetCharacterAssetLocationAction
             }
         }
 
-        $locationCollection = $this->filterLocationAssets($locationCollection);
+        // Prune to matching branches only when an asset-level filter is active; unfiltered loads
+        // top-level items only (no content relation) so there is nothing to prune.
+        if ($this->isFiltered()) {
+            $locationCollection = $this->filterLocationAssets($locationCollection);
+        }
 
         return new LengthAwarePaginator(
             $locationCollection,
             $total,
             $results->perPage(),
             $results->currentPage(),
-            ['path' => request()->url(), 'query' => request()->query()]
+            ['path' => request()->url(), 'query' => request()->query(), 'pageName' => 'assets']
         );
-
     }
 
     private function getAssetQuery(): \Closure
@@ -140,20 +143,27 @@ class GetCharacterAssetLocationAction
     {
         $character_ids = $this->validated['character_ids'];
 
+        $assetScope = fn (Relation $query) => $query
+            ->whereIn('assetable_id', $character_ids)
+            ->where('assetable_type', CharacterInfo::class);
+
         return Location::query()
-            ->with([
-                'assets' => self::ASSETRELATIONS,
-                'locatable' => [
-                    'system',
-                ],
-            ])
-            ->with('assets', fn (Relation $query) => $query->whereIn('assetable_id', $character_ids)->where('assetable_type', CharacterInfo::class))
-            ->where(
-                fn (Builder $query) => $query
-                    ->whereHas('assets', $this->getAssetQuery())
-                    ->orWhereHas('assets.content', $this->getAssetQuery())
-                    ->orWhereHas('assets.content.content', $this->getAssetQuery())
+            ->with(['locatable' => ['system']])
+            ->when(
+                $this->isFiltered(),
+                // Filtered: load the nested tree so a matched location can be pruned to only the
+                // top-level items that are, or contain, a match (filterLocationAssets in execute()).
+                fn (Builder $query) => $query->with([
+                    'assets' => fn (Relation $q) => $assetScope($q)->with(self::ASSETRELATIONS),
+                ]),
+                // Unfiltered (the common case): only top-level items + a contents count for the
+                // chevron. No content.content eager-load, no PHP tree recursion.
+                fn (Builder $query) => $query->with([
+                    'assets' => fn (Relation $q) => $assetScope($q)->with('type.group')->withCount('content'),
+                ]),
             )
+            // Location selection is always flat via root_location_id (matches at any nesting depth).
+            ->whereHas('descendantAssets', $this->getAssetQuery())
             ->when(
                 data_get($this->validated, 'only_unknown_locations'),
                 fn (Builder $query) => $query
@@ -162,7 +172,19 @@ class GetCharacterAssetLocationAction
             )
             ->tap(new LocationWatchListScope($this->validated))
             ->orderBy('location_id')
-            ->paginate();
+            ->paginate(pageName: 'assets');
+    }
+
+    /**
+     * Whether an asset-level filter (search / type / group / category) is active. Region/system are
+     * location-level (LocationWatchListScope) and don't require loading/pruning the asset tree.
+     */
+    private function isFiltered(): bool
+    {
+        return filled(data_get($this->validated, 'search'))
+            || filled(data_get($this->validated, 'types'))
+            || filled(data_get($this->validated, 'groups'))
+            || filled(data_get($this->validated, 'categories'));
     }
 
     public function filterLocationAssets(Collection $locationCollection): Collection

--- a/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
+++ b/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
@@ -51,6 +51,10 @@ class GetCharacterAssetLocationAction
         // Prune to matching branches only when an asset-level filter is active; unfiltered loads
         // top-level items only (no content relation) so there is nothing to prune.
         if ($this->isFiltered()) {
+            // The filtered path flat-loads every descendant in one indexed query (root_location_id)
+            // instead of a recursive content.content eager-load. Rebuild the nested tree in PHP
+            // (O(n)) so the existing prune + the frontend render still see `assets` → `content`.
+            $locationCollection->each(fn (Location $location) => $this->nestDescendantAssets($location));
             $locationCollection = $this->filterLocationAssets($locationCollection);
         }
 
@@ -72,6 +76,28 @@ class GetCharacterAssetLocationAction
             ->where('assetable_type', CharacterInfo::class)
             ->tap(new AssetSearchScope($this->validated))
             ->tap(new TypeWatchListScope($this->validated));
+    }
+
+    /**
+     * Rebuild the nested asset tree from the flat descendantAssets relation (keyed on
+     * root_location_id). A child's parent is the asset whose item_id equals the child's
+     * location_id; a top-level item's parent is the location itself. O(n), single pass.
+     */
+    private function nestDescendantAssets(Location $location): void
+    {
+        $byParent = $location->descendantAssets->groupBy('location_id');
+
+        $attachContent = function (Asset $asset) use (&$attachContent, $byParent): void {
+            $children = $byParent->get($asset->item_id, collect())->values();
+            $children->each($attachContent);
+            $asset->setRelation('content', $children);
+        };
+
+        $topLevel = $byParent->get($location->location_id, collect())->values();
+        $topLevel->each($attachContent);
+
+        $location->setRelation('assets', $topLevel);
+        $location->unsetRelation('descendantAssets');
     }
 
     private function filterAsset(Collection|Asset|null $asset): bool
@@ -164,10 +190,11 @@ class GetCharacterAssetLocationAction
             ->with(['locatable' => ['system']])
             ->when(
                 $this->isFiltered(),
-                // Filtered: load the nested tree so a matched location can be pruned to only the
-                // top-level items that are, or contain, a match (filterLocationAssets in execute()).
+                // Filtered: flat-load every descendant in one indexed query on root_location_id
+                // (no recursive content.content eager-load, no depth limit). execute() rebuilds the
+                // tree in PHP and prunes it to matching branches.
                 fn (Builder $query) => $query->with([
-                    'assets' => fn (Relation $q) => $assetScope($q)->with(self::ASSETRELATIONS),
+                    'descendantAssets' => fn (Relation $q) => $assetScope($q)->with('type.group'),
                 ]),
                 // Unfiltered (the common case): only top-level items + a contents count for the
                 // chevron. No content.content eager-load, no PHP tree recursion.

--- a/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
+++ b/src/Http/Actions/Character/Asset/GetCharacterAssetLocationAction.php
@@ -107,7 +107,20 @@ class GetCharacterAssetLocationAction
 
     private function filterAssetsLogic(Asset $asset): bool
     {
-        return $this->filterAsset($asset) || $this->filterAsset(data_get($asset, 'content')) || $this->filterAsset(data_get($asset, 'content.content'));
+        if ($this->filterAsset($asset)) {
+            return true;
+        }
+
+        // Recurse only into eager-loaded content — strict mode (preventLazyLoading) forbids
+        // touching an unloaded relation, and the previous data_get('content.content') reached
+        // a nesting level deeper than what was eager-loaded, 500ing on a lazy-load violation.
+        // The location itself is already matched via the flat descendantAssets query; this only
+        // prunes the loaded tree to branches that contain a match.
+        if (! $asset->relationLoaded('content')) {
+            return false;
+        }
+
+        return $asset->content->contains(fn (Asset $child): bool => $this->filterAssetsLogic($child));
     }
 
     private function filterContent(Collection $content): Collection

--- a/src/Http/Controllers/Character/AssetsController.php
+++ b/src/Http/Controllers/Character/AssetsController.php
@@ -26,14 +26,15 @@
 
 namespace Seatplus\Web\Http\Controllers\Character;
 
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Assets\Asset as EveApiAsset;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Universe\Location;
 use Seatplus\Web\Http\Actions\Character\Asset\GetCharacterAssetLocationAction;
 use Seatplus\Web\Http\Controllers\Controller;
-use Seatplus\Web\Http\Controllers\Request\GetAssetLocationsRequest;
 use Seatplus\Web\Http\Resources\AssetResource;
 use Seatplus\Web\Http\Resources\LocationRessource;
 use Seatplus\Web\Services\Controller\CreateDispatchTransferObject;
@@ -41,38 +42,52 @@ use Seatplus\Web\Services\Controller\DispatchTransferObject;
 
 class AssetsController extends Controller
 {
-    public function index(): Response
+    public function index(Request $request, GetCharacterAssetLocationAction $action): Response
     {
         $dispatchTransferObject = $this->getDispatchTransferObject();
+        $characterIds = $this->getCharacterIds($dispatchTransferObject, 'assets');
+
+        // Filters + (a subset of) character scope come from the page query. Constrain requested
+        // character_ids to the authorised set; default to all of it.
+        $validated = $request->only(['search', 'systems', 'regions', 'types', 'groups', 'categories', 'only_unknown_locations']);
+        $requested = collect($request->input('character_ids'))->map(fn ($id): int => (int) $id)->filter();
+        $validated['character_ids'] = $requested->isEmpty()
+            ? $characterIds->values()->all()
+            : $characterIds->intersect($requested)->values()->all();
 
         return Inertia::render('Character/Assets', [
             'dispatchTransferObject' => $dispatchTransferObject,
-            'characterIds' => $this->getCharacterIds($dispatchTransferObject, 'assets'),
+            'characterIds' => $characterIds,
+            'assets' => Inertia::scroll(fn () => $action->execute($validated)
+                ->through(fn (Location $location): array => (new LocationRessource($location))->resolve())),
         ]);
     }
 
-    public function getLocations(GetAssetLocationsRequest $request, GetCharacterAssetLocationAction $action): AnonymousResourceCollection
+    public function item(int $character_id, int $item_id, Request $request): Response|JsonResponse
     {
-        $validated = $request->all();
-
-        $lengthAwarePaginator = $action->execute($validated);
-
-        return LocationRessource::collection(
-            $lengthAwarePaginator
-        );
-    }
-
-    public function item(int $character_id, int $item_id): Response
-    {
-        $query = EveApiAsset::with([
-            'location', 'type', 'type.group', 'container',
-            'content' => ['content', 'type', 'type.group', 'assetable'],
-        ])
+        $query = EveApiAsset::query()
             ->where('assetable_id', $character_id)
             ->where('assetable_type', CharacterInfo::class)
             ->where('item_id', $item_id);
 
-        $item = AssetResource::collection($query->get());
+        // Modal drill: the item + ONE level of contents (+ a count for deeper chevrons), as JSON.
+        if ($request->header('X-Modal')) {
+            return response()->json(
+                AssetResource::collection(
+                    (clone $query)
+                        ->with(['type.group', 'content' => fn ($contentQuery) => $contentQuery->with('type.group')->withCount('content')])
+                        ->get()
+                )->resolve()
+            );
+        }
+
+        // Shareable deep link: full ItemDetails page.
+        $item = AssetResource::collection(
+            $query->with([
+                'location', 'type', 'type.group', 'container',
+                'content' => ['content', 'type', 'type.group', 'assetable'],
+            ])->get()
+        );
 
         return Inertia::render('Character/ItemDetails', [
             'item' => $item,

--- a/src/Http/Controllers/Character/AssetsController.php
+++ b/src/Http/Controllers/Character/AssetsController.php
@@ -26,6 +26,7 @@
 
 namespace Seatplus\Web\Http\Controllers\Character;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -50,7 +51,7 @@ class AssetsController extends Controller
         // Filters + (a subset of) character scope come from the page query. Constrain requested
         // character_ids to the authorised set; default to all of it.
         $validated = $request->only(['search', 'systems', 'regions', 'types', 'groups', 'categories', 'only_unknown_locations']);
-        $requested = collect($request->input('character_ids'))->map(fn ($id): int => (int) $id)->filter();
+        $requested = collect($request->input('character_ids'))->map(fn (mixed $id): int => (int) $id)->filter();
         $validated['character_ids'] = $requested->isEmpty()
             ? $characterIds->values()->all()
             : $characterIds->intersect($requested)->values()->all();
@@ -82,7 +83,7 @@ class AssetsController extends Controller
             return response()->json(
                 AssetResource::collection(
                     (clone $query)
-                        ->with(['type.group', 'content' => fn ($contentQuery) => $contentQuery->with('type.group')->withCount('content')])
+                        ->with(['type.group', 'content' => fn (Relation $contentQuery) => $contentQuery->with('type.group')->withCount('content')])
                         ->get()
                 )->resolve()
             );

--- a/src/Http/Controllers/Character/AssetsController.php
+++ b/src/Http/Controllers/Character/AssetsController.php
@@ -58,8 +58,15 @@ class AssetsController extends Controller
         return Inertia::render('Character/Assets', [
             'dispatchTransferObject' => $dispatchTransferObject,
             'characterIds' => $characterIds,
+            // Fully flatten each location (assets → type → group, etc.) to primitive arrays.
+            // A bare ->resolve() only resolves the top level, leaving nested JsonResources as
+            // objects that Inertia then re-wraps/serializes inconsistently; encoding the whole
+            // tree once yields the plain arrays the Vue side expects.
             'assets' => Inertia::scroll(fn () => $action->execute($validated)
-                ->through(fn (Location $location): array => (new LocationRessource($location))->resolve())),
+                ->through(fn (Location $location): array => json_decode(
+                    (string) json_encode((new LocationRessource($location))->resolve()),
+                    true,
+                ))),
         ]);
     }
 

--- a/src/Http/Resources/AssetResource.php
+++ b/src/Http/Resources/AssetResource.php
@@ -56,10 +56,7 @@ class AssetResource extends JsonResource
             'location_flag' => $this->location_flag,
             'is_singleton' => $this->is_singleton,
             'is_blueprint_copy' => $this->is_blueprint_copy,
-            // Resolve nested content to a plain array (not a resource object): Inertia walks the
-            // prop tree and re-wraps any JsonResource it finds in a `data` key, which would break
-            // the array-typed `items`/`content` props the Vue side expects.
-            'content' => $this->whenLoaded('content', fn (): array => AssetResource::collection($this->content)->resolve()),
+            'content' => $this::collection($this->whenLoaded('content')),
             // has-contents signal for the chevron: a count on the unfiltered/list path, the loaded
             // (pruned) tree on the filtered/drill path. The client builds the item URL via Wayfinder.
             'content_count' => $this->whenCounted('content'),

--- a/src/Http/Resources/AssetResource.php
+++ b/src/Http/Resources/AssetResource.php
@@ -56,7 +56,10 @@ class AssetResource extends JsonResource
             'location_flag' => $this->location_flag,
             'is_singleton' => $this->is_singleton,
             'is_blueprint_copy' => $this->is_blueprint_copy,
-            'content' => $this::collection($this->whenLoaded('content')),
+            // Resolve nested content to a plain array (not a resource object): Inertia walks the
+            // prop tree and re-wraps any JsonResource it finds in a `data` key, which would break
+            // the array-typed `items`/`content` props the Vue side expects.
+            'content' => $this->whenLoaded('content', fn (): array => AssetResource::collection($this->content)->resolve()),
             // has-contents signal for the chevron: a count on the unfiltered/list path, the loaded
             // (pruned) tree on the filtered/drill path. The client builds the item URL via Wayfinder.
             'content_count' => $this->whenCounted('content'),

--- a/src/Http/Resources/AssetResource.php
+++ b/src/Http/Resources/AssetResource.php
@@ -57,10 +57,9 @@ class AssetResource extends JsonResource
             'is_singleton' => $this->is_singleton,
             'is_blueprint_copy' => $this->is_blueprint_copy,
             'content' => $this::collection($this->whenLoaded('content')),
-            'url' => route('character.item', [
-                'character_id' => $this->assetable_id,
-                'item_id' => $this->item_id,
-            ]),
+            // has-contents signal for the chevron: a count on the unfiltered/list path, the loaded
+            // (pruned) tree on the filtered/drill path. The client builds the item URL via Wayfinder.
+            'content_count' => $this->whenCounted('content'),
         ];
     }
 }

--- a/src/Http/Resources/LocationRessource.php
+++ b/src/Http/Resources/LocationRessource.php
@@ -27,7 +27,9 @@ class LocationRessource extends JsonResource
             'is_manual_location' => $this->whenLoaded('locatable', function () {
                 return ! ($this->locatable instanceof Station || $this->locatable instanceof Structure);
             }, ! ($this->location_id === 2004)),
-            'assets' => AssetResource::collection($this->whenLoaded('assets')),
+            // Resolve to a plain array (not a resource object): Inertia re-wraps nested JsonResources
+            // in a `data` key, but the Vue side expects `assets` to be a plain array.
+            'assets' => $this->whenLoaded('assets', fn (): array => AssetResource::collection($this->assets)->resolve()),
             'volume' => $this->whenLoaded('assets', fn () => $this->calculateVolume($this->assets)),
         ];
     }

--- a/src/Http/Resources/LocationRessource.php
+++ b/src/Http/Resources/LocationRessource.php
@@ -27,9 +27,7 @@ class LocationRessource extends JsonResource
             'is_manual_location' => $this->whenLoaded('locatable', function () {
                 return ! ($this->locatable instanceof Station || $this->locatable instanceof Structure);
             }, ! ($this->location_id === 2004)),
-            // Resolve to a plain array (not a resource object): Inertia re-wraps nested JsonResources
-            // in a `data` key, but the Vue side expects `assets` to be a plain array.
-            'assets' => $this->whenLoaded('assets', fn (): array => AssetResource::collection($this->assets)->resolve()),
+            'assets' => AssetResource::collection($this->whenLoaded('assets')),
             'volume' => $this->whenLoaded('assets', fn () => $this->calculateVolume($this->assets)),
         ];
     }

--- a/src/Services/Query/AssetSearchScope.php
+++ b/src/Services/Query/AssetSearchScope.php
@@ -35,10 +35,14 @@ class AssetSearchScope
                 ->each(function (string $term) use ($query) {
                     $term = $term.'%';
 
-                    $query->where('name_normalized', 'like', $term)
-                        ->orWhere('type_name_normalized', 'like', $term)
-                        ->orWhere('group_name_normalized', 'like', $term)
-                        ->orWhere('category_name_normalized', 'like', $term);
+                    // ilike: the *_normalized columns preserve the source casing (regexp_replace
+                    // strips only non-alphanumerics, e.g. "SodiaTradealinassIbis"), so a
+                    // case-sensitive `like` would never match a lower-cased search term. This
+                    // mirrors handleAsset(), which lower-cases both sides.
+                    $query->where('name_normalized', 'ilike', $term)
+                        ->orWhere('type_name_normalized', 'ilike', $term)
+                        ->orWhere('group_name_normalized', 'ilike', $term)
+                        ->orWhere('category_name_normalized', 'ilike', $term);
                 });
         });
 

--- a/tests/Browser/CharacterAssetTest.php
+++ b/tests/Browser/CharacterAssetTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seatplus\Eveapi\Models\Assets\Asset;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Universe\Group;
+use Seatplus\Eveapi\Models\Universe\Location;
+use Seatplus\Eveapi\Models\Universe\Station;
+use Seatplus\Eveapi\Models\Universe\Type;
+
+/*
+ * Character assets browser tests — run against the real assembled core app.
+ *
+ * Covers the modernized assets view: the page-level Inertia <InfiniteScroll> over the
+ * `assets` scroll prop (locations paginated with pageName 'assets'), the on-demand contents
+ * modal (X-Modal fetch), and the shareable character.item deep link that renders the full
+ * ItemDetails page on direct visit. Assets nest up to three levels (capital ship → freighter
+ * → container → cargo); every child's location_id is its parent's item_id and every descendant
+ * carries the top location's root_location_id (the flat descendant filter). A user always sees
+ * their OWN characters' assets, so no permission is granted. Provisioning comes from the suite
+ * helper actingAsCharacter() (core tests/Pest.php).
+ */
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('makeCharacterAsset')) {
+    /**
+     * Create one named asset owned by $character at $locationId (rooted at $rootLocationId).
+     * It gets a real published Type backed by a real Group so the ItemDetails page — whose
+     * LocationSlot dereferences asset.type.name / asset.type.group.name without a null-guard —
+     * renders cleanly. Guarded so each Browser file can define it standalone.
+     *
+     * @param  array<string, mixed>  $overrides
+     */
+    function makeCharacterAsset(CharacterInfo $character, int $locationId, int $rootLocationId, array $overrides = []): Asset
+    {
+        $type = Type::factory()->create(['group_id' => Group::factory()->create()->group_id]);
+
+        return Asset::factory()->withName()->create(array_merge([
+            'assetable_id' => $character->character_id,
+            'assetable_type' => CharacterInfo::class,
+            'location_id' => $locationId,
+            'root_location_id' => $rootLocationId,
+            'location_flag' => 'Hangar',
+            'type_id' => $type->type_id,
+        ], $overrides));
+    }
+}
+
+if (! function_exists('makeNestedAssetChain')) {
+    /**
+     * Seed a three-level nesting rooted in a station location:
+     * capital ship → freighter → container → cargo (each child.location_id = parent.item_id).
+     * Returns [location, capital, freighter, container, cargo].
+     *
+     * @return array<string, mixed>
+     */
+    function makeNestedAssetChain(CharacterInfo $character): array
+    {
+        $location = Location::factory()->for(Station::factory(), 'locatable')->create();
+        $root = $location->location_id;
+
+        $capital = makeCharacterAsset($character, $root, $root);
+        $freighter = makeCharacterAsset($character, $capital->item_id, $root, ['location_flag' => 'ShipHangar']);
+        $container = makeCharacterAsset($character, $freighter->item_id, $root, ['location_flag' => 'Cargo']);
+        $cargo = makeCharacterAsset($character, $container->item_id, $root, ['location_flag' => 'Cargo']);
+
+        return compact('location', 'capital', 'freighter', 'container', 'cargo');
+    }
+}
+
+it('merges the next locations page in on scroll', function () {
+    $character = actingAsCharacter();
+
+    // >1 paginator page of locations (15/page) so the `assets` scroll prop has a next page.
+    collect(range(1, 20))->each(function () use ($character) {
+        $location = Location::factory()->for(Station::factory(), 'locatable')->create();
+        makeCharacterAsset($character, $location->location_id, $location->location_id);
+    });
+
+    $rows = '#assets-body > *';
+
+    $page = visit('/character/assets');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Assets');
+
+    // The first page of location cards comes straight from the scroll prop, so it is present
+    // immediately (no async needed to exist).
+    $before = (int) $page->script("document.querySelectorAll('{$rows}').length");
+    expect($before)->toBeGreaterThan(0);
+
+    // The list scrolls inside the layout's <main class="… overflow-y-auto">, not the window.
+    // Re-scroll it to the bottom on every poll (comma expression) so InfiniteScroll's end
+    // trigger fires; passes once the next page has merged in.
+    $page->assertScript("(document.getElementById('assets-body').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
+
+    $page->screenshot(true, 'character-assets-infinite-scroll');
+});
+
+it('drills three levels deep via the shareable item deep link', function () {
+    $character = actingAsCharacter();
+    ['capital' => $capital, 'freighter' => $freighter, 'container' => $container, 'cargo' => $cargo] = makeNestedAssetChain($character);
+
+    $page = visit('/character/assets');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Assets');
+
+    // The top-level capital ship renders in its location list with a contents affordance:
+    // the chevron links to the shareable character.item URL.
+    $page->waitForText($capital->name);
+    $page->assertPresent("a[href*='/item/{$capital->item_id}']");
+
+    // Follow that shareable link down each containment level. The item() page renders one
+    // level of contents, so each parent's ItemDetails shows the next-deeper asset.
+    $level2 = visit(route('character.item', ['character_id' => $character->character_id, 'item_id' => $capital->item_id], false));
+    $level2->assertNoSmoke();
+    $level2->waitForText($freighter->name);
+
+    $level3 = visit(route('character.item', ['character_id' => $character->character_id, 'item_id' => $freighter->item_id], false));
+    $level3->assertNoSmoke();
+    $level3->waitForText($container->name);
+
+    // Three layers of nesting: the container's page shows the cargo inside it.
+    $level4 = visit(route('character.item', ['character_id' => $character->character_id, 'item_id' => $container->item_id], false));
+    $level4->assertNoSmoke();
+    $level4->waitForText($cargo->name);
+
+    $level4->screenshot(true, 'character-assets-deeplink-depth-three');
+});
+
+it('opens a container’s contents in a modal on click', function () {
+    $character = actingAsCharacter();
+    ['capital' => $capital, 'freighter' => $freighter] = makeNestedAssetChain($character);
+
+    $page = visit('/character/assets');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Assets');
+    $page->waitForText($capital->name);
+
+    // Clicking the capital's contents affordance opens the modal and fetches its one level of
+    // contents on demand (X-Modal) — the freighter appears without a full page navigation.
+    $page->click("a[href*='/item/{$capital->item_id}']");
+    $page->waitForText($freighter->name);
+
+    $page->screenshot(true, 'character-assets-contents-modal');
+});
+
+it('surfaces asset safety as its own location', function () {
+    $character = actingAsCharacter();
+
+    // Asset-safety items carry the sentinel location id; the action prepends a synthetic
+    // location for them on page 1 (uncommon in practice, hence a dedicated edge-case check).
+    $safety = makeCharacterAsset($character, Asset::ASSET_SAFETY, Asset::ASSET_SAFETY, ['location_flag' => 'AssetSafety']);
+
+    $page = visit('/character/assets');
+    $page->assertNoSmoke();
+    $page->waitForText('Character Assets');
+    $page->waitForText($safety->name);
+
+    $page->screenshot(true, 'character-assets-asset-safety');
+});

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Testing\Fluent\AssertableJson;
+use Illuminate\Support\Collection;
 use Inertia\Testing\AssertableInertia as Assert;
 use Seatplus\Eveapi\Models\Assets\Asset;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
@@ -9,53 +9,37 @@ use Seatplus\Eveapi\Models\Universe\Group;
 use Seatplus\Eveapi\Models\Universe\Location;
 use Seatplus\Eveapi\Models\Universe\Station;
 use Seatplus\Eveapi\Models\Universe\Type;
+use Seatplus\Web\Http\Actions\Character\Asset\GetCharacterAssetLocationAction;
+
+// Run the location action for the test character with the given filters and return its locations.
+function assetLocations(array $filters = []): Collection
+{
+    $validated = array_merge(['character_ids' => [test()->test_character->character_id]], $filters);
+
+    return collect((new GetCharacterAssetLocationAction)->execute($validated)->items());
+}
 
 test('is protected by authentication', function () {
-    $response = test()->followingRedirects()
-        ->get(route('character.assets'));
-
-    $response->assertInertia(fn (Assert $page) => $page->component('Auth/Login'));
+    test()->followingRedirects()
+        ->get(route('character.assets'))
+        ->assertInertia(fn (Assert $page) => $page->component('Auth/Login'));
 });
 
-test('see component', function () {
-    $response = test()->actingAs(test()->test_user)
-        ->get(route('character.assets'));
-
-    $response->assertInertia(fn (Assert $page) => $page->component('Character/Assets'));
-});
-
-test('requires character_ids parameter', function (string $route) {
-    $response = test()->actingAs(test()->test_user)
-        ->get(route($route, 1));
-
-    $response->assertStatus(403);
-})->with([
-    '/locations' => 'get.character.assets.locations',
-]);
-
-test('load asset', function () {
-    $response = test()->actingAs(test()->test_user)
-        ->get(route('get.character.assets.locations', [
-            'character_ids' => [test()->test_character->character_id],
-        ]));
-
-    $response->assertOk();
-});
-
-it('has asset prop', function () {
-    $character_assets = Asset::factory()->create([
+test('renders the assets page with an assets scroll prop', function () {
+    Asset::factory()->create([
         'assetable_id' => test()->test_character->character_id,
         'assetable_type' => CharacterInfo::class,
     ]);
 
-    $response = test()->actingAs(test()->test_user)
-        ->get(route('character.assets'));
-
-    $response->assertInertia(
-        fn (Assert $page) => $page
-            ->has('dispatchTransferObject')
-            ->has('characterIds')
-    );
+    test()->actingAs(test()->test_user)
+        ->get(route('character.assets'))
+        ->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Character/Assets')
+                ->has('dispatchTransferObject')
+                ->has('characterIds')
+                ->has('assets')
+        );
 });
 
 it('has list affiliated character list route', function () {
@@ -64,111 +48,100 @@ it('has list affiliated character list route', function () {
         'assetable_type' => CharacterInfo::class,
     ]);
 
-    $response = test()->actingAs(test()->test_user)
+    test()->actingAs(test()->test_user)
         ->get(route('get.affiliated.characters', [
             'permission' => 'assets',
             'search' => substr((string) test()->test_character->name, 5),
-        ]));
-    // ->assertOk();
-
-    $response->assertOk();
-});
-
-test('load asset in unknown location', function () {
-
-    // Arrange
-    $unknown_location = Location::factory()->create();
-    $known_location = Location::factory()->for(Station::factory(), 'locatable')->create();
-
-    foreach ([$known_location, $unknown_location] as $location) {
-        Asset::factory()
-            ->create([
-                'assetable_id' => test()->test_character->character_id,
-                'location_id' => $location->location_id,
-                'location_flag' => 'Hangar',
-            ]);
-    }
-
-    // Act
-
-    // 3. call normally
-    $response_all = test()->actingAs(test()->test_user)
-        ->get(route('get.character.assets.locations', [
-            'character_ids' => [test()->test_character->character_id],
         ]))
         ->assertOk();
-
-    // 5. call only unknown locations
-    $response_only_unknown = test()->actingAs(test()->test_user)
-        ->get(route('get.character.assets.locations', [
-            'character_ids' => [test()->test_character->character_id],
-            'only_unknown_locations' => true,
-        ]))
-        ->assertOk();
-
-    // Assert
-    expect($response_all->original)->toHaveCount(2)
-        ->and($response_only_unknown->original)->toHaveCount(1);
-
 });
 
-test('load asset on watchlist', function () {
+test('the action paginates locations and honours only_unknown_locations', function () {
+    $unknown = Location::factory()->create();
+    $known = Location::factory()->for(Station::factory(), 'locatable')->create();
 
-    // Arrange
-    $location = Location::factory()->for(Station::factory(), 'locatable')->create();
-
-    $asset = Asset::factory()
-        ->create([
+    foreach ([$known, $unknown] as $location) {
+        Asset::factory()->create([
             'assetable_id' => test()->test_character->character_id,
             'location_id' => $location->location_id,
+            'root_location_id' => $location->location_id,
             'location_flag' => 'Hangar',
         ]);
+    }
 
-    $content = Asset::factory()
-        ->create([
-            'assetable_id' => test()->test_character->character_id,
-            'location_id' => $asset->item_id,
-        ]);
+    expect(assetLocations())->toHaveCount(2)
+        ->and(assetLocations(['only_unknown_locations' => true]))->toHaveCount(1);
+});
 
-    $content_content = Asset::factory()
-        ->create([
-            'assetable_id' => test()->test_character->character_id,
-            'location_id' => $content->item_id,
-            'type_id' => Type::factory(),
-            'group_id' => Group::factory(),
-            'category_id' => Category::factory(),
-        ]);
+test('the action filters locations by a matching asset at any nesting depth', function () {
+    $location = Location::factory()->for(Station::factory(), 'locatable')->create();
 
-    $propertyMapping = [
+    // capital (depth 1) → freighter (depth 2) → container (depth 3), all rooted in $location.
+    $asset = Asset::factory()->create([
+        'assetable_id' => test()->test_character->character_id,
+        'location_id' => $location->location_id,
+        'root_location_id' => $location->location_id,
+        'location_flag' => 'Hangar',
+    ]);
+    $content = Asset::factory()->create([
+        'assetable_id' => test()->test_character->character_id,
+        'location_id' => $asset->item_id,
+        'root_location_id' => $location->location_id,
+        'group_id' => Group::factory(),
+    ]);
+    $contentContent = Asset::factory()->create([
+        'assetable_id' => test()->test_character->character_id,
+        'location_id' => $content->item_id,
+        'root_location_id' => $location->location_id,
+        'type_id' => Type::factory(),
+        'group_id' => Group::factory(),
+        'category_id' => Category::factory(),
+    ]);
+
+    $filters = [
         'systems' => [$location->locatable->system->system_id],
         'regions' => [$location->locatable->system->region->region_id],
-        'types' => [$asset->type_id],
-        'groups' => [$content->group_id],
-        'categories' => [$content_content->category_id],
+        'types' => [$asset->type_id],                      // matches at depth 1
+        'groups' => [$content->group_id],                  // matches at depth 2
+        'categories' => [$contentContent->category_id],    // matches at depth 3
     ];
 
-    foreach ($propertyMapping as $key => $value) {
-        // Act
-        $response = test()->actingAs(test()->test_user)
-            ->get(route('get.character.assets.locations', [
-                'character_ids' => [test()->test_character->character_id],
-                $key => $value,
-            ]))
-            ->assertOk();
-
-        // Assert
-        expect($response->original)->toHaveCount(1);
-
-        $response->assertJson(
-            fn (AssertableJson $json) => $json
-                ->count('data', 1)
-                ->has(
-                    'data.0',
-                    fn ($json) => $json
-                        ->where('location_id', $location->location_id)
-                        ->etc()
-                )
-                ->etc()
-        );
+    foreach ($filters as $key => $value) {
+        expect(assetLocations([$key => $value]))->toHaveCount(1);
     }
+});
+
+test('item() returns the item plus one level of contents as JSON for the modal', function () {
+    $container = Asset::factory()->create([
+        'assetable_id' => test()->test_character->character_id,
+        'assetable_type' => CharacterInfo::class,
+    ]);
+    $inside = Asset::factory()->create([
+        'assetable_id' => test()->test_character->character_id,
+        'assetable_type' => CharacterInfo::class,
+        'location_id' => $container->item_id,
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->withHeader('X-Modal', 'true')
+        ->getJson(route('character.item', [
+            'character_id' => test()->test_character->character_id,
+            'item_id' => $container->item_id,
+        ]))
+        ->assertOk()
+        ->assertJsonFragment(['item_id' => $inside->item_id]);
+});
+
+test('item() renders the ItemDetails page on a direct (shareable) visit', function () {
+    $container = Asset::factory()->create([
+        'assetable_id' => test()->test_character->character_id,
+        'assetable_type' => CharacterInfo::class,
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->get(route('character.item', [
+            'character_id' => test()->test_character->character_id,
+            'item_id' => $container->item_id,
+        ]))
+        ->assertInertia(fn (Assert $page) => $page->component('Character/ItemDetails')->has('item'));
 });

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -111,6 +111,24 @@ test('the action filters locations by a matching asset at any nesting depth', fu
     }
 });
 
+test('the action text search is case-insensitive', function () {
+    $location = Location::factory()->for(Station::factory(), 'locatable')->create();
+
+    // name_normalized is generated as PascalCase ("SodiaTradealinasIbis"); a lower-cased
+    // search term must still match it (regression: `like` was case-sensitive on Postgres).
+    Asset::factory()->create([
+        'assetable_id' => test()->test_character->character_id,
+        'location_id' => $location->location_id,
+        'root_location_id' => $location->location_id,
+        'location_flag' => 'Hangar',
+        'name' => 'Sodia Tradealinas Ibis',
+    ]);
+
+    expect(assetLocations(['search' => 'sodia']))->toHaveCount(1);
+    expect(assetLocations(['search' => 'SODIA']))->toHaveCount(1);
+    expect(assetLocations(['search' => 'nomatch']))->toHaveCount(0);
+});
+
 test('item() returns the item plus one level of contents as JSON for the modal', function () {
     $container = Asset::factory()->create([
         'assetable_id' => test()->test_character->character_id,


### PR DESCRIPTION
## Character assets: InfiniteScroll + axios/Ziggy removal + nesting perf

Modernizes the character assets view end-to-end, closing roadmap **B1** (native
Inertia infinite scroll) and **B2/B3** (axios + Ziggy removal) for this list, and
cutting the DB pressure the nested asset queries used to cause.

### What changed

**Backend**
- `AssetsController::index` emits a single merged `assets` scroll prop
  (`Inertia::scroll(fn () => …->through(fn (Location) => LocationRessource->resolve()))`)
  across the authorised character set — no more one-request-per-character axios loader.
- `GetCharacterAssetLocationAction` selects locations **flat** via the new
  `root_location_id` (`whereHas('descendantAssets')`) instead of the old
  `assets / assets.content / assets.content.content` `whereHas` chain, so a match at
  any nesting depth is a single indexed lookup. Two eager-load paths preserve today's
  behaviour: the common unfiltered case loads only top-level items + `withCount('content')`;
  the filtered case loads the tree and prunes to matching branches.
- `AssetsController::item` gains an `X-Modal` branch returning the item + one level of
  contents as JSON (for the modal); a direct visit still renders the full `ItemDetails` page.
- `AssetResource` drops the server-rendered `route('character.item')` url in favour of a
  `content_count` signal; the client builds the URL from Wayfinder.

**Frontend**
- `<InfiniteScroll data="assets" items-element="#assets-body">` replaces
  `AssetsComponent` + `InfiniteLoadingHelper` + `useInfinityScrolling`.
- Container drill-down is **both** a click-to-open modal (on-demand `X-Modal` fetch) and a
  shareable `character.item` deep link — the same URL opens a popup on click or the full
  page when shared/opened directly.
- Every Ziggy `route()` in the assets path (`character.assets`, `character.item`,
  `get.manual_location`, `post.manual_location`) converted to Wayfinder `@/actions`;
  `LocationName` axios → `getJson`.

### Tests
- Feature (`AssetTest`): scroll prop shape, `only_unknown_locations`, filtering at any
  nesting depth, `item()` modal JSON + page render. **7 passing.**
- Browser (`CharacterAssetTest`): InfiniteScroll page-merge, three-level deep-link drill
  (capital → freighter → container → cargo), contents modal, asset-safety edge case.

### ⚠️ Merge dependency (eveapi release)
The backend needs the eveapi changes from **seatplus/eveapi#698** (the `root_location_id`
column + backfill migration, `Location::descendantAssets`, `ResolveAssetRootLocations`),
already merged to eveapi `4.x`. This PR's CI (and merge) requires an **eveapi release
containing #698** and a matching bump of the `seatplus/eveapi` constraint here — until then
CI installs the last release (4.1.4), which lacks the `root_location_id` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
