### PR TITLE
refactor: drop axios from character contacts (fetch via http.js) + fix broken request field

### DIFF
--- a/resources/js/Functions/http.js
+++ b/resources/js/Functions/http.js
@@ -50,3 +50,10 @@ export async function getJson(url, headers) {
 export function post(url, body = {}) {
     return request(url, { method: 'POST', body });
 }
+
+export async function postJson(url, body = {}, headers) {
+    const response = await request(url, { method: 'POST', body, headers });
+    const text = await response.text();
+
+    return text.length ? JSON.parse(text) : null;
+}

--- a/resources/js/Pages/Corporation/Recruitment/TabComponent.vue
+++ b/resources/js/Pages/Corporation/Recruitment/TabComponent.vue
@@ -73,7 +73,6 @@
         :key="'character.contact:' + character.character_id"
         :character="character"
         :corporation_id="targetCorporation.corporation_id"
-        :alliance_id="targetCorporation.alliance_id"
       />
     </div>
     <div

--- a/resources/js/Shared/Components/Contacts/CharacterContactsComponent.vue
+++ b/resources/js/Shared/Components/Contacts/CharacterContactsComponent.vue
@@ -40,19 +40,43 @@
         </div>
       </div>
       <ul class="relative z-0 divide-y divide-gray-200">
-        <CompleteLoadingHelper
-          route-name="character.contacts.detail"
-          :params="{character_id: character.character_id}"
-          :form-data="{corporation_id: corporation_id, alliance_id: alliance_id}"
-          @results="(result) => contacts_raw = result"
+        <li
+          v-if="loading"
+          class="flex justify-center py-6"
         >
-          <CharacterContactsRowComponent
-            v-for="(entry, index) in contacts"
-            :key="entry.contact_id"
-            :even="index%2"
-            :entry="entry"
-          />
-        </CompleteLoadingHelper>
+          <svg
+            class="animate-spin h-6 w-6 text-gray-400"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+        </li>
+        <li
+          v-else-if="!contacts.length"
+          class="text-center text-sm text-gray-500 py-6"
+        >
+          no entries
+        </li>
+        <CharacterContactsRowComponent
+          v-for="(entry, index) in contacts"
+          :key="entry.contact_id"
+          :even="index%2"
+          :entry="entry"
+        />
       </ul>
     </div>
   </CardWithHeader>
@@ -62,17 +86,17 @@
 
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
-import CompleteLoadingHelper from "../../Layout/CompleteLoadingHelper.vue";
 import CharacterContactsRowComponent from "./CharacterContactsRowComponent.vue";
-import {computed, ref} from "vue";
+import {computed, onMounted, ref} from "vue";
 import SimpleInlineList from "../../Layout/SimpleInlineList.vue";
+import { postJson } from "@/Functions/http";
+import { getContacts } from "@/actions/Seatplus/Web/Http/Controllers/Character/ContactsController";
 
 export default {
     name: "CharacterContactsComponent",
     components: {
         SimpleInlineList,
         CharacterContactsRowComponent,
-        CompleteLoadingHelper,
         CardWithHeader, EntityBlock
     },
     props: {
@@ -84,14 +108,25 @@ export default {
             required: true,
             type: Number
         },
-        alliance_id: {
-            required: false,
-            type: Number
-        },
     },
-    setup() {
+    setup(props) {
 
         const contacts_raw = ref([])
+        const loading = ref(true)
+
+        // The contacts endpoint is a POST (it takes the target corporation to compute relative
+        // standings) and returns the full, unpaginated list. Fetch it once, axios/Ziggy-free.
+        onMounted(async () => {
+            try {
+                const response = await postJson(getContacts.url(props.character.character_id), {
+                    target_corporation_id: props.corporation_id,
+                })
+                contacts_raw.value = response?.data ?? []
+            } finally {
+                loading.value = false
+            }
+        })
+
         const selected_filter = ref('')
         const options = [
             {id: 'all', title: 'All contacts'},
@@ -138,7 +173,8 @@ export default {
             contacts,
             options,
             selected_filter,
-            contacts_raw
+            contacts_raw,
+            loading,
         }
     }
 }

--- a/src/Http/Controllers/Character/ContactsController.php
+++ b/src/Http/Controllers/Character/ContactsController.php
@@ -82,8 +82,10 @@ class ContactsController extends Controller
         $query = Contact::with(['labels', 'characterAffiliation', 'corporationAffiliation', 'allianceAffiliation', 'factionAffiliation'])
             ->where('contactable_id', $character_id);
 
+        // Contacts are fetched in full client-side (http.js), so return them all rather than
+        // paginating — the standings context above is computed once per request either way.
         return ContactResource::collection(
-            $query->paginate(),
+            $query->get(),
         );
     }
 }

--- a/tests/Feature/ContactTest.php
+++ b/tests/Feature/ContactTest.php
@@ -99,7 +99,7 @@ it('has corporation standing', function (string $contact_type, string $corp_cont
             'target_corporation_id' => test()->test_character->corporation->corporation_id,
         ])
         ->assertJson(
-            fn (AssertableJson $json) => $json->has(3)
+            fn (AssertableJson $json) => $json->has(1)
                 ->has('data', 1)
                 ->has(
                     'data.0',


### PR DESCRIPTION
Part of removing axios + Ziggy from web (fetch-swap lane). **Also fixes a latent bug.**

`CharacterContactsComponent` (recruitment Contacts tab) used the axios-based `useLoadCompleteResource` (POST, load-all-pages) — and sent the **wrong body**: `{corporation_id, alliance_id}`, while `ContactsRequest` requires `target_corporation_id`. So the request **422'd** and the tab was effectively broken. (`ContactTest` already used the correct `target_corporation_id`, which is how the mismatch stayed hidden.) The backend derives the alliance from that corporation itself, so `alliance_id` was never needed.

## Changes
- **http.js:** add `postJson` (POST → parsed JSON) alongside `getJson`/`post`.
- **Backend:** `ContactsController@getContacts` returns `get()` (full, unpaginated). Standings context is computed once per request either way.
- **Frontend:** fetch once on mount via `postJson(getContacts.url(character_id), { target_corporation_id })` — **fixing the field** — with loading + empty states; drops `CompleteLoadingHelper` and the now-dead `alliance_id` prop (+ its `TabComponent` binding). Client-side filter/sort unchanged.
- **Test:** `ContactTest` already posts `target_corporation_id`; updated the response-shape assertion from the paginator (3 keys) to the unpaginated resource collection.

## Verification
- Pint + ESLint clean (one pre-existing `corporation_id` snake_case prop warning remains — app convention).
- Feature test runs in CI/host (worktree pest can't run — composer-autoload path mismatch).
- Manual: recruitment applicant → Contacts tab → contacts load (now actually work — previously 422), filter/sort work, no axios call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)