### PR TITLE
feat: resolve EVE image variation server-side (kill the per-image variants roundtrip)

### DIFF
--- a/resources/js/Shared/EveImage.vue
+++ b/resources/js/Shared/EveImage.vue
@@ -1,10 +1,11 @@
 <template>
-  <div ref="eveImageComponent">
+  <div>
     <img
       v-if="isReady"
       :class="tailwind_class"
       :src="imageUrl"
       :alt="object.name"
+      loading="lazy"
     >
     <svg
       v-else
@@ -24,9 +25,7 @@
 </template>
 
 <script>
-import {computed, onMounted, onUnmounted, ref, watch} from "vue";
-import { getJson } from "@/Functions/http";
-import { getResourceVariants } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
+import { computed } from "vue";
 
     export default {
         name: "EveImage",
@@ -55,58 +54,6 @@ import { getResourceVariants } from "@/actions/Seatplus/Web/Http/Controllers/Sha
             }
         },
         setup(props) {
-            const isReady = ref(false)
-            const resourceVariant = ref(null)
-            const eveImageComponent = ref(null)
-
-            const getImageVariant = async () => {
-                // Guard against a non-object (e.g. an unresolved "" entity) so the `in`
-                // checks below never throw.
-                if (!props.object || typeof props.object !== 'object')
-                    return;
-
-                if ('character_id' in props.object)
-                    return resourceVariant.value = 'portrait';
-
-                if ('corporation_id' in props.object || 'alliance_id' in props.object)
-                    return resourceVariant.value = 'logo';
-
-                // No recognizable EVE resource type (e.g. an unresolved/unknown entity, or a
-                // location/station) — bail before requesting variants, which would otherwise
-                // build a URL without a resource_type and throw.
-                if (!resourceType.value || !resourceId.value)
-                    return;
-
-                const variants = await getJson(getResourceVariants.url({
-                    resource_type: resourceType.value,
-                    resource_id: resourceId.value,
-                }))
-
-                // No variants for this resource (endpoint returned null/empty) — keep the default.
-                if (! variants) {
-                    return
-                }
-
-                function getVariant() {
-                    if (props.bpo && _.has(_.invert(variants), 'bp'))
-                        return 'bp'
-
-                    return variants[0]
-                }
-
-                resourceVariant.value = getVariant()
-            }
-
-            const resourceSize = computed(() => {
-
-                function isRetina() {
-                    return (window.devicePixelRatio > 1 ||	(window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches));
-                }
-
-                let size = props.size < 32 ? 32 : props.size
-
-                return isRetina() ? size*2 : size;
-            })
             const resourceId = computed(() => {
                 return _.chain(['type_id', 'character_id', 'corporation_id', 'alliance_id'])
                     .map(resource => _.get(props.object, resource))
@@ -114,6 +61,7 @@ import { getResourceVariants } from "@/actions/Seatplus/Web/Http/Controllers/Sha
                     .head()
                     .value()
             })
+
             const resourceType = computed(() => {
                 let array = {
                     'character_id': 'characters',
@@ -128,36 +76,46 @@ import { getResourceVariants } from "@/actions/Seatplus/Web/Http/Controllers/Sha
                     .head()
                     .value();
             })
+
+            // Resolved synchronously — no per-image HTTP roundtrip. characters/corps/alliances are
+            // deterministic; types carry their variation (render/bp/icon) from the backend
+            // (TypeResource.image_variant, derived from the inventory category), defaulting to icon.
+            const resourceVariant = computed(() => {
+                if (!props.object || typeof props.object !== 'object')
+                    return null
+
+                if ('character_id' in props.object)
+                    return 'portrait'
+
+                if ('corporation_id' in props.object || 'alliance_id' in props.object)
+                    return 'logo'
+
+                if (resourceType.value !== 'types')
+                    return null
+
+                return props.bpo ? 'bp' : (props.object.image_variant ?? 'icon')
+            })
+
+            const resourceSize = computed(() => {
+
+                function isRetina() {
+                    return (window.devicePixelRatio > 1 ||	(window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches));
+                }
+
+                let size = props.size < 32 ? 32 : props.size
+
+                return isRetina() ? size*2 : size;
+            })
+
             const imageUrl = computed(() => {
                 return `https://images.evetech.net/${resourceType.value}/${resourceId.value}/${resourceVariant.value}?size=${resourceSize.value}&tenant=tranquility`
             })
 
-            watch(resourceVariant, () => {
-                if(resourceVariant.value)
-                    isReady.value = true
-            })
-
-            const observer = new IntersectionObserver(function(entries) {
-                if(entries[0].isIntersecting === true) {
-                    if(isReady.value || resourceVariant.value)
-                        return
-
-                    getImageVariant()
-                }
-            }, { threshold: [1] });
-
-            onMounted(() => {
-                observer.observe(eveImageComponent.value);
-            })
-
-            onUnmounted(() => {
-                observer.disconnect()
-            })
+            const isReady = computed(() => Boolean(resourceType.value && resourceId.value && resourceVariant.value))
 
             return {
                 imageUrl,
                 isReady,
-                eveImageComponent
             }
 
         },

--- a/routes/Routes/Shared/Shared.php
+++ b/routes/Routes/Shared/Shared.php
@@ -55,5 +55,4 @@ Route::prefix('esi-search')
         Route::get('token', [HelperController::class, 'token'])->name('autosuggestion.token');
     });
 
-Route::get('/image/variants/{resource_type}/{resource_id}', [HelperController::class, 'getResourceVariants'])->name('get.resource.variants');
 Route::get('/markets/prices', [HelperController::class, 'getMarketsPrices'])->name('get.markets.prices');

--- a/src/Http/Controllers/Shared/HelperController.php
+++ b/src/Http/Controllers/Shared/HelperController.php
@@ -29,9 +29,7 @@ namespace Seatplus\Web\Http\Controllers\Shared;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\Eveapi\Models\RefreshToken;
@@ -143,22 +141,6 @@ class HelperController extends Controller
                     default => Type::class,
                 },
             ]);
-    }
-
-    public function getResourceVariants(string $resource_type, int $resource_id): array|string|null
-    {
-        $url = "https://images.evetech.net/${resource_type}/${resource_id}";
-
-        $image_variants = cache($url);
-
-        if (! $image_variants) {
-            $image_variants = Http::get(sprintf('https://images.evetech.net/%s/%s', $resource_type, $resource_id))->json();
-
-            // Cache::put($url, $image_variants, now()->addDay());
-            cache([$url => $image_variants], now()->addDay());
-        }
-
-        return $image_variants;
     }
 
     public function getMarketsPrices(EsiClient $esi): string

--- a/src/Http/Resources/Universe/GroupResource.php
+++ b/src/Http/Resources/Universe/GroupResource.php
@@ -39,6 +39,7 @@ class GroupResource extends JsonResource
     {
         return [
             'name' => $this->name,
+            'category_id' => $this->category_id,
         ];
     }
 }

--- a/src/Http/Resources/Universe/TypeResource.php
+++ b/src/Http/Resources/Universe/TypeResource.php
@@ -29,6 +29,7 @@ namespace Seatplus\Web\Http\Resources\Universe;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Seatplus\Eveapi\Models\Universe\Type;
+use Seatplus\Web\Services\EveImage\ImageVariant;
 
 /**
  * @mixin Type
@@ -42,6 +43,9 @@ class TypeResource extends JsonResource
             'volume' => $this->volume,
             'name' => $this->name,
             'group' => GroupResource::make($this->whenLoaded('group')),
+            // Image-server variation, derived from the type's inventory category so the client
+            // can build the images.evetech.net URL directly (no per-image variant roundtrip).
+            'image_variant' => ImageVariant::forCategory($this->group?->category_id),
         ];
     }
 }

--- a/src/Services/EveImage/ImageVariant.php
+++ b/src/Services/EveImage/ImageVariant.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\Web\Services\EveImage;
+
+class ImageVariant
+{
+    /** EVE inventory category ids whose types use a non-default image variation. */
+    private const int SHIP = 6;
+
+    private const int BLUEPRINT = 9;
+
+    /**
+     * The EVE Image Server variation for a type, derived from its inventory category.
+     *
+     * Ships get a 3D `render`, blueprints their `bp` art, everything else its `icon`.
+     * `icon` exists for effectively every type, so unknown/unmapped categories are safe.
+     * `bpc` (blueprint copies) and `relic` are per-instance / edge cases handled at the
+     * call site (the `bpo` prop), not here.
+     */
+    public static function forCategory(?int $categoryId): string
+    {
+        return match ($categoryId) {
+            self::SHIP => 'render',
+            self::BLUEPRINT => 'bp',
+            default => 'icon',
+        };
+    }
+}

--- a/tests/Feature/HelperControllerTest.php
+++ b/tests/Feature/HelperControllerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Http;
 use Seatplus\Eveapi\Models\Universe\Category;
 use Seatplus\Eveapi\Models\Universe\Group;
 use Seatplus\Eveapi\Models\Universe\Type;
@@ -31,30 +30,6 @@ test('esi search validates the search term length', function () {
 
     get(route('autosuggestion.search', ['search' => 'J', 'categories' => ['system']]))
         ->assertInvalid(['search' => 'The search field must be at least 3 characters.']);
-});
-
-test('one can get resource variants via http and cache', function () {
-    Http::fake();
-
-    $resource_type = 'types';
-    $resource_id = 587;
-    $url = "https://images.evetech.net/{$resource_type}/{$resource_id}";
-    $expected_response = ['render', 'icon'];
-
-    Http::shouldReceive('get->json')->once()->andReturn(json_encode($expected_response));
-
-    expect(cache($url))->toBeNull();
-
-    // first time miss cache
-    $result = test()->actingAs(test()->test_user)
-        ->get(route('get.resource.variants', [
-            'resource_type' => $resource_type,
-            'resource_id' => $resource_id,
-        ]))
-        ->assertOk()
-        ->assertJson($expected_response);
-
-    expect(cache($url))->not()->toBeNull();
 });
 
 test('one can get cached market prices without hitting esi', function () {

--- a/tests/Unit/Resources/GroupResourceTest.php
+++ b/tests/Unit/Resources/GroupResourceTest.php
@@ -12,3 +12,9 @@ test('correct data is returned in response', function () {
     expect($resource instanceof GroupResource)->toBeTrue();
     expect($resource->name)->toEqual($group->name);
 });
+
+test('exposes the category_id', function () {
+    $group = Event::fakeFor(fn () => Group::factory()->create(['category_id' => 6]));
+
+    expect((new GroupResource($group))->resolve()['category_id'])->toBe(6);
+});

--- a/tests/Unit/Resources/TypeResourceTest.php
+++ b/tests/Unit/Resources/TypeResourceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Event;
+use Seatplus\Eveapi\Models\Universe\Group;
 use Seatplus\Eveapi\Models\Universe\Type;
 use Seatplus\Web\Http\Resources\Universe\TypeResource;
 
@@ -12,3 +13,15 @@ test('correct data is returned in response', function () {
     expect($resource instanceof TypeResource)->toBeTrue();
     expect($resource->name)->toEqual($type->name);
 });
+
+it('derives image_variant from the type inventory category', function (int $categoryId, string $expected) {
+    $group = Event::fakeFor(fn () => Group::factory()->create(['category_id' => $categoryId]));
+    $type = Event::fakeFor(fn () => Type::factory()->create(['group_id' => $group->group_id]));
+    $type->load('group');
+
+    expect((new TypeResource($type))->resolve()['image_variant'])->toBe($expected);
+})->with([
+    'ship' => [6, 'render'],
+    'blueprint' => [9, 'bp'],
+    'other' => [17, 'icon'],
+]);

--- a/tests/Unit/Services/EveImage/ImageVariantTest.php
+++ b/tests/Unit/Services/EveImage/ImageVariantTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Seatplus\Web\Services\EveImage\ImageVariant;
+
+it('maps an inventory category to its EVE Image Server variation', function (?int $categoryId, string $expected) {
+    expect(ImageVariant::forCategory($categoryId))->toBe($expected);
+})->with([
+    'ship (6) → render' => [6, 'render'],
+    'blueprint (9) → bp' => [9, 'bp'],
+    'other category → icon' => [17, 'icon'],
+    'unknown/null → icon' => [null, 'icon'],
+]);


### PR DESCRIPTION
## Problem
`EveImage` fetched `GET /image/variants/{type}/{id}` (`HelperController::getResourceVariants`, proxying `images.evetech.net` + 1-day cache) **per image** just to learn a type's image-server variation (`icon`/`render`/`bp`). On image-heavy pages (assets) that's dozens of browser→app requests for essentially static metadata, and it was fragile — a variant-less/empty response made `response.json()` throw `JSON.parse: unexpected end of data`.

## Insight
Per the EVE Image Server docs, clients may point `<img>` **directly** at `images.evetech.net/{category}/{id}/{variation}?size=&tenant=` ("use it as a CDN, no need to cache locally"). `EveImage` already builds that URL and already resolves characters→`portrait`, corps/alliances→`logo` with no HTTP. The only unknown was the **type** variation — which is deterministic from the type's inventory **category**.

## Change (web-only, no eveapi release)
- **`GroupResource`** exposes `category_id` (data).
- **`Services/EveImage/ImageVariant`** maps category → variation: **Ship (6) → `render`**, **Blueprint (9) → `bp`**, else → `icon` (`icon` exists for ~every type, so unknown categories are safe). First named home for these category IDs (magic numbers elsewhere).
- **`TypeResource`** exposes `image_variant` from the (already eager-loaded) group's `category_id` — no N+1.
- **`EveImage.vue`** resolves the variation **synchronously** (`bpo?'bp':object.image_variant??'icon'` for types); drops the `getResourceVariants` fetch, the `getJson` image call, and the `IntersectionObserver`; uses native `loading="lazy"`.
- Removes the now-dead `getResourceVariants` controller method + `get.resource.variants` route (+ its unused `Http` import).

`bp` vs `bpc` and `relic` stay call-site/edge concerns (the `bpo` prop) — no worse than today, which never reliably picked `bpc` either. Bare `{type_id}` objects with no `image_variant` default to `icon`.

## Tests
`ImageVariant` mapping (ship/blueprint/other/null); `TypeResource` → `render`/`bp`/`icon`; `GroupResource` exposes `category_id`. 10 passing. Pint clean; `EveImage` ESLint clean.

## Notes
- **Stacks on #1549** (branched from the assets line, which carries the `EveImage`/`getJson` state this builds on) — the diff will include #1549's commits until it merges; merge #1549 first, then rebase/merge this. The `getJson` empty-body hardening from #1549 stays regardless.
- `@/actions` are regenerated by `wayfinder:generate` (core CI) — the dropped route disappears there; no source imports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)