### PR TITLE
refactor: drop axios from character skills + skill queue (fetch via http.js)

### DIFF
--- a/resources/js/Shared/Components/Skills/SkillQueue.vue
+++ b/resources/js/Shared/Components/Skills/SkillQueue.vue
@@ -53,8 +53,9 @@
 </template>
 
 <script>
-import {useLoadCompleteResource} from "@/Functions/useLoadCompleteResource";
-import {computed} from "vue";
+import {computed, onMounted, ref} from "vue";
+import { getJson } from "@/Functions/http";
+import { skillQueue as skillQueueAction } from "@/actions/Seatplus/Web/Http/Controllers/Character/SkillsController";
 import { BookOpenIcon } from '@heroicons/vue/20/solid'
 import Time from "@/Shared/Time.vue";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
@@ -69,9 +70,13 @@ export default {
         }
     },
     setup(props) {
-        const results = useLoadCompleteResource('get.character.skill.queue', { character_id: props.characterId })
+        // The skill queue is a small bounded list — fetch it in one request (axios/Ziggy-free).
+        const rawQueue = ref([])
+        onMounted(async () => {
+            rawQueue.value = await getJson(skillQueueAction.url(props.characterId)) ?? []
+        })
 
-        const queue = computed(() => _.chain(results.results.value)
+        const queue = computed(() => _.chain(rawQueue.value)
             .map((item) => {
                 return {
                     ...item,
@@ -83,7 +88,6 @@ export default {
         )
 
         return {
-            results,
             queue
         }
     }

--- a/resources/js/Shared/Components/Skills/Skills.vue
+++ b/resources/js/Shared/Components/Skills/Skills.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-for="(skills, group) in skills"
+    v-for="(groupSkills, group) in skills"
     :key="group"
   >
     <LeftAligned>
@@ -9,7 +9,7 @@
       </template>
       <template #description>
         <div class="flex justify-between">
-          <span>{{ sumSkillpoints(skills) }} total skillpoints</span>
+          <span>{{ sumSkillpoints(groupSkills) }} total skillpoints</span>
           <div class="flex space-x-1.5">
             <div class="flex">
               <div class="shrink-0 self-center">
@@ -31,7 +31,7 @@
         </div>
       </template>
       <LeftAlignedData
-        v-for="skill in skills"
+        v-for="skill in groupSkills"
         :key="skill.skill_id"
       >
         <template #title>
@@ -60,8 +60,9 @@
 </template>
 
 <script>
-import {useLoadCompleteResource} from "@/Functions/useLoadCompleteResource";
-import {computed} from "vue";
+import {computed, onMounted, ref} from "vue";
+import { getJson } from "@/Functions/http";
+import { skills as skillsAction } from "@/actions/Seatplus/Web/Http/Controllers/Character/SkillsController";
 import LeftAligned from "../../Layout/DataDisplay/LeftAligned.vue";
 import LeftAlignedData from "../../Layout/DataDisplay/LeftAlignedData.vue";
 import {StarIcon} from "@heroicons/vue/20/solid";
@@ -78,9 +79,13 @@ export default {
     },
     setup(props) {
 
-        const results = useLoadCompleteResource('get.character.skills', {character_id: props.characterId});
+        // A character's skills are bounded — fetch them all in one request (axios/Ziggy-free).
+        const rawSkills = ref([])
+        onMounted(async () => {
+            rawSkills.value = await getJson(skillsAction.url(props.characterId)) ?? []
+        })
 
-        const skills = computed(() => _.chain(results.results.value)
+        const skills = computed(() => _.chain(rawSkills.value)
             .map((skill) => {
                 return {
                     ...skill,

--- a/src/Http/Controllers/Character/SkillsController.php
+++ b/src/Http/Controllers/Character/SkillsController.php
@@ -27,7 +27,7 @@
 namespace Seatplus\Web\Http\Controllers\Character;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Skills\Skill;
 use Seatplus\Eveapi\Models\Skills\SkillQueue;
@@ -48,15 +48,17 @@ class SkillsController extends Controller
         ]);
     }
 
-    public function skills(int $character_id): LengthAwarePaginator
+    // A character's skills and skill queue are bounded lists, so return them in full (fetched
+    // client-side via http.js getJson) instead of paginating.
+    public function skills(int $character_id): Collection
     {
         return Skill::query()
             ->with('type.group')
             ->where('character_id', $character_id)
-            ->paginate();
+            ->get();
     }
 
-    public function skillQueue(int $character_id): LengthAwarePaginator
+    public function skillQueue(int $character_id): Collection
     {
         return SkillQueue::query()
             ->with('type.group')
@@ -67,6 +69,6 @@ class SkillsController extends Controller
                     ->orWhereNull('finish_date')
             )
             ->orderBy('queue_position', 'asc')
-            ->paginate();
+            ->get();
     }
 }

--- a/tests/Feature/SkillsIntegrationTest.php
+++ b/tests/Feature/SkillsIntegrationTest.php
@@ -2,6 +2,7 @@
 
 use Inertia\Testing\AssertableInertia as Assert;
 use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Eveapi\Models\Skills\Skill;
 
 beforeEach(function () {
     $permission = Permission::findOrCreate('superuser');
@@ -32,4 +33,16 @@ test('one get skill queue per character', function () {
     $response = test()->actingAs(test()->test_user)
         ->get(route('get.character.skill.queue', test()->test_character->character_id))
         ->assertOk();
+});
+
+test('skills endpoint returns the full skill list unpaginated', function () {
+    // More than one default page (15) to prove the response is not paginated.
+    Skill::factory()->count(20)->create([
+        'character_id' => test()->test_character->character_id,
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->getJson(route('get.character.skills', test()->test_character->character_id))
+        ->assertOk()
+        ->assertJsonCount(20);
 });


### PR DESCRIPTION
Part of removing axios + Ziggy from web. Same fetch-swap lane as #1564 (nested per-character tab lists).

`Skills.vue` and `SkillQueue.vue` (in the recruitment Skills tab) used the axios-based `useLoadCompleteResource` (fetch page 1, then all remaining pages in parallel via `axios.CancelToken`). A character's skills and skill queue are bounded, so this returns them in full and fetches once.

## Changes
- **Backend:** `SkillsController@skills` / `@skillQueue` return `get()` instead of `paginate()`.
- **Frontend:** both components fetch on mount via `getJson(SkillsController.{skills,skillQueue}.url(characterId))` (Wayfinder action) and drop `useLoadCompleteResource`. Also renamed the shadowing `v-for` loop var in `Skills.vue` → `groupSkills` (clears a `vue/no-template-shadow` warning).
- **Test:** `SkillsIntegrationTest` now asserts the skills endpoint returns the full list unpaginated (20 → `assertJsonCount(20)`), alongside the existing 200 checks.

## Verification
- Pint + ESLint clean. Feature test runs in CI/host (couldn't run pest in the isolated worktree — composer-autoload path mismatch).
- Manual: recruitment applicant → Skills tab → skills grouped + skill queue render, fetched via `fetch` (no axios), no console errors.

`useLoadCompleteResource` stays for now (contacts + a couple others still use it); it'll be deleted once its last consumer is migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)