### PR TITLE
chore: auto-generate Wayfinder output via vite-plugin-run

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,20 @@ export default defineConfig(({mode}) => {
             }),
             run([
                 {
+                    // Keep the Wayfinder output (@/actions, @/routes) generated and in sync.
+                    // Runs on dev/build startup so a fresh checkout always has it, and re-runs
+                    // when backend routes/controllers change. Avoids the drift where @/actions
+                    // goes missing while components still import from it.
+                    startup: true,
+                    name: 'wayfinder generate',
+                    run: ['php', 'artisan', 'wayfinder:generate'],
+                    pattern: [
+                        'routes/**',
+                        'vendor/seatplus/**/routes/**',
+                        'vendor/seatplus/**/src/Http/Controllers/**',
+                    ],
+                },
+                {
                     startup: false,
                     name: 'copy vendor',
                     run: ['php', 'artisan', 'vendor:publish', '--tag=web', '--force'],


### PR DESCRIPTION
## Why (Phase 0 of the axios+Ziggy removal)

The mass Ziggy→Wayfinder migration will add many `@/routes` / `@/actions` imports. Today Wayfinder output (`resources/js/{actions,routes}`) is **gitignored and generated manually** (`php artisan wayfinder:generate`) — which drifts: on this branch `resources/js/actions` was **missing entirely** while 11 components already imported from `@/actions`, so a fresh checkout's build would fail until someone remembers to regenerate.

## What

Add a `wayfinder:generate` entry to the **existing** `vite-plugin-run` config so the output is always generated and kept in sync:
- `startup: true` — regenerates on `npm run dev` / `build`, so a fresh checkout always has `@/actions` + `@/routes`.
- `pattern` — re-runs when backend routes/controllers change.

Reuses the already-installed `vite-plugin-run` — **no new npm dependency**. This file is published to core via `vendor:publish --tag=web`, so the app build picks it up.

## Verification

- JS syntax checked; the entry mirrors the existing "copy vendor" run block.
- ⚠️ Full behavior (that `npm run dev`/`build` actually regenerates) must be verified on the **host** — this is a backend-only container with no frontend build. `php artisan wayfinder:generate` itself is confirmed working (regenerates 112 actions + routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)