### PR TITLE
refactor: drop axios + Ziggy from member compliance + polish

### DIFF
--- a/resources/js/Pages/Corporation/MemberCompliance/CharacterComplianceElement.vue
+++ b/resources/js/Pages/Corporation/MemberCompliance/CharacterComplianceElement.vue
@@ -5,7 +5,7 @@
         <EveImage
           :object="character"
           :size="256"
-          tailwind_class="`h-8 w-8 rounded-full"
+          tailwind_class="h-8 w-8 rounded-full"
         />
         <!--        <span class="absolute bottom-0 right-0 block h-2 w-2 rounded-full ring-2 ring-white bg-red-400" />-->
         <div

--- a/resources/js/Pages/Corporation/MemberCompliance/ComplianceComponent.vue
+++ b/resources/js/Pages/Corporation/MemberCompliance/ComplianceComponent.vue
@@ -46,21 +46,26 @@
       </div>
 
       <ul class="relative z-0">
-        <CompleteLoadingHelper
-          :key="Object.values(urlParams).join(',')"
-          route-name="corporation.compliance"
-          :params="urlParams"
-          @results="(results) => rawUsers = results"
+        <MemberComplianceListElement
+          v-for="(user, index) in users"
+          :key="user.id"
+          :user="user"
+          :can-review="canReview"
+          :corporation-id="corporation.corporation_id"
+          :even="index%2 === 0"
+        />
+        <li
+          v-if="loading"
+          class="flex justify-center py-4 text-sm text-gray-500"
         >
-          <MemberComplianceListElement
-            v-for="(user, index) in users"
-            :key="user.id"
-            :user="user"
-            :can-review="canReview"
-            :corporation-id="corporation.corporation_id"
-            :even="index%2 === 0"
-          />
-        </CompleteLoadingHelper>
+          loading resource
+        </li>
+        <li
+          v-else-if="users.length === 0"
+          class="flex justify-center py-4 text-sm text-gray-500"
+        >
+          no entries
+        </li>
       </ul>
     </div>
   </CardWithHeader>
@@ -71,12 +76,12 @@ import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import { MagnifyingGlassIcon } from '@heroicons/vue/20/solid'
 import MemberComplianceListElement from "./MemberComplianceListElement.vue";
-import {computed, ref, watch} from "vue";
-import CompleteLoadingHelper from "@/Shared/Layout/CompleteLoadingHelper.vue";
+import {computed, onMounted, ref, watch} from "vue";
+import { getJson } from "@/Functions/http";
+import { getCorporationCompliance } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController";
 export default {
     name: "ComplianceComponent",
     components: {
-        CompleteLoadingHelper,
         MemberComplianceListElement,
         EntityBlock, CardWithHeader, MagnifyingGlassIcon},
     props: {
@@ -90,17 +95,13 @@ export default {
         },
         canReview: {
             type: Boolean,
-            required: true,
-            default: false
+            required: true
         }
     },
     setup(props) {
         const rawUsers = ref([])
         const search = ref('')
-        const urlParams = ref({
-            corporation_id: props.corporation.corporation_id,
-            type: props.corporation.type
-        })
+        const loading = ref(true)
 
         const users = computed(() => {
 
@@ -115,15 +116,38 @@ export default {
             return rawUsers.value
         })
 
-        watch(search,(newValue) => {
-            newValue.length >= 3 ? urlParams.value.search = newValue : delete urlParams.value.search
-        })
+        const load = async () => {
+            loading.value = true
+
+            // Only forward the search term once it is specific enough to matter; an empty query
+            // fetches the full corporation membership again (mirrors the previous urlParams idiom).
+            const query = search.value.length >= 3 ? { search: search.value } : {}
+
+            const url = getCorporationCompliance.url(
+                {
+                    corporation_id: props.corporation.corporation_id,
+                    type: props.corporation.type,
+                },
+                { query },
+            )
+
+            const response = await getJson(url)
+
+            rawUsers.value = response.data
+            loading.value = false
+        }
+
+        const debouncedLoad = _.debounce(load, 300)
+
+        watch(search, debouncedLoad)
+
+        onMounted(load)
 
         return {
             rawUsers,
             users,
             search,
-            urlParams
+            loading,
         }
     }
 }

--- a/resources/js/Pages/Corporation/MemberCompliance/ComplianceTabs.vue
+++ b/resources/js/Pages/Corporation/MemberCompliance/ComplianceTabs.vue
@@ -1,73 +1,30 @@
 <template>
-  <div>
-    <div class="sm:hidden">
-      <label
-        for="tabs"
-        class="sr-only"
-      >Select a tab</label>
-      <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-      <select
-        id="tabs"
-        name="tabs"
-        class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md"
-        @change="$emit('update:modelValue', $event.target.value)"
-      >
-        <option
-          v-for="tab in tabs"
-          :key="tab.name"
-          :selected="tab.current"
-          :value="tab.value"
-        >
-          {{ tab.name }}
-        </option>
-      </select>
-    </div>
-    <div class="hidden sm:block">
-      <nav
-        class="flex space-x-4"
-        aria-label="Tabs"
-      >
-        <button
-          v-for="tab in tabs"
-          :key="tab.name"
-          :class="[tab.current ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700', 'px-3 py-2 font-medium text-sm rounded-md']"
-          :aria-current="tab.current ? 'page' : undefined"
-          @click="$emit('update:modelValue', tab.value)"
-        >
-          {{ tab.name }}
-        </button>
-      </nav>
-    </div>
-  </div>
+  <BarWithUnderline
+    :tabs="tabs"
+    @select="(tab) => $emit('update:modelValue', tab.value)"
+  />
 </template>
 
 <script>
-import {computed} from "vue";
+import BarWithUnderline from "@/Shared/Layout/Tabs/BarWithUnderline.vue";
 
-const raw_tabs = [
-    { name: 'Default', value: 'default' },
-    { name: 'Renegades only', value: 'renegades'},
-    { name: 'Loyalists only', value: 'loyalists' },
+const tabs = [
+    { id: 0, name: 'Default', value: 'default' },
+    { id: 1, name: 'Renegades only', value: 'renegades' },
+    { id: 2, name: 'Loyalists only', value: 'loyalists' },
 ]
 
 export default {
     name: "ComplianceTabs",
+    components: {BarWithUnderline},
     props: {
         modelValue: {
             type: String,
-            required: true,
-            default: 'default'
+            required: true
         }
     },
-emits: ['update:modelValue'],
-    setup(props) {
-
-        const tabs = computed(() => _.map(raw_tabs, function (tab) {
-
-            tab.current = _.isEqual(tab.value, props.modelValue)
-            return tab
-        }))
-
+    emits: ['update:modelValue'],
+    setup() {
         return {
             tabs,
         }

--- a/resources/js/Pages/Corporation/MemberCompliance/MemberComplianceListElement.vue
+++ b/resources/js/Pages/Corporation/MemberCompliance/MemberComplianceListElement.vue
@@ -37,7 +37,7 @@
       <div class="flex gap-x-2 flex-wrap">
         <Button
           button-size="xs"
-          :href="route('corporation.review.user', {'corporation_id': corporationId, 'user': user.id})"
+          :href="reviewUrl"
         >
           Review
         </Button>
@@ -51,6 +51,7 @@ import {computed} from "vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import CharacterComplianceElement from "./CharacterComplianceElement.vue";
 import Button from "@/Shared/Layout/Button.vue";
+import { reviewUser } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController";
 
 export default {
     name: "MemberComplianceListElement",
@@ -85,10 +86,16 @@ export default {
 
         const compliantCharacters = computed(() => _.filter(characters.value, (character) => character.missing_scopes.length === 0))
 
+        const reviewUrl = computed(() => reviewUser.url({
+            corporation_id: props.corporationId,
+            user: props.user.id,
+        }))
+
         return {
             characters,
             nonCompliantCharacters,
-            compliantCharacters
+            compliantCharacters,
+            reviewUrl
         }
     }
 }

--- a/resources/js/Pages/Corporation/MemberCompliance/ReviewUser.vue
+++ b/resources/js/Pages/Corporation/MemberCompliance/ReviewUser.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-3">
     <div>
-      <PageHeader :breadcrumbs="[{name: 'Compliance ', route: route('corporation.member_compliance')}]">
+      <PageHeader :breadcrumbs="[{name: 'Compliance', route: complianceIndex}]">
         Review: {{ member.main_character.name }}
       </PageHeader>
       <div class="pt-1.5">
@@ -22,6 +22,7 @@
 <script>
 import TabComponent from "../Recruitment/TabComponent.vue";
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
+import { index } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController";
 export default {
     name: "ReviewUser",
     components: {PageHeader, TabComponent},
@@ -38,6 +39,11 @@ export default {
             required: true,
             type: Object
         },
+    },
+    setup() {
+        return {
+            complianceIndex: index.url()
+        }
     },
     methods: {
         getCharacterNames(member) {

--- a/src/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController.php
+++ b/src/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController.php
@@ -91,7 +91,7 @@ class MemberComplianceController
                 'application.corporation.alliance.ssoScopes',
             ]);
 
-        return CorporationComplianceResource::collection($users->paginate());
+        return CorporationComplianceResource::collection($users->get());
     }
 
     public function reviewUser(int $corporation_id, User $user, WatchlistArrayAction $action): Response

--- a/tests/Browser/MemberComplianceTest.php
+++ b/tests/Browser/MemberComplianceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Auth\Models\CharacterUser;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\SsoScopes;
+
+if (! function_exists('deviceVisit')) {
+    /**
+     * Visit $url on the given viewport ("desktop" or "iphone"). Browser tests run in the core app,
+     * whose tests/Pest.php is not overlaid, so this helper is defined here (guarded) alongside the
+     * suite's other function_exists helpers rather than in tests/Pest.php.
+     */
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        // iPhone: build a persistent page at the mobile viewport the same way visit() builds the
+        // desktop one, so the page loads mobile from the start (no desktop-load-then-resize reflow,
+        // no per-call re-navigation like ->on()->iPhone15()).
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    /**
+     * Settle before screenshotting: flip lazy EVE-image portraits/logos to eager so off-screen
+     * (full-page) images fetch, wait for the network to go idle, then capture — so screenshots show
+     * resolved images instead of loading placeholders. Best-effort: a slow/absent image won't fail.
+     */
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+if (! function_exists('complianceMember')) {
+    /**
+     * Create a member User owning a single character that belongs to the given corporation, so the
+     * user shows up in that corporation's compliance list. Mirrors actingAsCharacter() but for a
+     * plain (non-acting) member: the CharacterInfo factory places the character in a random corp,
+     * so repoint its affiliation at the target corporation.
+     */
+    function complianceMember(int $corporationId): CharacterInfo
+    {
+        $character = CharacterInfo::factory()->create();
+        $character->characterAffiliation->update(['corporation_id' => $corporationId]);
+
+        $user = new User;
+        $user->main_character_id = $character->character_id;
+        $user->save();
+
+        CharacterUser::create([
+            'user_id' => $user->getKey(),
+            'character_id' => $character->character_id,
+            'character_owner_hash' => sha1((string) $character->character_id),
+        ]);
+
+        return $character->refresh();
+    }
+}
+
+/*
+ * Corporation member-compliance browser test.
+ *
+ * Access is granted by the in-game Director corp role (giveCorporationRole) — not superuser —
+ * which CanUserService accepts, mirroring a real director reviewing their corp's SSO-scope
+ * compliance. The corporation only surfaces on the index once it carries an SsoScopes requirement,
+ * so one is attached. The member list itself is loaded asynchronously (fetch → getJson against the
+ * Wayfinder `getCorporationCompliance` endpoint, which now returns ->get() instead of ->paginate()),
+ * so we wait for a row to resolve before asserting / screenshotting. Provisioning helpers live in
+ * core's tests/Pest.php (actingAsCharacter / giveCorporationRole).
+ */
+
+uses(RefreshDatabase::class);
+
+it('lists corporation members and their sso scope compliance', function (string $device) {
+    $character = actingAsCharacter();
+    $corporationId = $character->corporation->corporation_id;
+
+    // Director corp role → grants member-compliance access (no superuser / Spatie permission).
+    giveCorporationRole($character);
+
+    // A corporation only appears on the compliance index once it has an SsoScopes requirement.
+    // Require a scope the members do not hold so they render as non-compliant ("renegades").
+    SsoScopes::updateOrCreate(
+        ['morphable_id' => $corporationId],
+        [
+            'morphable_type' => CorporationInfo::class,
+            'type' => 'default',
+            'selected_scopes' => ['esi-assets.read_assets.v1'],
+        ],
+    );
+
+    // A couple of additional members so the list renders multiple rows.
+    complianceMember($corporationId);
+    complianceMember($corporationId);
+
+    $page = deviceVisit($device, '/corporation/compliance');
+    $page->assertNoSmoke();
+    $page->assertSee('Corporation Member Compliance');
+
+    // The member list is fetched asynchronously, so wait for the acting director's own row to
+    // resolve before asserting the list rendered.
+    $page->waitForText($character->name);
+    $page->assertSee($character->name);
+    $page->assertSee('Main Character');
+
+    snap($page, "corporation-member-compliance-{$device}");
+})->with(['desktop', 'iphone']);


### PR DESCRIPTION
Supersedes #1573.

Migrates the **Corporation Member Compliance** UI off the axios + Ziggy (`route()`) stack, mirroring the phased Axios/Ziggy removal already applied to wallet, mails, contracts and corp history. `@inertiajs/vue3` is v2 here (no `useHttp`), so non-Inertia JSON is fetched via the native-fetch wrapper `Functions/http.js` with URLs built from Wayfinder actions.

## Changes

**Frontend** (`resources/js/Pages/Corporation/MemberCompliance/`)
- `ComplianceComponent.vue` — drops `CompleteLoadingHelper` (axios + `route-name`). This component is rendered multi-instance (one per corporation), so it now fetch-swaps directly: `getJson(getCorporationCompliance.url({ corporation_id, type }, { query: { search } }))`, debounced search input, reads `response.data`. Adds loading + empty states.
- `MemberComplianceListElement.vue` / `ReviewUser.vue` — `route(...)` → Wayfinder `@/actions` imports (`reviewUser`, `index`).
- `CharacterComplianceElement.vue` — fixes a stray backtick in the `EveImage` `tailwind_class` binding (`` `h-8 `` → `h-8`).
- `ComplianceTabs.vue` — replaces the hand-rolled `<select>`/`<button>` tab pair with the shared `Shared/Layout/Tabs/BarWithUnderline.vue`.
- `MemberCompliance.vue` is already modern — left as-is.

**Backend**
- `MemberComplianceController::getCorporationCompliance` returns `->get()` instead of `->paginate()` (the list is fully client-filtered; the tabs and search do the narrowing).

## Tests
- Existing `ComplianceLifeCycleTest` asserts `assertJsonCount(N, 'data')`, which still holds for a resource collection over `->get()` — no pagination meta was asserted, so no test changes were needed.
- Adds `tests/Browser/MemberComplianceTest.php` — director corp-role access (via `CanUserService`, no superuser), real EVE ids, desktop + iPhone snapshots.

## Verification
- `eslint` on all 5 changed `.vue` files → clean (also cleaned two pre-existing `required + default` prop warnings).
- `pint` on the controller and browser test → passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)