### PR TITLE
fix: guard null (pruned) job batch in getBatchStatus

### DIFF
--- a/src/Http/Controllers/Queue/DispatchJobController.php
+++ b/src/Http/Controllers/Queue/DispatchJobController.php
@@ -208,6 +208,16 @@ class DispatchJobController extends Controller
 
         $batch = Bus::findBatch($batch_id);
 
+        // Laravel prunes finished batches, so a completed (or unknown) batch is no longer found.
+        // Report it terminal instead of dereferencing null — otherwise every poll 500s on
+        // "read property failedJobs on null" and the client keeps polling, flooding the logs.
+        if (is_null($batch)) {
+            return [
+                'state' => 'finished',
+                'batch_id' => $batch_id,
+            ];
+        }
+
         if ($batch->failedJobs > 0 && $batch->progress() < 100) {
             return [
                 'state' => 'failures',


### PR DESCRIPTION
## Problem
Character/dispatch batch-status polling floods the logs with `Attempt to read property "failedJobs" on null` and repeated `job_batches` query dumps.

## Cause
`DispatchJobController::getBatchStatus()` did:
```php
$batch = Bus::findBatch($batch_id);
if ($batch->failedJobs > 0 && …) // ← $batch is null once the batch is pruned
```
Laravel prunes finished batches, so after a dispatch completes `Bus::findBatch()` returns `null`. Every subsequent poll 500s on the null dereference, the client never receives a terminal state, so it keeps polling — flooding the log (the raw SQL is `APP_DEBUG` context for each failed request, not a query logger).

## Fix
Guard the null case and report the batch as `finished` so the client stops polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)