### PR TITLE
refactor: load open enlistments via an Inertia deferred prop (drop axios)

### DIFF
--- a/resources/js/Pages/Dashboard/Enlistments.vue
+++ b/resources/js/Pages/Dashboard/Enlistments.vue
@@ -1,35 +1,50 @@
 <template>
-  <div
-    v-show="enlistments.length > 0"
-    class="py-5 border-b border-gray-200 space-y-2"
-  >
-    <h3 class="text-lg leading-6 font-medium text-gray-900">
-      Job Postings
-    </h3>
-    <p class="max-w-4xl text-sm leading-5 text-gray-500">
-      The following corporations are open for new recruits. These job listings do have two kind of characteristics: either 'character' or 'user' and it's defined by  a senior recruiter of that corporation.
-      For an enlistment with character type, this means you are able to apply with single characters of yours and sso-scope requirements are only enforced per applied character.
-      If an enlistment is of user type, upon application each and every character that belongs to your user account must fulfill the set sso-scope requirements of the recruiting corporation.
-    </p>
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <Enlistment
-        v-for="enlistment in enlistments"
-        :key="enlistment.corporation_id"
-        :enlistment="enlistment"
-      />
+  <Deferred data="openEnlistments">
+    <template #fallback>
+      <div class="py-5 border-b border-gray-200 space-y-2">
+        <h3 class="text-lg leading-6 font-medium text-gray-900">
+          Job Postings
+        </h3>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div
+            v-for="n in 2"
+            :key="n"
+            class="h-28 animate-pulse rounded-lg bg-gray-100"
+          />
+        </div>
+      </div>
+    </template>
+
+    <div
+      v-show="enlistments.length > 0"
+      class="py-5 border-b border-gray-200 space-y-2"
+    >
+      <h3 class="text-lg leading-6 font-medium text-gray-900">
+        Job Postings
+      </h3>
+      <p class="max-w-4xl text-sm leading-5 text-gray-500">
+        The following corporations are open for new recruits. These job listings do have two kind of characteristics: either 'character' or 'user' and it's defined by  a senior recruiter of that corporation.
+        For an enlistment with character type, this means you are able to apply with single characters of yours and sso-scope requirements are only enforced per applied character.
+        If an enlistment is of user type, upon application each and every character that belongs to your user account must fulfill the set sso-scope requirements of the recruiting corporation.
+      </p>
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Enlistment
+          v-for="enlistment in enlistments"
+          :key="enlistment.corporation_id"
+          :enlistment="enlistment"
+        />
+      </div>
     </div>
-  </div>
+  </Deferred>
 </template>
 
 <script setup>
-import {useLoadCompleteResource} from "@/Functions/useLoadCompleteResource";
-import {computed} from "vue";
+import { Deferred, usePage } from "@inertiajs/vue3";
+import { computed } from "vue";
 import Enlistment from "./Enlistment.vue";
 
-const completeResource = useLoadCompleteResource('list.open.enlistments')
-
-const enlistments = computed(() => completeResource.results.value)
-
+// openEnlistments is a deferred page prop (HomeController@home) — no client fetch/axios.
+const enlistments = computed(() => usePage().props.openEnlistments ?? [])
 </script>
 
 <style scoped>

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -50,7 +50,6 @@ Route::middleware('web')
         Route::middleware(['auth', CheckRequiredScopes::class, OnboardingMiddleware::class])
             ->group(function () {
                 Route::get('/home', [HomeController::class, 'home'])->name('home');
-                Route::get('/enlistments', [HomeController::class, 'getEnlistments'])->name('list.open.enlistments');
                 Route::get('/applications/{corporation_id}/related', [HomeController::class, 'getOwnApplications'])->name('list.existing.applications');
 
                 Route::prefix('queue')

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -43,12 +43,12 @@ class HomeController extends Controller
             'characters' => CharacterInfo::with('corporation', 'alliance', 'application', 'balance', 'batchUpdate')
                 ->whereIn('character_id', auth()->user()->characters->pluck('character_id')->toArray())
                 ->get(),
+            // Open job postings are a small, bounded list — deferred so the dashboard renders
+            // immediately and the list arrives in a follow-up request (no client fetch/axios).
+            'openEnlistments' => Inertia::defer(
+                fn () => Enlistment::with('corporation', 'corporation.alliance')->get()
+            ),
         ]);
-    }
-
-    public function getEnlistments(): LengthAwarePaginator
-    {
-        return Enlistment::with('corporation', 'corporation.alliance')->paginate();
     }
 
     public function getOwnApplications(int $corporation_id): LengthAwarePaginator

--- a/tests/Feature/RecruitmentLifeCycleTest.php
+++ b/tests/Feature/RecruitmentLifeCycleTest.php
@@ -76,17 +76,18 @@ test('user with permission and affiliations can delete enlistment', function () 
 test('secondary user can see enlistment', function () {
     createEnlistment();
 
-    $response = test()->actingAs(test()->secondary_user)
-        ->get(route('list.open.enlistments'))
-        ->assertJson(
-            fn (AssertableJson $json) => $json
-                ->has('data', 1)
-                ->has(
-                    'data.0',
-                    fn ($json) => $json
-                        ->where('corporation_id', test()->test_character->corporation->corporation_id)
-                        ->etc()
-                )
+    // openEnlistments is a deferred prop on the dashboard — resolve it via an Inertia partial reload.
+    test()->actingAs(test()->secondary_user)
+        ->get(route('home'), [
+            'X-Inertia' => 'true',
+            'X-Inertia-Partial-Component' => 'Dashboard/Index',
+            'X-Inertia-Partial-Data' => 'openEnlistments',
+        ])
+        ->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Dashboard/Index')
+                ->has('openEnlistments', 1)
+                ->where('openEnlistments.0.corporation_id', test()->test_character->corporation->corporation_id)
                 ->etc()
         );
 });


### PR DESCRIPTION
Part of removing axios + Ziggy from web. New lane: **`useLoadCompleteResource` → Inertia deferred props** for page-level lists.

`useLoadCompleteResource` isn't infinite scroll — it loads a resource's *entire* paginated set via axios. `Enlistments.vue` is a single, page-level, bounded list on the dashboard, so an **Inertia deferred prop** is the idiomatic axios/Ziggy-free replacement: the dashboard renders immediately, the list arrives in a follow-up request, native skeleton fallback — no client fetch, no separate endpoint, no `route()`.

## Changes
- **Backend:** `HomeController@home` adds `'openEnlistments' => Inertia::defer(fn () => Enlistment::with('corporation','corporation.alliance')->get())` (mirrors existing `Inertia::defer` usage in Wallets/ManualLocation controllers). Deletes the now-dead `getEnlistments()` + its `list.open.enlistments` route (only `Enlistments.vue` used it).
- **Frontend:** `Enlistments.vue` uses `<Deferred data="openEnlistments">` with a pulsing-skeleton `#fallback`, reads `usePage().props.openEnlistments`; drops `useLoadCompleteResource`.
- **Test:** `RecruitmentLifeCycleTest` "secondary user can see enlistment" now asserts the deferred prop via an Inertia partial reload of the dashboard (the old test hit the removed endpoint).

## Verification
- Pint + ESLint clean; grep guards clean (no `useLoadCompleteResource` in Enlistments, no `list.open.enlistments` anywhere).
- Feature test runs in CI/host (isolated worktree can't run pest — composer-autoload path mismatch, and to avoid touching the shared test DB).
- Manual: dashboard → Job Postings shows the skeleton, then enlistments arrive via a deferred partial request (no axios).

`useLoadCompleteResource` stays until Compliance (its last consumer) is migrated; then it + `CompleteLoadingHelper` get deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)