### PR TITLE
fix: convert remaining Tailwind v4 opacity utilities to slash syntax

### DIFF
--- a/resources/js/Shared/Components/Autosuggest.vue
+++ b/resources/js/Shared/Components/Autosuggest.vue
@@ -23,7 +23,7 @@
       />
       <ListboxOptions
         static
-        class="max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-hidden sm:text-sm"
+        class="max-h-60 rounded-md py-1 text-base ring-1 ring-black/5 overflow-auto focus:outline-hidden sm:text-sm"
       >
         <ListboxOption
           v-for="option in options"

--- a/resources/js/Shared/Components/EsiAutosuggest.vue
+++ b/resources/js/Shared/Components/EsiAutosuggest.vue
@@ -66,7 +66,7 @@
         />
         <ListboxOptions
           static
-          class="max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-hidden sm:text-sm"
+          class="max-h-60 rounded-md py-1 text-base ring-1 ring-black/5 overflow-auto focus:outline-hidden sm:text-sm"
         >
           <ListboxOption
             v-for="option in options"

--- a/resources/js/Shared/Components/Mails/MobileMailList.vue
+++ b/resources/js/Shared/Components/Mails/MobileMailList.vue
@@ -14,7 +14,7 @@
         v-slot="{open}"
         as="li"
       >
-        <DisclosureButton class="flex w-full py-2 hover:bg-violet-200 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-violet-500 focus-visible:ring-opacity-75">
+        <DisclosureButton class="flex w-full py-2 hover:bg-violet-200 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-violet-500/75">
           <div class="flex w-full space-x-3">
             <EveImage
               :object="{character_id: mail.from}"

--- a/resources/js/Shared/Components/SelectComponent.vue
+++ b/resources/js/Shared/Components/SelectComponent.vue
@@ -32,7 +32,7 @@
         leave-from-class="opacity-100"
         leave-to-class="opacity-0"
       >
-        <ListboxOptions class="absolute z-10 mt-1 w-full bg-white shadow-lg max-h-56 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-hidden sm:text-sm">
+        <ListboxOptions class="absolute z-10 mt-1 w-full bg-white shadow-lg max-h-56 rounded-md py-1 text-base ring-1 ring-black/5 overflow-auto focus:outline-hidden sm:text-sm">
           <ListboxOption
             v-for="option in options"
             :key="option.id"

--- a/resources/js/Shared/Layout/SlideOver.vue
+++ b/resources/js/Shared/Layout/SlideOver.vue
@@ -17,7 +17,7 @@
         >
           <div
             v-if="open"
-            class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+            class="absolute inset-0 bg-gray-500/75 transition-opacity"
             @click="flipStatus()"
           />
         </transition>

--- a/resources/js/Shared/SidebarLayout/DarkSidebar.vue
+++ b/resources/js/Shared/SidebarLayout/DarkSidebar.vue
@@ -22,7 +22,7 @@
           leave-from="opacity-100"
           leave-to="opacity-0"
         >
-          <DialogOverlay class="fixed inset-0 bg-gray-600 bg-opacity-75" />
+          <DialogOverlay class="fixed inset-0 bg-gray-600/75" />
         </TransitionChild>
         <TransitionChild
           as="template"

--- a/resources/js/Shared/Toasts/Toast.vue
+++ b/resources/js/Shared/Toasts/Toast.vue
@@ -28,7 +28,7 @@ const isError = ref(props.toast.appearance === 'error')
 </script>
 
 <template>
-  <div class="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+  <div class="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black/5">
     <div class="p-4">
       <div class="flex items-start">
         <div class="shrink-0">


### PR DESCRIPTION
## Why

Tailwind v4 removed the standalone `*-opacity-*` utilities. Seven components still used them, so on v4 they were **silent no-ops**: modal/slide-over overlays rendered fully opaque (no dimming) and a couple of focus rings sat at full strength.

## What

Converted each to the v4 color/opacity slash syntax (behaviour now matches the original v3 intent):

| Component | Before | After |
|---|---|---|
| `SlideOver.vue` | `bg-gray-500 bg-opacity-75` | `bg-gray-500/75` |
| `DarkSidebar.vue` | `bg-gray-600 bg-opacity-75` | `bg-gray-600/75` |
| `Toast.vue` | `ring-black ring-opacity-5` | `ring-black/5` |
| `Autosuggest.vue` | `ring-black ring-opacity-5` | `ring-black/5` |
| `EsiAutosuggest.vue` | `ring-black ring-opacity-5` | `ring-black/5` |
| `SelectComponent.vue` | `ring-black ring-opacity-5` | `ring-black/5` |
| `MobileMailList.vue` | `ring-violet-500 ring-opacity-75` | `ring-violet-500/75` |

Grep guard: no `*-opacity-*` utilities remain in `resources/js`. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)