### PR TITLE
refactor: drop Ziggy from recruitment configuration (Wayfinder)

### DIFF
--- a/resources/js/Pages/Corporation/Recruitment/Configuration/EnlistmentConfig.vue
+++ b/resources/js/Pages/Corporation/Recruitment/Configuration/EnlistmentConfig.vue
@@ -76,14 +76,12 @@
       </div>
     </div>
     <template #button>
-      <button
-        :disabled="form.processing"
-        type="submit"
-        class="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      <Button
+        :is-inertia-button="false"
         @click="submit()"
       >
         Save
-      </button>
+      </Button>
     </template>
   </TwoColumnCardWithSubmitAction>
 </template>
@@ -95,10 +93,12 @@ import SimpleToggle from "@/Shared/SimpleToggle.vue";
 import Autosuggest from "@/Shared/Components/Autosuggest.vue";
 import TwoColumnCardWithSubmitAction from "@/Shared/Layout/Forms/TwoColumnCardWithSubmitAction.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
+import Button from "@/Shared/Layout/Button.vue";
+import { create as createEnlistment } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/EnlistmentsController";
 
 export default {
     name: "EnlistmentConfig",
-    components: {EntityByIdBlock, TwoColumnCardWithSubmitAction, Autosuggest, SimpleToggle},
+    components: {Button, EntityByIdBlock, TwoColumnCardWithSubmitAction, Autosuggest, SimpleToggle},
     props: {
         enlistment: {
             required: false,
@@ -122,7 +122,7 @@ export default {
         const submit = () => {
             form
                 .transform((data) => ({ ...data, corporation_id: data.corporation.corporation_id}))
-                .post(route('create.corporation.recruitment'), {
+                .post(createEnlistment.url(), {
                 onSuccess: () => {
                     emit('onSuccess')
                 }

--- a/resources/js/Pages/Corporation/Recruitment/Configuration/Index.vue
+++ b/resources/js/Pages/Corporation/Recruitment/Configuration/Index.vue
@@ -6,7 +6,7 @@
         <!--TODO: Create Delete Button with confirmation dialog-->
         <span class="shadow-xs rounded-md">
           <Button
-            :href="route('delete.enlistment', enlistment.corporation_id)"
+            :href="deleteUrl"
             method="delete"
           >
             Delete
@@ -52,14 +52,12 @@
 
 
       <template #button>
-        <button
-          :disabled="form.processing"
-          type="submit"
-          class="bg-indigo-600 border border-transparent rounded-md shadow-xs py-2 px-4 inline-flex justify-center text-sm font-medium text-white hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        <Button
+          :is-inertia-button="false"
           @click="submit"
         >
           Save
-        </button>
+        </Button>
       </template>
     </TwoColumnCardWithSubmitAction>
     <ItemsWatchlist
@@ -76,7 +74,9 @@ import EnlistmentConfig from "./EnlistmentConfig.vue";
 import Button from "@/Shared/Layout/Button.vue";
 import ItemsWatchlist from "./ItemsWatchlist.vue";
 import EsiMultiselect from "@/Shared/Components/EsiMultiselect.vue";
-import {router, useForm} from "@inertiajs/vue3";
+import { useForm } from "@inertiajs/vue3";
+import { deleteMethod as deleteEnlistment, updateWatchlist } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/EnlistmentsController";
+import GetRecruitmentIndexController from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/GetRecruitmentIndexController";
 
 export default {
     name: "Index",
@@ -96,7 +96,7 @@ export default {
             breadcrumbs: [
                 {
                     name: 'Corporation Recruitment',
-                    route: route('corporation.recruitment')
+                    route: GetRecruitmentIndexController.url()
                 }
             ],
             form: useForm({
@@ -105,9 +105,14 @@ export default {
             }),
         }
     },
+    computed: {
+        deleteUrl() {
+            return deleteEnlistment.url(this.enlistment.corporation_id)
+        }
+    },
     methods: {
         submit() {
-          router.post(route('update.watchlist', this.corporationId), this.form)
+            this.form.post(updateWatchlist.url(this.enlistment.corporation_id))
         }
     }
 }

--- a/resources/js/Pages/Corporation/Recruitment/Configuration/ItemsWatchlist.vue
+++ b/resources/js/Pages/Corporation/Recruitment/Configuration/ItemsWatchlist.vue
@@ -27,14 +27,12 @@
       </div>
     </div>
     <template #button>
-      <button
-        :disabled="form.processing"
-        type="submit"
-        class="bg-indigo-600 border border-transparent rounded-md shadow-xs py-2 px-4 inline-flex justify-center text-sm font-medium text-white hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      <Button
+        :is-inertia-button="false"
         @click="submit"
       >
         Save
-      </button>
+      </Button>
     </template>
   </TwoColumnCardWithSubmitAction>
 </template>
@@ -44,11 +42,13 @@ import TwoColumnCardWithSubmitAction from "@/Shared/Layout/Forms/TwoColumnCardWi
 import Autosuggest from "@/Shared/Components/Autosuggest.vue";
 import {ref, watch} from "vue";
 import DismissibleButton from "@/Shared/Layout/Buttons/DismissibleButton.vue";
+import Button from "@/Shared/Layout/Button.vue";
 import { useForm } from "@inertiajs/vue3";
+import { updateWatchlist } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/EnlistmentsController";
 
 export default {
     name: "ItemsWatchlist",
-    components: {DismissibleButton, Autosuggest, TwoColumnCardWithSubmitAction},
+    components: {Button, DismissibleButton, Autosuggest, TwoColumnCardWithSubmitAction},
     props: {
         items: {
             required: true,
@@ -69,7 +69,7 @@ export default {
 
         const select = (selection) => form.items.push(selection)
         const unselect = (id) => form.items = _.filter(form.items, (item) => item.id !== id)
-        const submit = () => form.post(route('update.watchlist', props.corporationId))
+        const submit = () => form.post(updateWatchlist.url(props.corporationId))
 
         watch(form.items, () => uniqueId.value++, {deep: true})
 

--- a/tests/Browser/RecruitmentConfigTest.php
+++ b/tests/Browser/RecruitmentConfigTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Web\Models\Recruitment\Enlistment;
+
+/*
+ * Recruitment configuration browser test.
+ *
+ * The configuration page (Corporation/Recruitment/Configuration/Index) is corporation-scoped:
+ * EnlistmentsController@edit renders it behind CheckAuthorization:'can open or close corporations
+ * for recruitment,director'. Access is granted here by the in-game Director corp role
+ * (giveCorporationRole) — not superuser — which CanUserService accepts for the ,director gate,
+ * mirroring a real senior-HR director opening their corporation's recruitment settings.
+ *
+ * An Enlistment record must exist for the corporation for @edit to hydrate the page; without it the
+ * `enlistment` prop is null and the page cannot render the (edit-mode) config card. Provisioning
+ * helpers (actingAsCharacter, giveCorporationRole) live in the core app's tests/Browser/Pest.php —
+ * browser tests run against the assembled core, whose Pest.php is not overlaid here, so the two
+ * viewport/screenshot helpers below are defined guarded alongside the suite's other tests.
+ */
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('deviceVisit')) {
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+it('a corp admin sees the recruitment configuration', function (string $device) {
+    $character = actingAsCharacter();
+    $corporationId = $character->corporation->corporation_id;
+
+    // Director corp role → satisfies the ,director branch of the recruitment gate (no superuser).
+    giveCorporationRole($character);
+
+    // The open enlistment @edit hydrates the page from.
+    Enlistment::create([
+        'corporation_id' => $corporationId,
+        'type' => 'user',
+        'steps' => 'First interview; Second interview',
+    ]);
+
+    $page = deviceVisit($device, "/corporation/recruitment/{$corporationId}");
+    $page->assertNoSmoke();
+
+    // Page header + the enlistment config card (edit mode: distinctive "Review Process Steps" field).
+    $page->waitForText('Corporation Enlistment');
+    $page->assertSee('Enlistment');
+    $page->assertSee('Review Process Steps');
+
+    // Region/System filter card and the items watchlist card both render.
+    $page->assertSee('Region or System Filter');
+    $page->assertSee('Items Watchlist');
+
+    // A config form is present: the review-process-steps input and the save actions render.
+    $page->assertScript("!!document.querySelector('#steps')");
+    $page->assertSee('Save');
+
+    snap($page, "recruitment-config-{$device}");
+})->with(['desktop', 'iphone']);


### PR DESCRIPTION
## What

Removes every Ziggy `route()` call from the **recruitment configuration** pages, wiring them to typed Wayfinder imports, and standardizes the repeated hand-rolled indigo submit `<button>`s onto the shared `Shared/Layout/Button.vue`.

## Changes

`resources/js/Pages/Corporation/Recruitment/Configuration/`:

- **Index.vue** (3 `route()` removed)
  - `delete.enlistment` → `deleteMethod` (Wayfinder renames the reserved `delete` method) from `EnlistmentsController`, via a `deleteUrl` computed for the template.
  - `corporation.recruitment` breadcrumb → `GetRecruitmentIndexController.url()` (invokable).
  - `update.watchlist` → `updateWatchlist.url(...)`; the region/system save now uses `this.form.post(...)` over `enlistment.corporation_id` (previously posted to an **undefined** `this.corporationId`).
- **EnlistmentConfig.vue** (1) — `create.corporation.recruitment` → `create.url()`.
- **ItemsWatchlist.vue** (1) — `update.watchlist` → `updateWatchlist.url(props.corporationId)`.

Each `TwoColumnCardWithSubmitAction` `#button` slot's bespoke indigo `<button>` is replaced with `<Button :is-inertia-button="false" @click="submit">Save</Button>`.

`CreateEnlistmentModal.vue` contained no `route()` calls (it only renders `EnlistmentConfig`); no change needed.

The Autosuggest `route-name` props (`get.affiliated.corporations`, `autosuggestion.typesOrGroupOrCategories`) are component contracts, not `route()` calls, and are left as-is.

## Test

Adds `tests/Browser/RecruitmentConfigTest.php`: a director (via `giveCorporationRole`, satisfying the `,director` branch of the recruitment gate) opens their corporation's `/corporation/recruitment/{id}` configuration and the test asserts the enlistment config, region/system filter, and items watchlist render with a config form present (desktop + iPhone, `snap()`).

## Verification

- `eslint` on the changed `.vue` files → 0 errors (only pre-existing `v-on-event-hyphenation` warnings on untouched lines).
- `pint` on the new test → passed.
- Not run (per scope): pest, `npm run build`, `wayfinder:generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)