### PR TITLE
fix: reliable return redirect after step-up SSO (pass current URL)

### DIFF
--- a/resources/js/Shared/SidebarLayout/RequiredScopesWarning.vue
+++ b/resources/js/Shared/SidebarLayout/RequiredScopesWarning.vue
@@ -49,7 +49,7 @@
               <div class="mt-4 sm:mt-0 sm:ml-6 sm:shrink-0">
                 <span class="inline-flex rounded-md shadow-xs">
                   <a
-                    :href="route('auth.eve.step_up', { character_id: character.character_id, add_scopes: getMissingScopeString(character.missing_scopes)})"
+                    :href="route('auth.eve.step_up', { character_id: character.character_id, add_scopes: getMissingScopeString(character.missing_scopes), redirect: currentUrl })"
                     class="inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md text-gray-700 bg-white hover:text-gray-500 focus:outline-hidden focus:border-blue-300 focus:ring-blue active:text-gray-800 active:bg-gray-50 transition ease-in-out duration-150"
                   >
                     Fix
@@ -90,6 +90,9 @@ const props = defineProps({
 
 const requiredScopes = _.get(props.dispatchTransferObject, 'required_scopes', [])
 const characters = usePage().props.user.data.characters
+
+// Explicit origin for the step-up return url (the callback stores this, validated, as `rurl`).
+const currentUrl = computed(() => usePage().url)
 
 const globalState = useGlobalState()
 const state = globalState.openScopeWarning


### PR DESCRIPTION
## Why

The step-up (scope-widening) flow returned the user to `getPreviousUrl()` — the last **HTTP request** the session saw. On the XHR-heavy Inertia SPA that is usually a *background* fetch (an EVE image, an `InfiniteScroll` page, an id-resolve call), **not** the page the user was actually looking at. So after fixing their scopes, users landed somewhere unexpected.

## What

The `auth.eve.step_up` link in `RequiredScopesWarning.vue` now passes the current Inertia page URL as an explicit `redirect` query param:

```diff
- :href="route('auth.eve.step_up', { character_id, add_scopes })"
+ :href="route('auth.eve.step_up', { character_id, add_scopes, redirect: currentUrl })"
```
```js
const currentUrl = computed(() => usePage().url)
```

The auth callback validates that param (local relative path only, open-redirect-safe) and uses it as the return URL instead of trusting the session's previous URL.

## Pairs with

- **seatplus/auth#417** (auth side: accept + validate the `redirect` param, stop relying on `getPreviousUrl()` for step-up). This web change is safe to merge in any order — an unrecognized query param is simply ignored by the current backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)