### PR TITLE
feat: ACL foundation — role-type metadata, resource capability flags, i18n (redesign PR 0)

### DIFF
--- a/resources/lang/de/access_control.php
+++ b/resources/lang/de/access_control.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'group' => 'Gruppe',
+    'groups' => 'Gruppen',
+
+    'join_method' => [
+        'label' => 'Beitrittsart',
+        'automatic' => [
+            'label' => 'Automatisch',
+            'description' => 'Alle Berechtigten werden automatisch hinzugefügt und entfernt. Keine Anfragen, keine manuellen Änderungen.',
+        ],
+        'manual' => [
+            'label' => 'Verwaltet',
+            'description' => 'Moderatoren fügen Mitglieder von Hand hinzu und entfernen sie.',
+        ],
+        'on-request' => [
+            'label' => 'Auf Anfrage',
+            'description' => 'Berechtigte Mitglieder beantragen den Zugang; ein Moderator genehmigt oder lehnt ab.',
+        ],
+        'opt-in' => [
+            'label' => 'Selbstbedienung',
+            'description' => 'Berechtigte Mitglieder treten sofort bei, ohne Genehmigung.',
+        ],
+    ],
+
+    'eligibility' => [
+        'label' => 'Berechtigung',
+        'help' => 'Mitglieder welcher Corporations oder Allianzen dieser Gruppe beitreten können.',
+        'everyone' => 'Jeder kann beitreten',
+    ],
+
+    'applies_to' => [
+        'label' => 'Gilt für',
+        'help' => 'Die Corporations, Allianzen oder Charaktere, für die die Berechtigungen dieser Gruppe gelten.',
+        'mode' => [
+            'only_these' => 'Nur diese',
+            'everyone_except' => 'Alle außer',
+        ],
+        'exclude' => 'Nie (ausschließen)',
+        'exclude_help' => 'Immer ausgeschlossen, auch wenn oben zutreffend.',
+        'everything' => 'Alles',
+    ],
+
+    'status' => [
+        'active' => 'Mitglied',
+        'pending' => 'Ausstehend',
+        'none' => 'Kein Mitglied',
+    ],
+
+    'actions' => [
+        'join' => 'Beitreten',
+        'apply' => 'Beitritt anfragen',
+        'leave' => 'Verlassen',
+        'approve' => 'Genehmigen',
+        'deny' => 'Ablehnen',
+        'add_member' => 'Mitglied hinzufügen',
+        'remove_member' => 'Entfernen',
+        'add_moderator' => 'Moderator hinzufügen',
+        'remove_moderator' => 'Moderator entfernen',
+        'create' => 'Gruppe erstellen',
+        'delete' => 'Gruppe löschen',
+        'configure' => 'Konfigurieren',
+        'manage_members' => 'Mitglieder verwalten',
+    ],
+
+    'sections' => [
+        'membership' => 'Mitgliedschaft',
+        'authorization' => 'Autorisierung',
+        'permissions' => 'Berechtigungen',
+        'members' => 'Mitglieder',
+        'moderators' => 'Moderatoren',
+        'applications' => 'Ausstehende Anträge',
+    ],
+
+    'discover' => [
+        'my_groups' => 'Meine Gruppen',
+        'available' => 'Verfügbar zum Beitritt',
+        'none_available' => 'Keine Gruppen zum Beitritt verfügbar.',
+        'no_groups' => 'Du bist noch in keiner Gruppe.',
+    ],
+];

--- a/resources/lang/en/access_control.php
+++ b/resources/lang/en/access_control.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // The group itself
+    'group' => 'Group',
+    'groups' => 'Groups',
+
+    // Join method (role type) — WHO can be a member and how they get in.
+    'join_method' => [
+        'label' => 'Join method',
+        'automatic' => [
+            'label' => 'Automatic',
+            'description' => 'Everyone eligible is added and removed automatically. No requests, no manual changes.',
+        ],
+        'manual' => [
+            'label' => 'Managed',
+            'description' => 'Moderators add and remove members by hand.',
+        ],
+        'on-request' => [
+            'label' => 'Request to join',
+            'description' => 'Eligible members request access; a moderator approves or denies.',
+        ],
+        'opt-in' => [
+            'label' => 'Self-service',
+            'description' => 'Eligible members join instantly, no approval needed.',
+        ],
+    ],
+
+    // Eligibility (membership criteria) — which corps/alliances' members qualify to join / are auto-added.
+    'eligibility' => [
+        'label' => 'Eligibility',
+        'help' => 'Which corporations or alliances\' members can join this group.',
+        'everyone' => 'Anyone can join',
+    ],
+
+    // Applies to (affiliations) — the entities this group\'s PERMISSIONS operate on. NOT membership.
+    'applies_to' => [
+        'label' => 'Applies to',
+        'help' => 'The corporations, alliances or characters this group\'s permissions apply to.',
+        'mode' => [
+            'only_these' => 'Only these',
+            'everyone_except' => 'Everyone except',
+        ],
+        'exclude' => 'Never (exclude)',
+        'exclude_help' => 'Always excluded, even if matched above.',
+        'everything' => 'Everything',
+    ],
+
+    // Membership status
+    'status' => [
+        'active' => 'Member',
+        'pending' => 'Pending',
+        'none' => 'Not a member',
+    ],
+
+    // Actions
+    'actions' => [
+        'join' => 'Join',
+        'apply' => 'Request to join',
+        'leave' => 'Leave',
+        'approve' => 'Approve',
+        'deny' => 'Deny',
+        'add_member' => 'Add member',
+        'remove_member' => 'Remove',
+        'add_moderator' => 'Add moderator',
+        'remove_moderator' => 'Remove moderator',
+        'create' => 'Create group',
+        'delete' => 'Delete group',
+        'configure' => 'Configure',
+        'manage_members' => 'Manage members',
+    ],
+
+    // Page sections
+    'sections' => [
+        'membership' => 'Membership',
+        'authorization' => 'Authorization',
+        'permissions' => 'Permissions',
+        'members' => 'Members',
+        'moderators' => 'Moderators',
+        'applications' => 'Pending applications',
+    ],
+
+    // Discover
+    'discover' => [
+        'my_groups' => 'My groups',
+        'available' => 'Available to join',
+        'none_available' => 'No groups available to join.',
+        'no_groups' => 'You are not in any groups yet.',
+    ],
+];

--- a/src/Http/Resources/RoleRessource.php
+++ b/src/Http/Resources/RoleRessource.php
@@ -32,6 +32,7 @@ use Seatplus\Auth\Enums\RoleType;
 use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Roles\BaseRoleService;
+use Seatplus\Web\Support\AccessControl\RoleTypeMetadata;
 
 /**
  * @mixin Role
@@ -43,30 +44,46 @@ class RoleRessource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $user = auth()->user();
+        $service = (new BaseRoleService)->for($this->resource);
+        $meta = RoleTypeMetadata::for($this->type);
+
+        $isSuperuser = $user->can('superuser');
+        // Match the route middleware ('administrate access control groups'), not the old
+        // mismatched 'create,update and delete access control group' permission string.
+        $canEdit = $isSuperuser || $user->can('administrate access control groups');
+
+        $myStatus = $this->myStatus($user);          // 'active' | 'pending' | false
+        // canJoin() == meetsCriteria() for on-request/opt-in (eligible to apply/join).
+        $isEligible = $service->canJoin($user);
+
         return [
-            'name' => $this->name,
             'id' => $this->id,
+            'name' => $this->name,
+            'type' => $this->type->value,
+            'type_label' => $meta['label'],
+            'type_description' => $meta['description'],
             'members' => $this->users->count(),
-            'type' => $this->type,
-            'can_edit' => $this->when(auth()->user()->can('create,update and delete access control group'), true),
-            'can_moderate' => $this->when($this->canModerate(), true),
-            'status' => $this->roleMemberships()
-                ->where('entity_type', User::class)
-                ->where('entity_id', auth()->user()->getAuthIdentifier())
-                ->value('status') ?? false,
+            'my_status' => $myStatus,
+            'can_edit' => $canEdit,
+            // Fixed: delegate to the service for ALL moderated types (manual/on-request/opt-in),
+            // not the old hardcoded ON_REQUEST-only check. Automatic roles can't be moderated.
+            'can_moderate' => $isSuperuser || $service->canModerate($user),
+            // Per-user, per-type action affordances (apply = on-request, join = opt-in).
+            'can_apply' => $this->type === RoleType::ON_REQUEST && $myStatus === false && $isEligible,
+            'can_join' => $this->type === RoleType::OPT_IN && $myStatus === false && $isEligible,
+            'can_leave' => $myStatus !== false && $this->type !== RoleType::AUTOMATIC,
         ];
     }
 
-    private function canModerate(): bool
+    /**
+     * The authenticated user's membership status for this role, or false if not a member.
+     */
+    private function myStatus(User $user): string|false
     {
-        if ($this->type !== RoleType::ON_REQUEST) {
-            return false;
-        }
-
-        if (auth()->user()->can('superuser')) {
-            return true;
-        }
-
-        return (new BaseRoleService)->for($this->resource)->canModerate(auth()->user());
+        return $this->roleMemberships()
+            ->where('entity_type', User::class)
+            ->where('entity_id', $user->getAuthIdentifier())
+            ->value('status') ?? false;
     }
 }

--- a/src/Support/AccessControl/RoleTypeMetadata.php
+++ b/src/Support/AccessControl/RoleTypeMetadata.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\Web\Support\AccessControl;
+
+use Seatplus\Auth\Enums\RoleType;
+
+/**
+ * Web-side, presentational metadata for the four role types (the "join methods").
+ *
+ * The backend `RoleType` enum is a bare string enum with no labels; this is the single
+ * source of truth for how each type is described and what it can do, so the UI never has
+ * to re-derive capability rules from ad-hoc booleans. Labels/descriptions come from the
+ * `web::access_control` translations; capability flags are static domain rules.
+ */
+class RoleTypeMetadata
+{
+    /**
+     * @return array{key: string, label: string, description: string, supports_moderators: bool, uses_eligibility: bool, self_service: string, auto_assigned: bool}
+     */
+    public static function for(RoleType $type): array
+    {
+        return [
+            'key' => $type->value,
+            'label' => (string) trans("web::access_control.join_method.{$type->value}.label"),
+            'description' => (string) trans("web::access_control.join_method.{$type->value}.description"),
+            // Automatic roles cannot have moderators; managed/request/self-service can.
+            'supports_moderators' => $type !== RoleType::AUTOMATIC,
+            // Managed roles have no eligibility criteria (members are added by hand); the rest gate on criteria.
+            'uses_eligibility' => $type !== RoleType::MANUAL,
+            // How a member gets in on their own: request an approval, join instantly, or neither.
+            'self_service' => match ($type) {
+                RoleType::ON_REQUEST => 'apply',
+                RoleType::OPT_IN => 'join',
+                default => 'none',
+            },
+            'auto_assigned' => $type === RoleType::AUTOMATIC,
+        ];
+    }
+
+    /**
+     * Metadata for every role type, keyed by enum value — for the join-method picker.
+     *
+     * @return array<int, array{key: string, label: string, description: string, supports_moderators: bool, uses_eligibility: bool, self_service: string, auto_assigned: bool}>
+     */
+    public static function all(): array
+    {
+        return array_map(static fn (RoleType $type): array => self::for($type), RoleType::cases());
+    }
+}

--- a/tests/Feature/AccessControl/RoleResourceTest.php
+++ b/tests/Feature/AccessControl/RoleResourceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Queue;
+use Seatplus\Auth\Enums\RoleType;
+use Seatplus\Auth\Models\AccessControl\RoleMembership;
+use Seatplus\Auth\Models\Permissions\Role;
+use Seatplus\Auth\Models\User;
+use Seatplus\Web\Http\Resources\RoleRessource;
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+function makeRole(RoleType $type = RoleType::MANUAL): Role
+{
+    $role = Role::create(['name' => 'test']);
+    $role->update(['type' => $type]);
+
+    return Role::findById($role->id);
+}
+
+function resolveRole(Role $role): array
+{
+    return (new RoleRessource($role->fresh()))->resolve();
+}
+
+it('exposes the join-method label and description from the metadata helper', function () {
+    $role = makeRole(RoleType::OPT_IN);
+    test()->actingAs(test()->test_user);
+
+    $data = resolveRole($role);
+
+    expect($data['type'])->toBe('opt-in')
+        ->and($data['type_label'])->toBe('Self-service')
+        ->and($data['type_description'])->not->toBeEmpty();
+});
+
+it('reports can_moderate for a moderator of an OPT-IN role (regression: old resource only handled on-request)', function () {
+    $role = makeRole(RoleType::OPT_IN);
+
+    RoleMembership::create([
+        'role_id' => $role->id,
+        'entity_type' => User::class,
+        'entity_id' => test()->test_user->getKey(),
+        'can_moderate' => true,
+        'status' => 'active',
+    ]);
+
+    test()->actingAs(test()->test_user);
+
+    expect(resolveRole($role)['can_moderate'])->toBeTrue();
+});
+
+it('can_edit follows the administrate permission, not the old mismatched string', function () {
+    $role = makeRole();
+    test()->actingAs(test()->test_user);
+
+    expect(resolveRole($role)['can_edit'])->toBeFalse();
+
+    assignPermissionToTestUser('administrate access control groups');
+    test()->test_user->forgetCachedPermissions();
+
+    expect(resolveRole($role)['can_edit'])->toBeTrue();
+});
+
+it('my_status reflects an active membership and enables leave for non-automatic roles', function () {
+    $role = makeRole(RoleType::OPT_IN);
+
+    RoleMembership::create([
+        'role_id' => $role->id,
+        'entity_type' => User::class,
+        'entity_id' => test()->test_user->getKey(),
+        'status' => 'active',
+    ]);
+
+    test()->actingAs(test()->test_user);
+
+    $data = resolveRole($role);
+
+    expect($data['my_status'])->toBe('active')
+        ->and($data['can_leave'])->toBeTrue()
+        ->and($data['can_join'])->toBeFalse()
+        ->and($data['can_apply'])->toBeFalse();
+});
+
+it('an automatic role is never moderatable or leavable', function () {
+    $role = makeRole(RoleType::AUTOMATIC);
+
+    RoleMembership::create([
+        'role_id' => $role->id,
+        'entity_type' => User::class,
+        'entity_id' => test()->test_user->getKey(),
+        'can_moderate' => true,
+        'status' => 'active',
+    ]);
+
+    test()->actingAs(test()->test_user);
+
+    $data = resolveRole($role);
+
+    expect($data['can_moderate'])->toBeFalse()
+        ->and($data['can_leave'])->toBeFalse();
+});


### PR DESCRIPTION
## What
Shared **backend foundation** for the ACL/Role redesign (PR 0 of the staged effort). Web-side only — no `seatplus/auth` change.

- **`RoleTypeMetadata`** (`src/Support/AccessControl/`) — one source of truth for the four "join methods" (automatic / managed / on-request / opt-in): label, description, and capability rules (`supports_moderators`, `uses_eligibility`, `self_service`, `auto_assigned`). Labels/descriptions come from `web::access_control` i18n.
- **`RoleRessource` fix + enrichment**:
  - **Bug fix:** `canModerate()` hardcoded `type !== ON_REQUEST → false`, so moderators of **manual/opt-in** roles never got `can_moderate`. Now delegates to `BaseRoleService` for all moderated types (superuser-aware).
  - Aligns `can_edit` with the permission the routes actually enforce (`administrate access control groups`) instead of the mismatched `create,update and delete access control group`.
  - Adds per-user, per-type flags: `my_status`, `can_apply` (on-request), `can_join` (opt-in), `can_leave`, plus `type_label`/`type_description`.
- **i18n**: `resources/lang/{en,de}/access_control.php` (`web::access_control`) — join methods, "Applies to", eligibility, actions, sections (en/de at parity, auto-discovered by `seatplus:i18n:missing-keys`).

## Why
The role backend (4 types + moderators + apply/approve) is complete, but the frontend never caught up and the resource had the `can_moderate` bug + a permission-string mismatch. This PR lays the shared, tested groundwork the surface PRs build on.

## Scope note
`RoleDetailResource` and the shared Vue primitives (RoleCard, useRoleActions, …) intentionally land in **PR 1**, alongside their first rendered consumer, so they're browser-tested rather than shipped unused.

## Tests
`tests/Feature/AccessControl/RoleResourceTest.php` — 5 cases incl. the `can_moderate` regression for an opt-in moderator, the `can_edit` permission alignment, `my_status`/`can_leave`, and automatic-role never moderatable/leavable. Pint ✓, PHPStan ✓, 100% type coverage ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
