### PR TITLE
feat: ACL redesign PR3 — moderator & member management

### DIFF
--- a/resources/js/Pages/AccessControl/ModerateMembers.vue
+++ b/resources/js/Pages/AccessControl/ModerateMembers.vue
@@ -1,214 +1,80 @@
 <template>
-  <div class="space-y-4">
-    <PageHeader :page-title="pageTitle" :breadcrumbs="breadcrumbs" />
-    <div class="bg-white overflow-hidden shadow-sm rounded-lg">
-      <!--Header-->
-      <div class="border-b border-gray-200 px-4 py-5 sm:px-6">
-        <!-- Content goes here -->
-        <div class="-ml-4 -mt-2 flex items-center justify-between flex-wrap sm:flex-nowrap">
-          <div class="ml-4 mt-2">
-            <h3 class="text-lg leading-6 font-medium text-gray-900">
-              Manage Members {{ role.name }}
-            </h3>
-          </div>
-        </div>
-        <!-- We use less vertical padding on card headers on desktop than on body sections -->
-      </div>
+  <div class="space-y-6">
+    <PageHeader
+      :page-title="role.name"
+      :breadcrumbs="breadcrumbs"
+    >
+      <template #secondary>
+        <RoleTypeBadge
+          :type="role.type"
+          :label="role.type_label"
+        />
+      </template>
+    </PageHeader>
 
-      <!--Content below-->
-      <div class="bg-white shadow-sm overflow-hidden sm:rounded-md">
-        <ul class="divide-y divide-gray-200">
-          <InfiniteLoadingHelper
-            v-slot="{results}"
-            route-name="acl.members"
-            :params="{role_id: role.id}"
-          >
-            <li
-              v-for="member in sortMembers(results)"
-              :key="member.id"
-            >
-              <div class="block hover:bg-gray-50 focus:outline-hidden focus:bg-gray-50 transition duration-150 ease-in-out">
-                <div class="px-4 py-4 sm:px-6">
-                  <div class="flex items-center justify-between">
-                    <div>
-                      <div class="inline-flex items-center space-x-3">
-                        <EveImage
-                          :object="member.main_character"
-                          :size="256"
-                          tailwind_class="h-8 w-8 rounded-full"
-                        />
-                        <div class="text-sm leading-5 font-medium text-indigo-600 truncate">
-                          {{ member.main_character.name }}
-                        </div>
-                        <span :class="[{'bg-emerald-100 text-emerald-800': member.status === 'member', 'bg-blue-100 text-blue-800': member.status === 'waitlist', 'bg-amber-100 text-amber-800': member.status === 'paused'},'px-2 inline-flex text-xs leading-5 font-semibold rounded-full capitalize']">
-                          {{ member.status }}
-                        </span>
-                      </div>
-                      <div
-                        v-if="member.characters.length > 0"
-                        class="truncate"
-                      >
-                        <AvatarGroupTopToBottom
-                          :objects="member.characters"
-                          :size="256"
-                        />
-                      </div>
-                    </div>
+    <!-- Applications — on-request groups only (pending applicants awaiting approval). -->
+    <RoleApplicationsSection
+      v-if="hasApplications"
+      :role-id="role.id"
+      :applicants="applicants"
+    />
 
-                    <div class="ml-2 shrink-0 flex">
-                      <span
-                        v-if="member.status === 'waitlist'"
-                        class="relative z-0 inline-flex shadow-xs rounded-md"
-                      >
-                        <button
-                          type="button"
-                          class="relative inline-flex items-center px-4 py-2 rounded-l-md border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700 hover:text-gray-500 focus:z-10 focus:outline-hidden focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150"
-                          @click="approve(member)"
-                        >
-                          <svg
-                            class="-ml-1 mr-2 h-5 w-5 text-gray-400"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>
-                          Approve
-                        </button>
-                        <button
-                          type="button"
-                          class="-ml-px relative inline-flex items-center px-4 py-2 rounded-r-md border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700 hover:text-gray-500 focus:z-10 focus:outline-hidden focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150"
-                          @click="removeMember(member)"
-                        >
-                          <svg
-                            class="-ml-1 mr-2 h-5 w-5 text-gray-400"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>
-                          Deny
-                        </button>
-                      </span>
-                      <span
-                        v-if="member.status === 'member'"
-                        class="inline-flex rounded-md shadow-xs"
-                      >
-                        <button
-                          type="button"
-                          class="inline-flex items-center px-3 py-2 border border-gray-300t text-sm leading-4 font-medium rounded-md bg-white hover:text-gray-500 focus:outline-hidden focus:border-blue-700 focus:ring-blue active:text-gray-700 active:bg-gray-100 transition ease-in-out duration-150"
-                          @click="removeMember(member)"
-                        >
-                          <svg
-                            class="-ml-1 mr-2 h-5 w-5 text-gray-400"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>
-                          Kick member
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </li>
-          </InfiniteLoadingHelper>
-        </ul>
-      </div>
-    </div>
+    <!-- Members — moderators/admins add and kick. -->
+    <RoleMembersSection
+      :role-id="role.id"
+      :members="members"
+    />
+
+    <!-- Moderators — admins only; hidden for automatic (unsupported). -->
+    <RoleModeratorsSection
+      v-if="role.capabilities.supports_moderators"
+      :role-id="role.id"
+      :moderators="moderators"
+      :can-manage="canManageModerators"
+    />
   </div>
 </template>
 
-<script>
-    import EveImage from "@/Shared/EveImage.vue"
-    import AvatarGroupTopToBottom from "@/Shared/AvatarGroupTopToBottom.vue"
-    import PageHeader from "@/Shared/Layout/PageHeader.vue";
-    import InfiniteLoadingHelper from "@/Shared/InfiniteLoadingHelper.vue";
-    import {router} from "@inertiajs/vue3";
-    export default {
-        name: "ModerateMembers",
-        components: {
-            InfiniteLoadingHelper,
-            PageHeader,
-            AvatarGroupTopToBottom, EveImage
-        },
-        props: {
-            role: {
-                required: true,
-                type: Object
-            }
-        },
-        data()  {
-            return {
-                pageTitle: 'Manage Members',
-                breadcrumbs: [
-                    {
-                        name: 'Control Group',
-                        route: route('acl.groups')
-                    }
-                ]
-            }
-        },
-        methods: {
-            approve(member) {
+<script setup>
+import { computed } from "vue";
+import PageHeader from "@/Shared/Layout/PageHeader.vue";
+import RoleTypeBadge from "@/Shared/Components/AccessControl/RoleTypeBadge.vue";
+import RoleApplicationsSection from "@/Shared/Components/AccessControl/RoleApplicationsSection.vue";
+import RoleMembersSection from "@/Shared/Components/AccessControl/RoleMembersSection.vue";
+import RoleModeratorsSection from "@/Shared/Components/AccessControl/RoleModeratorsSection.vue";
+import { useTranslations } from "@/composables/useTranslations";
+import ShowControlGroupsController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ShowControlGroupsController";
 
-                let data = {
-                    user_id: member.id,
-                    role_id: this.role.id
-                };
+const props = defineProps({
+    role: {
+        type: Object,
+        required: true,
+    },
+    members: {
+        type: Array,
+        default: () => [],
+    },
+    applicants: {
+        type: Array,
+        default: () => [],
+    },
+    moderators: {
+        type: Array,
+        default: () => [],
+    },
+    canManageModerators: {
+        type: Boolean,
+        default: false,
+    },
+});
 
-                router.post(route('acl.join'), data, {
-                    replace: false,
-                    preserveState: false,
-                    preserveScroll: false,
-                    only: [],
-                })
-            },
-            removeMember(member) {
+const { trans } = useTranslations();
 
-                router.delete(route('acl.leave', { role_id: this.role.id, user_id: member.id}), {
-                    replace: false,
-                    preserveState: false,
-                    preserveScroll: false,
-                    only: [],
-                })
-            },
-            sortMembers(members) {
+// Applications only exist for the request-to-join method.
+const hasApplications = computed(() => props.role.capabilities.self_service === "apply");
 
-                let cleanMembers = _.map(members, function (member) {
-                    member.characters = _.reject(member.characters, (character) => character.character_id === member.main_character.character_id)
-                    return member
-                })
-
-                let sortedMembers = []
-
-                _.each(['waitlist', 'paused', 'member'], function (type) {
-
-                    let filteredMembers = _.filter(cleanMembers, (member) => member.status === type)
-
-                    _.each(filteredMembers, (filteredMember) => sortedMembers.push(filteredMember))
-                })
-
-                return sortedMembers
-
-            }
-        }
-    }
+const breadcrumbs = computed(() => [
+    { name: trans("web::access_control.groups"), route: ShowControlGroupsController.url() },
+    { name: props.role.name, route: "" },
+]);
 </script>
-
-<style scoped>
-
-</style>

--- a/resources/js/Pages/AccessControl/RoleDetail.vue
+++ b/resources/js/Pages/AccessControl/RoleDetail.vue
@@ -5,10 +5,18 @@
       :breadcrumbs="breadcrumbs"
     >
       <template
-        v-if="can_edit"
+        v-if="can_edit || role.can_moderate"
         #primary
       >
         <Link
+          v-if="role.can_moderate || can_edit"
+          :href="manageUrl"
+          class="rounded-md px-3 py-2 text-sm font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50"
+        >
+          {{ trans('web::access_control.actions.manage_members') }}
+        </Link>
+        <Link
+          v-if="can_edit"
           :href="configureUrl"
           class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
         >
@@ -27,6 +35,7 @@ import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import RoleOverviewSection from "@/Shared/Components/AccessControl/RoleOverviewSection.vue";
 import { useTranslations } from "@/composables/useTranslations";
 import ShowControlGroupsController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ShowControlGroupsController";
+import ManageMembersController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ManageMembersController";
 import { index as configureRoute } from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ManageControlGroupMembersController";
 
 const props = defineProps({
@@ -49,4 +58,5 @@ const breadcrumbs = computed(() => [
 ]);
 
 const configureUrl = computed(() => configureRoute.url({ role_id: props.role.id }));
+const manageUrl = computed(() => ManageMembersController.url({ role_id: props.role.id }));
 </script>

--- a/resources/js/Shared/Components/AccessControl/EntityChip.vue
+++ b/resources/js/Shared/Components/AccessControl/EntityChip.vue
@@ -8,13 +8,15 @@
       :size="32"
       tailwind_class="h-4 w-4 rounded-full"
     />
-    {{ entity.name ?? entity.id }}
+    {{ label }}
   </span>
 </template>
 
 <script setup>
 import EveImage from "@/Shared/EveImage.vue";
-import { computed } from "vue";
+import { computed, ref, watchEffect } from "vue";
+import { getJson } from "@/Functions/http";
+import { getEntityFromId } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
 
 const props = defineProps({
     // { id, name, category | entity_type }
@@ -33,4 +35,20 @@ const imageObject = computed(() => {
 
     return { ...props.entity, [`${category}_id`]: props.entity.id };
 });
+
+// Affiliations can reference an entity the app has never persisted (e.g. a character/corp added by
+// id via ESI search), so the resource carries no name. Resolve it lazily by id through the cached
+// resolve.id endpoint — the portrait already renders from the id alone.
+const resolvedName = ref(null);
+
+watchEffect(async () => {
+    if (props.entity?.name || ! props.entity?.id) {
+        return;
+    }
+
+    const data = await getJson(getEntityFromId.url(props.entity.id));
+    resolvedName.value = data?.name ?? null;
+});
+
+const label = computed(() => props.entity?.name ?? resolvedName.value ?? props.entity?.id);
 </script>

--- a/resources/js/Shared/Components/AccessControl/EntitySummary.vue
+++ b/resources/js/Shared/Components/AccessControl/EntitySummary.vue
@@ -12,13 +12,12 @@
 
     <div class="mt-3 flex flex-wrap gap-2">
       <template v-if="entities.length">
-        <span
+        <EntityChip
           v-for="entity in entities"
           :key="`${entity.entity_type}-${entity.id}`"
-          class="inline-flex items-center rounded-md bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700"
-        >
-          {{ entity.name ?? entity.id }}
-        </span>
+          :entity="entity"
+          chip-class="bg-indigo-50 text-indigo-700"
+        />
       </template>
       <span
         v-else
@@ -34,18 +33,18 @@
       class="mt-3 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-3"
     >
       <span class="text-xs font-medium text-gray-500">{{ excludedLabel }}</span>
-      <span
+      <EntityChip
         v-for="entity in excluded"
         :key="`ex-${entity.entity_type}-${entity.id}`"
-        class="inline-flex items-center rounded-md bg-rose-50 px-2 py-1 text-xs font-medium text-rose-700"
-      >
-        {{ entity.name ?? entity.id }}
-      </span>
+        :entity="entity"
+        chip-class="bg-rose-50 text-rose-700"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
+import EntityChip from "./EntityChip.vue";
 import { useTranslations } from "@/composables/useTranslations";
 
 defineProps({

--- a/resources/js/Shared/Components/AccessControl/MemberRow.vue
+++ b/resources/js/Shared/Components/AccessControl/MemberRow.vue
@@ -1,0 +1,39 @@
+<template>
+  <li class="flex items-center justify-between gap-3 py-3">
+    <div class="flex min-w-0 items-center gap-3">
+      <EveImage
+        :object="member.character"
+        :size="64"
+        tailwind_class="h-8 w-8 rounded-full"
+      />
+      <span class="truncate text-sm font-medium text-gray-900">
+        {{ member.character.name ?? '—' }}
+      </span>
+      <span
+        v-if="badge"
+        class="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+      >
+        {{ badge }}
+      </span>
+    </div>
+    <div class="flex shrink-0 items-center gap-2">
+      <slot />
+    </div>
+  </li>
+</template>
+
+<script setup>
+import EveImage from "@/Shared/EveImage.vue";
+
+defineProps({
+    // { user_id, status, can_moderate, character: { character_id, name } }
+    member: {
+        type: Object,
+        required: true,
+    },
+    badge: {
+        type: String,
+        default: null,
+    },
+});
+</script>

--- a/resources/js/Shared/Components/AccessControl/MemberRow.vue
+++ b/resources/js/Shared/Components/AccessControl/MemberRow.vue
@@ -5,21 +5,31 @@
         v-if="member.character.character_id"
         :object="member.character"
         :size="64"
-        tailwind_class="h-8 w-8 rounded-full"
+        tailwind_class="h-8 w-8 shrink-0 rounded-full"
       />
       <span
         v-else
         class="h-8 w-8 shrink-0 rounded-full bg-gray-200"
       />
-      <span class="truncate text-sm font-medium text-gray-900">
-        {{ member.character.name ?? '—' }}
-      </span>
-      <span
-        v-if="badge"
-        class="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
-      >
-        {{ badge }}
-      </span>
+      <div class="min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="truncate text-sm font-medium text-gray-900">
+            {{ member.character.name ?? '—' }}
+          </span>
+          <span
+            v-if="badge"
+            class="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+          >
+            {{ badge }}
+          </span>
+        </div>
+        <div
+          v-if="altNames"
+          class="truncate text-xs text-gray-400"
+        >
+          {{ altNames }}
+        </div>
+      </div>
     </div>
     <div class="flex shrink-0 items-center gap-2">
       <slot />
@@ -28,10 +38,11 @@
 </template>
 
 <script setup>
+import { computed } from "vue";
 import EveImage from "@/Shared/EveImage.vue";
 
-defineProps({
-    // { user_id, status, can_moderate, character: { character_id, name } }
+const props = defineProps({
+    // { user_id, status, can_moderate, character: { character_id, name }, characters: [{ character_id, name }] }
     member: {
         type: Object,
         required: true,
@@ -41,4 +52,11 @@ defineProps({
         default: null,
     },
 });
+
+// The user's other characters (everything except the main), shown as subtext — same as the picker.
+const altNames = computed(() => (props.member.characters ?? [])
+    .filter((character) => character.character_id !== props.member.character.character_id)
+    .map((character) => character.name)
+    .filter(Boolean)
+    .join(", "));
 </script>

--- a/resources/js/Shared/Components/AccessControl/MemberRow.vue
+++ b/resources/js/Shared/Components/AccessControl/MemberRow.vue
@@ -2,9 +2,14 @@
   <li class="flex items-center justify-between gap-3 py-3">
     <div class="flex min-w-0 items-center gap-3">
       <EveImage
+        v-if="member.character.character_id"
         :object="member.character"
         :size="64"
         tailwind_class="h-8 w-8 rounded-full"
+      />
+      <span
+        v-else
+        class="h-8 w-8 shrink-0 rounded-full bg-gray-200"
       />
       <span class="truncate text-sm font-medium text-gray-900">
         {{ member.character.name ?? '—' }}

--- a/resources/js/Shared/Components/AccessControl/RoleApplicationsSection.vue
+++ b/resources/js/Shared/Components/AccessControl/RoleApplicationsSection.vue
@@ -1,0 +1,60 @@
+<template>
+  <section class="rounded-lg bg-white p-6 shadow-sm ring-1 ring-black/5">
+    <h3 class="text-sm font-semibold text-gray-900">
+      {{ trans('web::access_control.sections.applications') }}
+    </h3>
+
+    <ul
+      v-if="applicants.length"
+      class="mt-2 divide-y divide-gray-100"
+    >
+      <MemberRow
+        v-for="applicant in applicants"
+        :key="applicant.user_id"
+        :member="applicant"
+        :badge="trans('web::access_control.status.pending')"
+      >
+        <button
+          type="button"
+          class="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700"
+          @click="actions.approve(roleId, applicant.user_id)"
+        >
+          {{ trans('web::access_control.actions.approve') }}
+        </button>
+        <button
+          type="button"
+          class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50"
+          @click="actions.deny(roleId, applicant.user_id)"
+        >
+          {{ trans('web::access_control.actions.deny') }}
+        </button>
+      </MemberRow>
+    </ul>
+    <p
+      v-else
+      class="mt-3 text-sm text-gray-400"
+    >
+      {{ trans('web::access_control.moderate.no_applications') }}
+    </p>
+  </section>
+</template>
+
+<script setup>
+import MemberRow from "./MemberRow.vue";
+import { useRoleActions } from "@/composables/useRoleActions";
+import { useTranslations } from "@/composables/useTranslations";
+
+defineProps({
+    roleId: {
+        type: Number,
+        required: true,
+    },
+    applicants: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const actions = useRoleActions();
+const { trans } = useTranslations();
+</script>

--- a/resources/js/Shared/Components/AccessControl/RoleCard.vue
+++ b/resources/js/Shared/Components/AccessControl/RoleCard.vue
@@ -58,6 +58,22 @@
       >
         {{ trans('web::access_control.actions.leave') }}
       </button>
+
+      <!-- Moderator / admin entry points -->
+      <Link
+        v-if="canManageMembers"
+        :href="manageUrl"
+        class="flex-1 py-3 text-center text-sm font-medium text-gray-700 hover:bg-gray-50"
+      >
+        {{ trans('web::access_control.actions.manage_members') }}
+      </Link>
+      <Link
+        v-if="role.can_edit"
+        :href="configureUrl"
+        class="flex-1 py-3 text-center text-sm font-medium text-indigo-600 hover:bg-indigo-50"
+      >
+        {{ trans('web::access_control.actions.configure') }}
+      </Link>
     </div>
   </div>
 </template>
@@ -69,6 +85,8 @@ import RoleTypeBadge from "./RoleTypeBadge.vue";
 import { useRoleActions } from "@/composables/useRoleActions";
 import { useTranslations } from "@/composables/useTranslations";
 import ShowControlGroupController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ShowControlGroupController";
+import ManageMembersController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ManageMembersController";
+import { index as configureController } from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ManageControlGroupMembersController";
 
 const props = defineProps({
     role: {
@@ -81,7 +99,19 @@ const actions = useRoleActions();
 const { trans, trans_choice } = useTranslations();
 
 const detailUrl = computed(() => ShowControlGroupController.url({ role_id: props.role.id }));
-const hasActions = computed(() => props.role.can_join || props.role.can_apply || props.role.can_leave);
+const manageUrl = computed(() => ManageMembersController.url({ role_id: props.role.id }));
+const configureUrl = computed(() => configureController.url({ role_id: props.role.id }));
+
+// Manage-members is reachable by moderators and admins (matches the controller gate).
+const canManageMembers = computed(() => props.role.can_moderate || props.role.can_edit);
+
+const hasActions = computed(() =>
+    props.role.can_join
+    || props.role.can_apply
+    || props.role.can_leave
+    || props.role.can_edit
+    || canManageMembers.value);
+
 const statusLabel = computed(() => {
     if (props.role.my_status === "active") {
         return trans("web::access_control.status.active");

--- a/resources/js/Shared/Components/AccessControl/RoleMembersSection.vue
+++ b/resources/js/Shared/Components/AccessControl/RoleMembersSection.vue
@@ -1,0 +1,58 @@
+<template>
+  <section class="rounded-lg bg-white p-6 shadow-sm ring-1 ring-black/5">
+    <h3 class="text-sm font-semibold text-gray-900">
+      {{ trans('web::access_control.sections.members') }}
+    </h3>
+
+    <!-- Add a member by hand (moderators + admins). -->
+    <div class="mt-3">
+      <UserPicker @select="(userId) => actions.addMember(roleId, userId)" />
+    </div>
+
+    <ul
+      v-if="members.length"
+      class="mt-2 divide-y divide-gray-100"
+    >
+      <MemberRow
+        v-for="member in members"
+        :key="member.user_id"
+        :member="member"
+      >
+        <button
+          type="button"
+          class="rounded-md px-3 py-1.5 text-sm font-medium text-rose-600 ring-1 ring-rose-200 hover:bg-rose-50"
+          @click="actions.removeMember(roleId, member.user_id)"
+        >
+          {{ trans('web::access_control.actions.remove_member') }}
+        </button>
+      </MemberRow>
+    </ul>
+    <p
+      v-else
+      class="mt-3 text-sm text-gray-400"
+    >
+      {{ trans('web::access_control.moderate.no_members') }}
+    </p>
+  </section>
+</template>
+
+<script setup>
+import MemberRow from "./MemberRow.vue";
+import UserPicker from "./UserPicker.vue";
+import { useRoleActions } from "@/composables/useRoleActions";
+import { useTranslations } from "@/composables/useTranslations";
+
+defineProps({
+    roleId: {
+        type: Number,
+        required: true,
+    },
+    members: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const actions = useRoleActions();
+const { trans } = useTranslations();
+</script>

--- a/resources/js/Shared/Components/AccessControl/RoleModeratorsSection.vue
+++ b/resources/js/Shared/Components/AccessControl/RoleModeratorsSection.vue
@@ -1,0 +1,66 @@
+<template>
+  <section class="rounded-lg bg-white p-6 shadow-sm ring-1 ring-black/5">
+    <h3 class="text-sm font-semibold text-gray-900">
+      {{ trans('web::access_control.sections.moderators') }}
+    </h3>
+
+    <!-- Only admins manage moderators. -->
+    <div
+      v-if="canManage"
+      class="mt-3"
+    >
+      <UserPicker @select="(userId) => actions.addModerator(roleId, userId)" />
+    </div>
+
+    <ul
+      v-if="moderators.length"
+      class="mt-2 divide-y divide-gray-100"
+    >
+      <MemberRow
+        v-for="moderator in moderators"
+        :key="moderator.user_id"
+        :member="moderator"
+      >
+        <button
+          v-if="canManage"
+          type="button"
+          class="rounded-md px-3 py-1.5 text-sm font-medium text-rose-600 ring-1 ring-rose-200 hover:bg-rose-50"
+          @click="actions.removeModerator(roleId, moderator.user_id)"
+        >
+          {{ trans('web::access_control.actions.remove_moderator') }}
+        </button>
+      </MemberRow>
+    </ul>
+    <p
+      v-else
+      class="mt-3 text-sm text-gray-400"
+    >
+      {{ trans('web::access_control.moderate.no_moderators') }}
+    </p>
+  </section>
+</template>
+
+<script setup>
+import MemberRow from "./MemberRow.vue";
+import UserPicker from "./UserPicker.vue";
+import { useRoleActions } from "@/composables/useRoleActions";
+import { useTranslations } from "@/composables/useTranslations";
+
+defineProps({
+    roleId: {
+        type: Number,
+        required: true,
+    },
+    moderators: {
+        type: Array,
+        default: () => [],
+    },
+    canManage: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const actions = useRoleActions();
+const { trans } = useTranslations();
+</script>

--- a/resources/js/Shared/Components/AccessControl/UserPicker.vue
+++ b/resources/js/Shared/Components/AccessControl/UserPicker.vue
@@ -19,9 +19,14 @@
         @click="pick(user)"
       >
         <EveImage
+          v-if="user.mainCharacter"
           :object="user.mainCharacter"
           :size="64"
           tailwind_class="h-6 w-6 rounded-full"
+        />
+        <span
+          v-else
+          class="h-6 w-6 shrink-0 rounded-full bg-gray-200"
         />
         <span class="truncate">{{ user.mainCharacter?.name ?? `#${user.id}` }}</span>
       </li>

--- a/resources/js/Shared/Components/AccessControl/UserPicker.vue
+++ b/resources/js/Shared/Components/AccessControl/UserPicker.vue
@@ -19,8 +19,8 @@
         @click="pick(user)"
       >
         <EveImage
-          v-if="user.mainCharacter"
-          :object="user.mainCharacter"
+          v-if="user.main_character"
+          :object="user.main_character"
           :size="64"
           tailwind_class="h-6 w-6 rounded-full"
         />
@@ -28,7 +28,7 @@
           v-else
           class="h-6 w-6 shrink-0 rounded-full bg-gray-200"
         />
-        <span class="truncate">{{ user.mainCharacter?.name ?? `#${user.id}` }}</span>
+        <span class="truncate">{{ user.main_character?.name ?? `#${user.id}` }}</span>
       </li>
     </ul>
   </div>

--- a/resources/js/Shared/Components/AccessControl/UserPicker.vue
+++ b/resources/js/Shared/Components/AccessControl/UserPicker.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="relative">
+    <input
+      v-model="query"
+      type="search"
+      autocomplete="off"
+      :placeholder="trans('web::access_control.moderate.search_users')"
+      class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-xs focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-hidden"
+      @input="search"
+    >
+    <ul
+      v-if="results.length"
+      class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5"
+    >
+      <li
+        v-for="user in results"
+        :key="user.id"
+        class="flex cursor-pointer items-center gap-3 px-3 py-2 text-sm hover:bg-indigo-50"
+        @click="pick(user)"
+      >
+        <EveImage
+          :object="user.mainCharacter"
+          :size="64"
+          tailwind_class="h-6 w-6 rounded-full"
+        />
+        <span class="truncate">{{ user.mainCharacter?.name ?? `#${user.id}` }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import EveImage from "@/Shared/EveImage.vue";
+import { getJson } from "@/Functions/http";
+import { useTranslations } from "@/composables/useTranslations";
+import ListUserController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ListUserController";
+
+const emit = defineEmits(["select"]);
+const { trans } = useTranslations();
+
+const query = ref("");
+const results = ref([]);
+let timer = null;
+
+const search = () => {
+    clearTimeout(timer);
+    timer = setTimeout(async () => {
+        if (query.value.trim().length < 3) {
+            results.value = [];
+            return;
+        }
+        const response = await getJson(ListUserController.url({ query: { name: query.value.trim() } }));
+        results.value = response?.data ?? [];
+    }, 300);
+};
+
+const pick = (user) => {
+    emit("select", user.id);
+    query.value = "";
+    results.value = [];
+};
+</script>

--- a/resources/js/Shared/Components/AccessControl/UserPicker.vue
+++ b/resources/js/Shared/Components/AccessControl/UserPicker.vue
@@ -19,16 +19,26 @@
         @click="pick(user)"
       >
         <EveImage
-          v-if="user.main_character"
-          :object="user.main_character"
+          v-if="user.mainCharacter"
+          :object="user.mainCharacter"
           :size="64"
-          tailwind_class="h-6 w-6 rounded-full"
+          tailwind_class="h-6 w-6 shrink-0 rounded-full"
         />
         <span
           v-else
           class="h-6 w-6 shrink-0 rounded-full bg-gray-200"
         />
-        <span class="truncate">{{ user.main_character?.name ?? `#${user.id}` }}</span>
+        <div class="min-w-0">
+          <div class="truncate text-gray-900">
+            {{ user.mainCharacter?.name ?? `#${user.id}` }}
+          </div>
+          <div
+            v-if="altNames(user)"
+            class="truncate text-xs text-gray-400"
+          >
+            {{ altNames(user) }}
+          </div>
+        </div>
       </li>
     </ul>
   </div>
@@ -47,6 +57,14 @@ const { trans } = useTranslations();
 const query = ref("");
 const results = ref([]);
 let timer = null;
+
+// The user's other characters (everything except the main), so you can tell who you're picking
+// even when you searched by an alt.
+const altNames = (user) => (user.characters ?? [])
+    .filter((character) => character.character_id !== user.mainCharacter?.character_id)
+    .map((character) => character.name)
+    .filter(Boolean)
+    .join(", ");
 
 const search = () => {
     clearTimeout(timer);

--- a/resources/js/Shared/Layout/Buttons/DismissibleEntityButton.vue
+++ b/resources/js/Shared/Layout/Buttons/DismissibleEntityButton.vue
@@ -6,7 +6,7 @@
       tailwind_class="h-5 w-5 rounded-full"
     />
     <span class="flex flex-col leading-tight">
-      <span class="max-w-[12rem] truncate">{{ entity.name ?? entity.id }}</span>
+      <span class="max-w-[12rem] truncate">{{ label }}</span>
       <span
         v-if="subText"
         class="max-w-[12rem] truncate text-[10px] text-indigo-400"
@@ -17,7 +17,7 @@
       class="ml-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:bg-indigo-500 focus:text-white focus:outline-hidden"
       @click="$emit('remove', entity.id)"
     >
-      <span class="sr-only">Remove {{ entity.name ?? entity.id }}</span>
+      <span class="sr-only">Remove {{ label }}</span>
       <svg
         class="h-2 w-2"
         stroke="currentColor"
@@ -36,7 +36,9 @@
 
 <script setup>
 import EveImage from "@/Shared/EveImage.vue";
-import { computed } from "vue";
+import { computed, ref, watchEffect } from "vue";
+import { getJson } from "@/Functions/http";
+import { getEntityFromId } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
 
 const props = defineProps({
     // { id, name, category, ... } — a search result or a loaded selection.
@@ -56,6 +58,22 @@ const imageObject = computed(() => {
 
     return { ...props.entity, [`${category}_id`]: props.entity.id };
 });
+
+// A loaded selection can reference an entity the app has never persisted (added by id via ESI
+// search), so it carries no name. Resolve it lazily by id through the cached resolve.id endpoint —
+// the portrait already renders from the id alone. Mirrors EntityChip.
+const resolvedName = ref(null);
+
+watchEffect(async () => {
+    if (props.entity?.name || ! props.entity?.id) {
+        return;
+    }
+
+    const data = await getJson(getEntityFromId.url(props.entity.id));
+    resolvedName.value = data?.name ?? null;
+});
+
+const label = computed(() => props.entity?.name ?? resolvedName.value ?? props.entity?.id);
 
 // Corp/alliance context, shown only when the entity carries it.
 const subText = computed(() => {

--- a/resources/js/Shared/Modals/Modal.vue
+++ b/resources/js/Shared/Modals/Modal.vue
@@ -13,7 +13,15 @@
         v-if="open"
         class="fixed bottom-0 z-10 inset-x-0 px-4 pb-4 sm:inset-0 sm:flex sm:items-center sm:justify-center"
       >
-        <div class="fixed inset-0 transition-opacity">
+        <!--
+          -z-10 keeps the backdrop below the panel. The panel used to rely on the `transform`
+          utility for its stacking context, but Tailwind v4 dropped the standalone `transform`
+          class, so the panel became a non-positioned in-flow box and this fixed-position backdrop
+          painted on top of it. Pushing the backdrop to a negative z-index (within this modal's own
+          z-10 stacking context) restores backdrop-behind-panel without depending on the panel's
+          own classes.
+        -->
+        <div class="fixed inset-0 transition-opacity -z-10">
           <div
             class="absolute inset-0 bg-gray-500 opacity-75"
             @click="toggle"

--- a/resources/js/composables/useRoleActions.js
+++ b/resources/js/composables/useRoleActions.js
@@ -2,14 +2,18 @@ import { router, usePage } from "@inertiajs/vue3";
 import JoinOptInRoleController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/JoinOptInRoleController";
 import ApplyToRoleController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ApplyToRoleController";
 import LeaveControlGroupController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/LeaveControlGroupController";
+import ApproveApplicationController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/ApproveApplicationController";
+import DenyApplicationController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/DenyApplicationController";
+import AddManualMemberController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/AddManualMemberController";
+import RemoveMemberController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/RemoveMemberController";
+import AddModeratorController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/AddModeratorController";
+import RemoveModeratorController from "@/actions/Seatplus/Web/Http/Controllers/AccessControl/RemoveModeratorController";
 
 /**
- * Thin wrapper over the ACL Wayfinder actions so the discover/detail views don't hardcode URLs
- * or HTTP verbs. Each call is an Inertia visit that follows the controller's redirect and refreshes
- * the page props (so My/Available lists and membership status update in place).
- *
- * Member-management actions (approve/deny/member/moderator) are added alongside the moderator
- * surface (PR 3); this composable covers the self-service discover actions.
+ * Thin wrapper over the ACL Wayfinder actions so the views don't hardcode URLs or HTTP verbs.
+ * Each call is an Inertia visit that follows the controller's redirect and refreshes the page
+ * props in place. Covers the self-service discover actions (join/apply/leave) and the moderator /
+ * member-management actions (approve/deny, member add/kick, moderator add/remove).
  */
 export function useRoleActions() {
     const page = usePage();
@@ -18,14 +22,24 @@ export function useRoleActions() {
     const currentUserId = () => page.props.user.data.id;
 
     return {
-        // opt-in: join instantly
+        // --- discover (self-service) ---
         join: (roleId) => router.post(JoinOptInRoleController.url({ role_id: roleId }), {}, options),
-        // on-request: submit an application (pending until a moderator approves)
         apply: (roleId) => router.post(ApplyToRoleController.url({ role_id: roleId }), {}, options),
-        // leave / cancel a pending application for yourself
         leave: (roleId, userId = null) => router.delete(
             LeaveControlGroupController.url({ role_id: roleId, user_id: userId ?? currentUserId() }),
             options,
         ),
+
+        // --- moderator: applications ---
+        approve: (roleId, userId) => router.post(ApproveApplicationController.url({ role_id: roleId, user_id: userId }), {}, options),
+        deny: (roleId, userId) => router.delete(DenyApplicationController.url({ role_id: roleId, user_id: userId }), options),
+
+        // --- members (moderator / admin) ---
+        addMember: (roleId, userId) => router.post(AddManualMemberController.url({ role_id: roleId, user_id: userId }), {}, options),
+        removeMember: (roleId, userId) => router.delete(RemoveMemberController.url({ role_id: roleId, user_id: userId }), options),
+
+        // --- moderators (admin) ---
+        addModerator: (roleId, userId) => router.post(AddModeratorController.url({ role_id: roleId, user_id: userId }), {}, options),
+        removeModerator: (roleId, userId) => router.delete(RemoveModeratorController.url({ role_id: roleId, user_id: userId }), options),
     };
 }

--- a/resources/lang/de/access_control.php
+++ b/resources/lang/de/access_control.php
@@ -6,6 +6,12 @@ return [
     'group' => 'Gruppe',
     'groups' => 'Gruppen',
     'members_count' => '{0} Keine Mitglieder|{1} :count Mitglied|[2,*] :count Mitglieder',
+    'moderate' => [
+        'no_applications' => 'Keine ausstehenden Anträge.',
+        'no_members' => 'Noch keine Mitglieder.',
+        'no_moderators' => 'Noch keine Moderatoren.',
+        'search_users' => 'Nach Charaktername suchen…',
+    ],
     'delete_confirm' => 'Gruppe ":name" endgültig löschen? Dies kann nicht rückgängig gemacht werden.',
 
     'join_method' => [

--- a/resources/lang/en/access_control.php
+++ b/resources/lang/en/access_control.php
@@ -7,6 +7,12 @@ return [
     'group' => 'Group',
     'groups' => 'Groups',
     'members_count' => '{0} No members|{1} :count member|[2,*] :count members',
+    'moderate' => [
+        'no_applications' => 'No pending applications.',
+        'no_members' => 'No members yet.',
+        'no_moderators' => 'No moderators yet.',
+        'search_users' => 'Search by character name…',
+    ],
     'delete_confirm' => 'Permanently delete ":name"? This cannot be undone.',
 
     // Join method (role type) — WHO can be a member and how they get in.

--- a/src/Http/Controllers/AccessControl/ListUserController.php
+++ b/src/Http/Controllers/AccessControl/ListUserController.php
@@ -27,25 +27,31 @@
 namespace Seatplus\Web\Http\Controllers\AccessControl;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Seatplus\Auth\Models\User;
 use Seatplus\Web\Http\Controllers\Controller;
+use Seatplus\Web\Http\Resources\UserSearchResource;
 
 class ListUserController extends Controller
 {
-    public function __invoke()
+    public function __invoke(): AnonymousResourceCollection
     {
         $name_lookup = request()->get('name');
 
-        return User::with('mainCharacter', 'characters')
-            ->when(
-                request()->has('name'),
-                fn (Builder $query) => $query
-                    ->whereHas(
-                        'characters',
-                        fn (Builder $query) => $query
-                            ->where('name', 'like', "%${name_lookup}%")
-                    )
-            )
-            ->paginate();
+        // Wrap in a light camelCase resource (mainCharacter + characters) so the picker gets a
+        // stable shape instead of a raw model dump — without over-fetching or lazy loading.
+        return UserSearchResource::collection(
+            User::with('mainCharacter', 'characters')
+                ->when(
+                    request()->has('name'),
+                    fn (Builder $query) => $query
+                        ->whereHas(
+                            'characters',
+                            fn (Builder $query) => $query
+                                ->where('name', 'like', "%{$name_lookup}%")
+                        )
+                )
+                ->paginate()
+        );
     }
 }

--- a/src/Http/Controllers/AccessControl/ManageMembersController.php
+++ b/src/Http/Controllers/AccessControl/ManageMembersController.php
@@ -1,46 +1,61 @@
 <?php
 
-/*
- * MIT License
- *
- * Copyright (c) 2019, 2020, 2021 Felix Huber
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+declare(strict_types=1);
 
 namespace Seatplus\Web\Http\Controllers\AccessControl;
 
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Inertia\Inertia;
+use Inertia\Response;
+use Seatplus\Auth\Enums\RoleMembershipStatus;
 use Seatplus\Auth\Models\Permissions\Role;
+use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Roles\BaseRoleService;
 use Seatplus\Web\Http\Controllers\Controller;
+use Seatplus\Web\Http\Resources\RoleMemberResource;
+use Seatplus\Web\Support\AccessControl\RoleTypeMetadata;
+use Seatplus\Web\Support\Translations;
 
 class ManageMembersController extends Controller
 {
-    public function __invoke(int $role_id)
+    public function __invoke(int $role_id): Response
     {
-        $role = Role::find($role_id);
+        $role = Role::findOrFail($role_id);
 
-        abort_unless((new BaseRoleService)->for($role)->canModerate(auth()->user()), 403);
+        $user = auth()->user();
+
+        // Moderators are managed by admins only; a plain moderator manages members/applications.
+        $canManageModerators = $user->can('superuser') || $user->can('administrate access control groups');
+        $canModerate = (new BaseRoleService)->for($role)->canModerate($user);
+
+        // Admins (superuser / global ACL admin) and per-role moderators may open the manage page.
+        abort_unless($canManageModerators || $canModerate, 403);
+
+        $memberships = $role->roleMemberships()
+            ->where('entity_type', User::class)
+            ->with(['entity' => fn (MorphTo $morph) => $morph->morphWith([User::class => ['mainCharacter']])])
+            ->get();
 
         return Inertia::render('AccessControl/ModerateMembers', [
-            'role' => $role,
+            'role' => [
+                'id' => $role->id,
+                'name' => $role->name,
+                'type' => $role->type->value,
+                'type_label' => RoleTypeMetadata::for($role->type)['label'],
+                'capabilities' => RoleTypeMetadata::for($role->type),
+            ],
+            'members' => RoleMemberResource::collection(
+                $memberships->where('status', RoleMembershipStatus::ACTIVE->value)
+            )->resolve(),
+            'applicants' => RoleMemberResource::collection(
+                $memberships->where('status', RoleMembershipStatus::PENDING->value)
+            )->resolve(),
+            'moderators' => RoleMemberResource::collection(
+                $memberships->where('can_moderate', true)
+            )->resolve(),
+            'canManageModerators' => $canManageModerators,
+            'activeSidebarElement' => 'acl.groups',
+            'pageTranslations' => Translations::gather(['web::access_control']),
         ]);
     }
 }

--- a/src/Http/Controllers/AccessControl/ManageMembersController.php
+++ b/src/Http/Controllers/AccessControl/ManageMembersController.php
@@ -33,7 +33,7 @@ class ManageMembersController extends Controller
 
         $memberships = $role->roleMemberships()
             ->where('entity_type', User::class)
-            ->with(['entity' => fn (MorphTo $morph) => $morph->morphWith([User::class => ['mainCharacter']])])
+            ->with(['entity' => fn (MorphTo $morph) => $morph->morphWith([User::class => ['mainCharacter', 'characters']])])
             ->get();
 
         return Inertia::render('AccessControl/ModerateMembers', [

--- a/src/Http/Controllers/AccessControl/ShowControlGroupsController.php
+++ b/src/Http/Controllers/AccessControl/ShowControlGroupsController.php
@@ -24,7 +24,9 @@ class ShowControlGroupsController extends Controller
         $userId = $user->getAuthIdentifier();
 
         // The corps/alliances the user belongs to — used to find groups they're eligible to join.
-        $characters = $user->characters;
+        // Eager-load characterAffiliation: the corporation_id/alliance_id accessors read it, and
+        // lazy loading is disabled (strict mode).
+        $characters = $user->characters()->with('characterAffiliation')->get();
         $corporationIds = $characters->pluck('corporation_id')->filter()->unique()->values()->all();
         $allianceIds = $characters->pluck('alliance_id')->filter()->unique()->values()->all();
 

--- a/src/Http/Resources/RoleMemberResource.php
+++ b/src/Http/Resources/RoleMemberResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\Web\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Seatplus\Auth\Models\AccessControl\RoleMembership;
+
+/**
+ * One User membership row of a role — a member, applicant, or moderator — reduced to what the
+ * manage-members UI needs: the owning user id (for approve/deny/kick/moderator actions, which are
+ * keyed by user_id), their main character for display, and the status / can_moderate flags.
+ *
+ * Expects the membership's `entity` (User) eager-loaded with its `mainCharacter`.
+ *
+ * @mixin RoleMembership
+ */
+class RoleMemberResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $mainCharacterId = data_get($this->entity, 'mainCharacter.character_id');
+        $mainCharacterName = data_get($this->entity, 'mainCharacter.name');
+
+        return [
+            'user_id' => (int) $this->entity_id,
+            'status' => $this->status,
+            'can_moderate' => (bool) $this->can_moderate,
+            'character' => [
+                'character_id' => is_int($mainCharacterId) ? $mainCharacterId : (int) $mainCharacterId,
+                'name' => is_string($mainCharacterName) ? $mainCharacterName : null,
+            ],
+        ];
+    }
+}

--- a/src/Http/Resources/RoleMemberResource.php
+++ b/src/Http/Resources/RoleMemberResource.php
@@ -7,6 +7,7 @@ namespace Seatplus\Web\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Seatplus\Auth\Models\AccessControl\RoleMembership;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 /**
  * One User membership row of a role — a member, applicant, or moderator — reduced to what the
@@ -32,6 +33,13 @@ class RoleMemberResource extends JsonResource
                 'character_id' => is_int($mainCharacterId) ? $mainCharacterId : (int) $mainCharacterId,
                 'name' => is_string($mainCharacterName) ? $mainCharacterName : null,
             ],
+            // Every character on the user, so the row can show the alts as subtext (like the picker).
+            'characters' => collect(data_get($this->entity, 'characters', []))
+                ->map(fn (CharacterInfo $character): array => [
+                    'character_id' => $character->character_id,
+                    'name' => $character->name,
+                ])
+                ->values(),
         ];
     }
 }

--- a/src/Http/Resources/RoleRessource.php
+++ b/src/Http/Resources/RoleRessource.php
@@ -63,7 +63,7 @@ class RoleRessource extends JsonResource
             'type' => $this->type->value,
             'type_label' => $meta['label'],
             'type_description' => $meta['description'],
-            'members' => $this->users->count(),
+            'members' => $this->users()->count(),
             'my_status' => $myStatus,
             'can_edit' => $canEdit,
             // Fixed: delegate to the service for ALL moderated types (manual/on-request/opt-in),

--- a/src/Http/Resources/UserSearchResource.php
+++ b/src/Http/Resources/UserSearchResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\Web\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+
+/**
+ * Minimal, camelCase user shape for the add-member / add-moderator picker: the user id, their main
+ * character (portrait + name), and every character's name (so a result found via an alt shows who
+ * it is). Deliberately lighter than UserRessource — no scopes/corp/alliance — so a search doesn't
+ * over-fetch (and doesn't touch relations that would need extra eager loading under strict mode).
+ *
+ * Expects `mainCharacter` and `characters` eager-loaded.
+ *
+ * @mixin User
+ */
+class UserSearchResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'mainCharacter' => $this->mainCharacter
+                ? [
+                    'character_id' => $this->mainCharacter->character_id,
+                    'name' => $this->mainCharacter->name,
+                ]
+                : null,
+            'characters' => $this->characters
+                ->map(fn (CharacterInfo $character): array => [
+                    'character_id' => $character->character_id,
+                    'name' => $character->name,
+                ])
+                ->values(),
+        ];
+    }
+}

--- a/tests/Browser/CharacterAccessControlTest.php
+++ b/tests/Browser/CharacterAccessControlTest.php
@@ -12,6 +12,7 @@ use Seatplus\Auth\Models\Permissions\Affiliation;
 use Seatplus\Auth\Models\Permissions\Permission;
 use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 if (! function_exists('deviceVisit')) {
@@ -272,4 +273,77 @@ it('creates an open-to-all group through the wizard (admin)', function (string $
     $page->assertNoSmoke();
 
     snap($page, "acl-create-wizard-everyone-{$device}");
+})->with(['desktop', 'iphone']);
+
+if (! function_exists('makeOnRequestRole')) {
+    /** A request-to-join (on-request) group. */
+    function makeOnRequestRole(string $name): Role
+    {
+        $role = Role::findById(Role::create(['name' => $name])->id);
+        $role->update(['type' => RoleType::ON_REQUEST]);
+
+        return $role;
+    }
+}
+
+if (! function_exists('makeApplicant')) {
+    /** Seed a distinct user (named character) with a pending application to $role. */
+    function makeApplicant(Role $role, string $name): CharacterInfo
+    {
+        $character = CharacterInfo::factory()->create(['name' => $name]);
+
+        $user = new User;
+        $user->main_character_id = $character->character_id;
+        $user->save();
+
+        CharacterUser::create([
+            'user_id' => $user->getKey(),
+            'character_id' => $character->character_id,
+            'character_owner_hash' => sha1((string) $character->character_id),
+        ]);
+
+        RoleMembership::create([
+            'role_id' => $role->id,
+            'entity_type' => User::class,
+            'entity_id' => $user->getKey(),
+            'status' => 'pending',
+        ]);
+
+        return $character;
+    }
+}
+
+it('lets a moderator approve a pending application', function (string $device) {
+    $character = actingAsCharacter();
+    grantAclAdmin($character->character_id);
+    $role = makeOnRequestRole('Recruiters');
+    makeApplicant($role, 'Hopeful Pilot');
+
+    $page = deviceVisit($device, '/acl/'.$role->id.'/manage_members');
+    $page->assertNoSmoke();
+
+    // The pending applicant shows under Applications.
+    $page->waitForText('Pending applications');
+    $page->waitForText('Hopeful Pilot');
+
+    // Approving moves them into Members.
+    $page->click('Approve');
+    $page->assertScript("(document.body.innerText.includes('Members') && document.body.innerText.includes('Hopeful Pilot'))");
+    $page->assertNoSmoke();
+
+    snap($page, "acl-moderate-approve-{$device}");
+})->with(['desktop', 'iphone']);
+
+it('shows members and moderators sections on the manage page (admin)', function (string $device) {
+    $character = actingAsCharacter();
+    grantAclAdmin($character->character_id);
+    $role = makeOnRequestRole('Logistics');
+
+    $page = deviceVisit($device, '/acl/'.$role->id.'/manage_members');
+    $page->assertNoSmoke();
+
+    $page->waitForText('Members');
+    $page->waitForText('Moderators');
+
+    snap($page, "acl-moderate-sections-{$device}");
 })->with(['desktop', 'iphone']);

--- a/tests/Browser/CharacterAccessControlTest.php
+++ b/tests/Browser/CharacterAccessControlTest.php
@@ -319,7 +319,7 @@ it('lets a moderator approve a pending application', function (string $device) {
     $role = makeOnRequestRole('Recruiters');
     makeApplicant($role, 'Hopeful Pilot');
 
-    $page = deviceVisit($device, '/acl/'.$role->id.'/manage_members');
+    $page = deviceVisit($device, '/acl/acl/'.$role->id.'/manage_members');
     $page->assertNoSmoke();
 
     // The pending applicant shows under Applications.
@@ -339,7 +339,7 @@ it('shows members and moderators sections on the manage page (admin)', function 
     grantAclAdmin($character->character_id);
     $role = makeOnRequestRole('Logistics');
 
-    $page = deviceVisit($device, '/acl/'.$role->id.'/manage_members');
+    $page = deviceVisit($device, '/acl/acl/'.$role->id.'/manage_members');
     $page->assertNoSmoke();
 
     $page->waitForText('Members');
@@ -351,6 +351,8 @@ it('shows members and moderators sections on the manage page (admin)', function 
 it('surfaces configure and manage-members entry points to an admin on the index', function (string $device) {
     $character = actingAsCharacter();
     grantAclAdmin($character->character_id);
+    // The /acl index is gated by 'view access control'; a global ACL admin also needs it to load.
+    grantAclView($character->character_id);
 
     $role = Role::findById(Role::create(['name' => 'Ops Team'])->id);
     $role->update(['type' => RoleType::MANUAL]);

--- a/tests/Browser/CharacterAccessControlTest.php
+++ b/tests/Browser/CharacterAccessControlTest.php
@@ -347,3 +347,21 @@ it('shows members and moderators sections on the manage page (admin)', function 
 
     snap($page, "acl-moderate-sections-{$device}");
 })->with(['desktop', 'iphone']);
+
+it('surfaces configure and manage-members entry points to an admin on the index', function (string $device) {
+    $character = actingAsCharacter();
+    grantAclAdmin($character->character_id);
+
+    $role = Role::findById(Role::create(['name' => 'Ops Team'])->id);
+    $role->update(['type' => RoleType::MANUAL]);
+
+    $page = deviceVisit($device, '/acl');
+    $page->assertNoSmoke();
+
+    // The admin's "All groups" section lists it with the privileged actions on the card.
+    $page->waitForText('Ops Team');
+    $page->assertSee('Configure');
+    $page->assertSee('Manage members');
+
+    snap($page, "acl-admin-entrypoints-{$device}");
+})->with(['desktop', 'iphone']);

--- a/tests/Feature/Controller/ListUserControllerTest.php
+++ b/tests/Feature/Controller/ListUserControllerTest.php
@@ -58,6 +58,8 @@ it('finds a user by any of their characters (an alt), returning the main for dis
         ->assertOk()
         // matched via the alt, but the user is returned…
         ->assertJsonFragment(['id' => test()->test_user->id])
-        // …with the user's MAIN character for the pill/row (snake_case main_character key).
-        ->assertJsonPath('data.0.main_character.character_id', test()->test_user->main_character_id);
+        // …with the user's MAIN character for the pill/row (camelCase mainCharacter)…
+        ->assertJsonPath('data.0.mainCharacter.character_id', test()->test_user->main_character_id)
+        // …and the alt's name available for the picker subtext.
+        ->assertJsonFragment(['name' => 'Alt Toon']);
 });

--- a/tests/Feature/Controller/ListUserControllerTest.php
+++ b/tests/Feature/Controller/ListUserControllerTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Queue;
+use Seatplus\Auth\Models\CharacterUser;
 use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 beforeEach(function () {
     Queue::fake();
@@ -38,4 +40,24 @@ it('searches users by character name', function () {
         ->get(route('list.users', ['name' => test()->test_character->name]))
         ->assertOk()
         ->assertJsonFragment(['id' => test()->test_user->id]);
+});
+
+it('finds a user by any of their characters (an alt), returning the main for display', function () {
+    assignPermissionToTestUser(['administrate access control groups']);
+
+    // Add an alt to the test user; the main stays test_character.
+    $alt = CharacterInfo::factory()->create(['name' => 'Alt Toon']);
+    CharacterUser::create([
+        'user_id' => test()->test_user->getKey(),
+        'character_id' => $alt->character_id,
+        'character_owner_hash' => sha1((string) $alt->character_id),
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->get(route('list.users', ['name' => 'Alt Toon']))
+        ->assertOk()
+        // matched via the alt, but the user is returned…
+        ->assertJsonFragment(['id' => test()->test_user->id])
+        // …with the user's MAIN character for the pill/row (snake_case main_character key).
+        ->assertJsonPath('data.0.main_character.character_id', test()->test_user->main_character_id);
 });

--- a/tests/Feature/Controller/ManageMembersControllerTest.php
+++ b/tests/Feature/Controller/ManageMembersControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia as Assert;
+use Seatplus\Auth\Models\AccessControl\RoleMembership;
 use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Auth\Models\User;
 
@@ -36,13 +37,42 @@ it('allows a moderator to access ManageMembersController', function () {
     test()->actingAs(test()->test_user)
         ->get(route('manage.acl.members', test()->role->id))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->component('AccessControl/ModerateMembers'));
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('AccessControl/ModerateMembers')
+            // a plain moderator manages members/applications but not moderators
+            ->where('canManageModerators', false)
+            ->has('members')
+            ->has('applicants')
+            ->has('moderators', 1));
 });
 
-it('denies superuser who is not a moderator', function () {
-    assignPermissionToTestUser(['superuser']);
+it('allows a global ACL admin (not a moderator) and enables moderator management', function () {
+    // Administrate permission only — not superuser, not a per-role moderator.
+    assignPermissionToTestUser(['administrate access control groups']);
 
     test()->actingAs(test()->test_user)
         ->get(route('manage.acl.members', test()->role->id))
-        ->assertForbidden();
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('AccessControl/ModerateMembers')
+            ->where('canManageModerators', true));
+});
+
+it('splits user memberships into members, applicants, and moderators', function () {
+    $admin = User::factory()->create();
+    assignPermission($admin, ['administrate access control groups']);
+
+    $member = User::factory()->create();
+    $applicant = User::factory()->create();
+
+    RoleMembership::create(['role_id' => test()->role->id, 'entity_type' => User::class, 'entity_id' => $member->id, 'status' => 'active']);
+    RoleMembership::create(['role_id' => test()->role->id, 'entity_type' => User::class, 'entity_id' => $applicant->id, 'status' => 'pending']);
+    RoleMembership::create(['role_id' => test()->role->id, 'entity_type' => User::class, 'entity_id' => $admin->id, 'can_moderate' => true, 'status' => 'active']);
+
+    test()->actingAs($admin)
+        ->get(route('manage.acl.members', test()->role->id))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('members', 2)      // member + admin (both active)
+            ->has('applicants', 1)
+            ->has('moderators', 1)); // admin (can_moderate)
 });

--- a/tests/Feature/Controller/ShowControlGroupsControllerTest.php
+++ b/tests/Feature/Controller/ShowControlGroupsControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia as Assert;
 use Seatplus\Auth\Enums\RoleType;
@@ -93,4 +94,29 @@ it('segments roles into my groups and available-to-join', function () {
             ->where('myGroups.0.name', 'mine')
             ->where('availableGroups.0.name', 'available')
             ->where('availableGroups.0.can_join', true));
+});
+
+it('renders the index under strict mode without lazy-loading violations', function () {
+    assignPermissionToTestUser(['view access control', 'administrate access control groups']);
+
+    // A real membership so RoleRessource runs against an actual row (users count, type meta, flags).
+    $role = Role::findById(Role::create(['name' => 'Ops'])->id);
+    $role->update(['type' => RoleType::MANUAL]);
+    RoleMembership::create([
+        'role_id' => $role->id,
+        'entity_type' => User::class,
+        'entity_id' => test()->test_user->getKey(),
+        'status' => 'active',
+    ]);
+
+    // The dev app disables lazy loading; enforce it here so the index's eager loading is verified.
+    Model::preventLazyLoading(true);
+
+    try {
+        test()->actingAs(test()->test_user)
+            ->get(route('acl.groups'))
+            ->assertOk();
+    } finally {
+        Model::preventLazyLoading(false);
+    }
 });


### PR DESCRIPTION
## What
The **moderator & member-management** surface of the ACL redesign (PR 3), rebuilding `manage.acl.members` for moderators *and* admins and wiring it to the dedicated endpoints — replacing the old page that funnelled everything through `acl.join`/`acl.leave`.

### Three capability-gated sections
- **Applications** (on-request only) — pending applicants with **Approve** (`acl.approve`) / **Deny** (`acl.deny`).
- **Members** — active members with **Remove/kick** (`acl.member.remove`) and an **Add member** user-search (`acl.member.add`). Moderators + admins.
- **Moderators** — **admin-only** add/remove (`acl.moderator.add`/`remove`); **hidden for automatic** roles.

## How
- **Backend:** `ManageMembersController` passes structured `members`/`applicants`/`moderators` (new `RoleMemberResource`: user_id + main character + status/can_moderate) + `capabilities` + `canManageModerators`. Gate allows admins (superuser / `administrate access control groups`) as well as per-role moderators.
- **Frontend (Wayfinder + `<script setup>` + i18n, section components reused by the PR 4 hub):** `useRoleActions` extended (approve/deny, member/moderator add/remove); `RoleApplicationsSection`, `RoleMembersSection`, `RoleModeratorsSection`, `MemberRow`, `UserPicker` (searches `list.users`); rebuilt `ModerateMembers.vue`.
- `web::access_control.moderate.*` i18n (en/de).

## Tests
- Feature (`ManageMembersControllerTest`): structured split; gate for moderator + global admin; denies non-moderator/unauthenticated.
- Browser (core CI, desktop+iPhone): approve application → moves to Members; sections render for admin.
- Pint / PHPStan / 100% type coverage / eslint clean.

## Notes
- Opt-in is moderator-capable (auth #1487, merged); moderator controls hidden only for automatic.
- **PR 4 (unified hub)** composes the discover/config/members sections into one page, then we drop the less-liked layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
