### PR TITLE
refactor: Member Tracking → Inertia InfiniteScroll (drop axios/Ziggy) + polish

### DIFF
--- a/resources/js/Pages/Corporation/MemberTracking/MemberTrackingComponent.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTrackingComponent.vue
@@ -9,44 +9,79 @@
       </div>
     </template>
 
-    <div class="relative max-h-96 overflow-y-auto">
-      <div class="hidden sm:grid grid-cols-12 gap-x-0 gap-y-1 grid-flow-row z-10 sticky top-0 border-t border-b border-gray-200 bg-gray-50 text-sm font-medium text-gray-500">
-        <div class="px-3 py-1">
-          Token
-        </div>
-        <div class="px-3 py-1 col-span-3">
-          Name
-        </div>
-        <div class="px-3 py-1 col-span-3">
-          Last Location
-        </div>
-        <div class="px-3 py-1 col-span-3">
-          Ship
-        </div>
-        <div class="px-3 py-1">
-          Joined
-        </div>
-        <div class="px-3 py-1">
-          Last Login
-        </div>
-      </div>
+    <!-- scroll-region: lets Inertia track/restore this custom scroll container's
+         position, so <InfiniteScroll> merges the next page without jumping to top. -->
+    <div
+      class="relative max-h-96 overflow-y-auto"
+      scroll-region=""
+    >
+      <!-- Member list is delivered as a per-corporation page scroll prop
+           (MemberTrackingController::index → members_<corporation>), consumed here via
+           native Inertia infinite scroll. Replaces the axios/Ziggy useInfinityScrolling loader. -->
+      <InfiniteScroll
+        :data="scrollKey"
+        :items-element="`#${bodyId}`"
+        preserve-url
+      >
+        <StickyHeaderTable
+          :header-titles="headerTitles"
+          :body-id="bodyId"
+        >
+          <template #default="{ countColumns, columns }">
+            <MemberTrackingListElementForSmallDevices
+              v-for="member in members"
+              :key="`mobile-${member.character_id}`"
+              :member="member"
+              :required_scopes="corporation.required_scopes"
+            />
+            <MemberTrackingListElement
+              v-for="member in members"
+              :key="`desktop-${member.character_id}`"
+              :member="member"
+              :required_scopes="corporation.required_scopes"
+              :columns="columns"
+              :count-columns="countColumns"
+            />
+          </template>
+        </StickyHeaderTable>
 
-      <ul class="relative z-0">
-        <MemberTrackingListElementForSmallDevices
-          v-for="member in result"
-          :key="member.character_id"
-          :member="member"
-          :required_scopes="corporation.required_scopes"
-        />
-        <MemberTrackingListElement
-          v-for="(member, index) in result"
-          :key="member.character_id"
-          :member="member"
-          :required_scopes="corporation.required_scopes"
-          :even="index%2"
-        />
-        <div ref="scrollComponent" />
-      </ul>
+        <!-- Shown in whichever trigger is fetching the next/previous page. -->
+        <template #loading>
+          <div class="relative block w-full py-6 text-center">
+            <svg
+              class="animate-spin mx-auto h-8 w-8 text-gray-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              />
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            <span class="mt-2 block text-sm font-medium text-gray-500">
+              loading more members…
+            </span>
+          </div>
+        </template>
+      </InfiniteScroll>
+
+      <!-- Empty state: no member-tracking rows for this corporation yet. -->
+      <div
+        v-if="members.length === 0"
+        class="py-10 text-center text-sm font-medium text-gray-500"
+      >
+        No member tracking data available.
+      </div>
     </div>
   </CardWithHeader>
 </template>
@@ -54,15 +89,29 @@
 <script>
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
+import StickyHeaderTable from "@/Shared/Layout/Table/StickyHeaderTable.vue";
 import MemberTrackingListElement from "./MemberTrackingListElement.vue";
-import {useInfinityScrolling} from "@/Functions/useInfinityScrolling";
 import MemberTrackingListElementForSmallDevices from "./MemberTrackingListElementForSmallDevices.vue";
+import { InfiniteScroll } from "@inertiajs/vue3";
+
+const headerTitles = [
+    {title: 'Token', columnSpan: 1},
+    {title: 'Name', columnSpan: 3},
+    {title: 'Last Location', columnSpan: 3},
+    {title: 'Ship', columnSpan: 3},
+    {title: 'Joined', columnSpan: 1},
+    {title: 'Last Login', columnSpan: 1},
+];
 
 export default {
     name: "MemberTrackingComponent",
     components: {
+        InfiniteScroll,
+        StickyHeaderTable,
         MemberTrackingListElementForSmallDevices,
-        MemberTrackingListElement, EntityBlock, CardWithHeader
+        MemberTrackingListElement,
+        EntityBlock,
+        CardWithHeader,
     },
     props: {
         corporation: {
@@ -70,9 +119,22 @@ export default {
             type: Object
         },
     },
-    setup(props) {
-
-        return useInfinityScrolling('get.corporation.member_tracking', {corporation_id: props.corporation.corporation_id})
+    setup() {
+        return {
+            headerTitles,
+        }
+    },
+    computed: {
+        // Matches the CorporationMemberTrackingController scroll prop key.
+        scrollKey() {
+            return `members_${this.corporation.corporation_id}`
+        },
+        bodyId() {
+            return `member-tracking-body-${this.corporation.corporation_id}`
+        },
+        members() {
+            return this.$page.props[this.scrollKey]?.data ?? []
+        }
     }
 }
 </script>

--- a/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElement.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElement.vue
@@ -1,59 +1,77 @@
 <template>
-  <li
-    :class="[even ? 'bg-gray-50' : 'bg-white']"
-    class="hidden sm:grid grid-cols-12 gap-x-0 sm:gap-y-1 grid-flow-row justify-items-auto text-sm text-gray-500 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
-  >
-    <div class="px-3 py-4 sm:py-1 self-center whitespace-normal">
-      <CheckCircleIcon
-        v-if="isOk"
-        class="h-5 w-5 text-emerald-500"
-      />
-      <XCircleIcon
-        v-else
-        class="h-5 w-5 text-red-500"
-      />
-    </div>
+  <li class="hidden sm:block">
+    <StickyHeaderTableRow :number-columns="countColumns">
+      <StickyHeaderCell
+        :cell="columns[0]"
+        class="self-center"
+      >
+        <CheckCircleIcon
+          v-if="isOk"
+          class="h-5 w-5 text-emerald-500"
+        />
+        <XCircleIcon
+          v-else
+          class="h-5 w-5 text-red-500"
+        />
+      </StickyHeaderCell>
 
-    <div class="px-3 py-4 sm:py-1 self-center whitespace-normal col-span-3">
-      <EntityBlock
-        v-if="member.character"
-        :entity="member.character"
-        :image-size="8"
-        name-font-size="md"
-      />
-      <EntityByIdBlock
-        v-else
-        :id="member.character_id"
-        :with-sub-text="false"
-        :image-size="8"
-        name-font-size="md"
-      />
-    </div>
+      <StickyHeaderCell
+        :cell="columns[1]"
+        class="self-center"
+      >
+        <EntityBlock
+          v-if="member.character"
+          :entity="member.character"
+          :image-size="8"
+          name-font-size="md"
+        />
+        <EntityByIdBlock
+          v-else
+          :id="member.character_id"
+          :with-sub-text="false"
+          :image-size="8"
+          name-font-size="md"
+        />
+      </StickyHeaderCell>
 
-    <div class="px-3 py-4 sm:py-1 self-center whitespace-normal col-span-3">
-      {{ locationName }}
-    </div>
+      <StickyHeaderCell
+        :cell="columns[2]"
+        class="self-center"
+      >
+        {{ locationName }}
+      </StickyHeaderCell>
 
-    <div class="px-3 py-4 sm:py-1 self-center whitespace-normal col-span-3">
-      <EntityBlock
-        :entity="{type_id: member.ship_type_id, name: member.ship?.name}"
-        :image-size="6"
-        name-font-size="sm"
-      />
-    </div>
-    <div class="px-3 py-4 sm:py-1 self-center whitespace-normal">
-      <Time
-        format="YYYY-MM-DD HH:mm:ss"
-        :timestamp="member.start_date"
-      />
-    </div>
+      <StickyHeaderCell
+        :cell="columns[3]"
+        class="self-center"
+      >
+        <EntityBlock
+          :entity="{type_id: member.ship_type_id, name: member.ship?.name}"
+          :image-size="6"
+          name-font-size="sm"
+        />
+      </StickyHeaderCell>
 
-    <div class="px-3 py-4 sm:py-1 self-center whitespace-normal">
-      <Time
-        format="YYYY-MM-DD HH:mm:ss"
-        :timestamp="member.logon_date"
-      />
-    </div>
+      <StickyHeaderCell
+        :cell="columns[4]"
+        class="self-center"
+      >
+        <Time
+          format="YYYY-MM-DD HH:mm:ss"
+          :timestamp="member.start_date"
+        />
+      </StickyHeaderCell>
+
+      <StickyHeaderCell
+        :cell="columns[5]"
+        class="self-center"
+      >
+        <Time
+          format="YYYY-MM-DD HH:mm:ss"
+          :timestamp="member.logon_date"
+        />
+      </StickyHeaderCell>
+    </StickyHeaderTableRow>
   </li>
 </template>
 
@@ -62,15 +80,22 @@ import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/vue/20/solid'
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import Time from "@/Shared/Time.vue";
+import StickyHeaderTableRow from "@/Shared/Layout/Table/StickyHeaderTableRow.vue";
+import StickyHeaderCell from "@/Shared/Layout/Table/StickyHeaderCell.vue";
+
 export default {
     name: "MemberTrackingListElement",
-    components: {Time, EntityByIdBlock, EntityBlock, CheckCircleIcon, XCircleIcon},
+    components: {Time, EntityByIdBlock, EntityBlock, CheckCircleIcon, XCircleIcon, StickyHeaderTableRow, StickyHeaderCell},
     props: {
         member: {
             required: true,
             type: Object
         },
-        even: {
+        columns: {
+            required: true,
+            type: Array
+        },
+        countColumns: {
             required: true,
             type: Number
         },

--- a/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElementForSmallDevices.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElementForSmallDevices.vue
@@ -32,27 +32,11 @@
         <div class="mt-2 sm:flex sm:justify-between">
           <div class="sm:flex">
             <div class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0">
-              <svg
-                class="shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                  clip-rule="evenodd"
-                />
-              </svg>
+              <MapPinIcon class="shrink-0 mr-1.5 h-5 w-5 text-gray-400" />
               {{ locationName }}
             </div>
             <div class="mt-2 mr-6 flex items-center text-sm leading-5 text-gray-500 space-x-1.5">
-              <svg
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                class="shrink-0 h-5 w-5 text-gray-400"
-              >
-                <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z" />
-              </svg>
+              <RocketLaunchIcon class="shrink-0 h-5 w-5 text-gray-400" />
               <EveImage
                 :object="{type_id: member.ship_type_id}"
                 :size="256"
@@ -62,34 +46,14 @@
             </div>
           </div>
           <div class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0">
-            <svg
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              class="mr-1.5 w-5 h-5 text-gray-400"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M6 3a1 1 0 011-1h.01a1 1 0 010 2H7a1 1 0 01-1-1zm2 3a1 1 0 00-2 0v1a2 2 0 00-2 2v1a2 2 0 00-2 2v.683a3.7 3.7 0 011.055.485 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0A3.7 3.7 0 0118 12.683V12a2 2 0 00-2-2V9a2 2 0 00-2-2V6a1 1 0 10-2 0v1h-1V6a1 1 0 10-2 0v1H8V6zm10 8.868a3.704 3.704 0 01-4.055-.036 1.704 1.704 0 00-1.89 0 3.704 3.704 0 01-4.11 0 1.704 1.704 0 00-1.89 0A3.704 3.704 0 012 14.868V17a1 1 0 001 1h14a1 1 0 001-1v-2.132zM9 3a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm3 0a1 1 0 011-1h.01a1 1 0 110 2H13a1 1 0 01-1-1z"
-                clip-rule="evenodd"
-              />
-            </svg>
+            <CalendarIcon class="mr-1.5 w-5 h-5 text-gray-400" />
             <span> Joined <Time
               format="YYYY-MM-DD HH:mm:ss"
               :timestamp="member.start_date"
             /></span>
           </div>
           <div class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0">
-            <svg
-              class="shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
-                clip-rule="evenodd"
-              />
-            </svg>
+            <ClockIcon class="shrink-0 mr-1.5 h-5 w-5 text-gray-400" />
             <span> Last Login <Time
               format="YYYY-MM-DD HH:mm:ss"
               :timestamp="member.logon_date"
@@ -106,10 +70,11 @@ import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import EveImage from "@/Shared/EveImage.vue";
 import Time from "@/Shared/Time.vue";
+import { CalendarIcon, ClockIcon, MapPinIcon, RocketLaunchIcon } from '@heroicons/vue/20/solid'
 
 export default {
     name: "MemberTrackingListElementForSmallDevices",
-    components: {Time, EveImage, EntityByIdBlock, EntityBlock},
+    components: {Time, EveImage, EntityByIdBlock, EntityBlock, CalendarIcon, ClockIcon, MapPinIcon, RocketLaunchIcon},
     props: {
         member: {
             required: true,

--- a/routes/Routes/Corporation/MemberTracking.php
+++ b/routes/Routes/Corporation/MemberTracking.php
@@ -34,8 +34,4 @@ Route::prefix('tracking')
         Route::middleware(CheckAuthorization::class.':view member tracking,director')
             ->get('', [MemberTrackingController::class, 'index'])
             ->name('corporation.member_tracking');
-
-        Route::middleware(CheckAuthorization::class.':view member tracking,director')
-            ->get('/members/{corporation_id}', [MemberTrackingController::class, 'getMemberTracking'])
-            ->name('get.corporation.member_tracking');
     });

--- a/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
+++ b/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
@@ -28,10 +28,8 @@ namespace Seatplus\Web\Http\Controllers\Corporation\MemberTracking;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Inertia\Inertia;
 use Inertia\Response;
-use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
 use Seatplus\Eveapi\Models\SsoScopes;
@@ -48,33 +46,32 @@ class MemberTrackingController extends Controller
             ->setIsCharacter(false)
             ->create(CorporationMemberTracking::class);
 
+        $corporations = $this->getAffiliatedCorporations($dispatchTransferObject);
+
+        // One native infinite-scroll prop per affiliated corporation (the page renders a
+        // card per corporation), each with its own pageName so scroll state never collides;
+        // <InfiniteScroll> reads it via the matching `members_<corporation>` key. Replaces
+        // the axios/Ziggy useInfinityScrolling loader against get.corporation.member_tracking.
+        $members = $corporations->mapWithKeys(fn (CorporationInfo $corporation) => [
+            "members_{$corporation->corporation_id}" => Inertia::scroll(
+                fn () => MemberTrackingResource::collection(
+                    $this->memberQuery($corporation->corporation_id)
+                        ->paginate(pageName: "members_{$corporation->corporation_id}")
+                ),
+            ),
+        ])->all();
+
         return Inertia::render('Corporation/MemberTracking/MemberTracking', [
             'dispatchTransferObject' => $dispatchTransferObject,
-            'corporations' => $this->getAffiliatedCorporations($dispatchTransferObject),
+            'corporations' => $corporations,
+            ...$members,
         ]);
     }
 
-    public function getMemberTracking(int $corporation_id): AnonymousResourceCollection
+    private function memberQuery(int $corporation_id): Builder
     {
-        /** @var CorporationInfo|null $corporation */
-        $corporation = CorporationInfo::find($corporation_id);
-
-        /** @var SsoScopes|null $corporation_sso_scopes */
-        $corporation_sso_scopes = $corporation?->ssoScopes;
-        /** @var AllianceInfo|null $alliance */
-        $alliance = $corporation?->alliance;
-        /** @var SsoScopes|null $alliance_sso_scopes */
-        $alliance_sso_scopes = $alliance?->ssoScopes;
-
-        $sso_scopes = collect([
-            'corporation_scopes' => $corporation_sso_scopes?->selected_scopes,
-            'alliance_scopes' => $alliance_sso_scopes?->selected_scopes,
-        ])->flatten(1)->filter();
-
-        $query = CorporationMemberTracking::where('corporation_id', $corporation_id)
+        return CorporationMemberTracking::where('corporation_id', $corporation_id)
             ->with('character.refreshToken', 'location.locatable', 'ship');
-
-        return MemberTrackingResource::collection($query->paginate())->additional(['required_scopes' => $sso_scopes]);
     }
 
     private function getAffiliatedCorporations(DispatchTransferObject $dispatchTransferObject): Collection

--- a/tests/Browser/MemberTrackingTest.php
+++ b/tests/Browser/MemberTrackingTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
+use Seatplus\Eveapi\Models\SsoScopes;
+
+if (! function_exists('deviceVisit')) {
+    /**
+     * Visit $url on the given viewport ("desktop" or "iphone"). Browser tests run in the core app,
+     * whose tests/Pest.php is not overlaid, so this helper is defined here (guarded) alongside the
+     * suite's other function_exists helpers rather than in tests/Pest.php.
+     */
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        // iPhone: build a persistent page at the mobile viewport the same way visit() builds the
+        // desktop one, so the page loads mobile from the start (no desktop-load-then-resize reflow,
+        // no per-call re-navigation like ->on()->iPhone15()).
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    /**
+     * Settle before screenshotting: flip lazy EVE-image portraits/logos to eager so off-screen
+     * (full-page) images fetch, wait for the network to go idle, then capture — so screenshots show
+     * resolved images instead of loading placeholders. Best-effort: a slow/absent image won't fail.
+     */
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+if (! function_exists('realCharacterId')) {
+    /**
+     * A real EVE character id (verified CEO) so images.evetech.net serves a real portrait in
+     * screenshots instead of the generic default it returns for fabricated ids. Picks one not yet
+     * used in this (RefreshDatabase-isolated) test; falls back to a random id if the pool is spent.
+     */
+    function realCharacterId(): int
+    {
+        $pool = [197343093, 1319140135, 92081232, 1191750472, 94391213, 887625289, 1435633555, 1809892636];
+        $available = array_values(array_diff($pool, CharacterInfo::query()->pluck('character_id')->all()));
+
+        return $available[0] ?? fake()->unique()->numberBetween(9000000, 98000000);
+    }
+}
+
+/*
+ * Corporation member-tracking browser test.
+ *
+ * The page renders a card per affiliated corporation, each with its own
+ * members_<corporation> scroll prop (Inertia <InfiniteScroll>). Access is granted by the
+ * in-game Director corp role (giveCorporationRole) — not superuser / Spatie permission —
+ * which CanUserService accepts, mirroring a real director viewing their corp's roster.
+ *
+ * getAffiliatedCorporations only surfaces a corporation that has SsoScopes (or its
+ * alliance does) AND has member-tracking rows, so both are provisioned here.
+ * Provisioning helpers (actingAsCharacter / giveCorporationRole) live in the core suite.
+ */
+
+uses(RefreshDatabase::class);
+
+it('merges the next member tracking page in on scroll', function (string $device) {
+    $character = actingAsCharacter();
+    $corporationId = $character->corporation->corporation_id;
+
+    // Director corp role → grants member-tracking access (no superuser / Spatie permission).
+    giveCorporationRole($character);
+
+    // A corporation only appears on the page if it (or its alliance) has SsoScopes.
+    SsoScopes::factory()->create([
+        'morphable_id' => $corporationId,
+        'morphable_type' => CorporationInfo::class,
+        'type' => 'default',
+        'selected_scopes' => [],
+    ]);
+
+    // 40 tracked members (real EVE character ids while the pool lasts so the first page's
+    // portraits resolve in the screenshot; the rest random), spanning several paginator
+    // pages (default 15/page). start_date/logon_date make the rows render meaningful dates.
+    collect(range(1, 40))->each(function (int $i) use ($corporationId) {
+        $member = CharacterInfo::factory()->create(['character_id' => realCharacterId()]);
+
+        CorporationMemberTracking::factory()->create([
+            'corporation_id' => $corporationId,
+            'character_id' => $member->character_id,
+            'start_date' => now()->subDays($i * 10),
+            'logon_date' => now()->subDays($i),
+        ]);
+    });
+
+    // Scroll the list's own container to the bottom → InfiniteScroll's end trigger fires and
+    // merges the next page. assertScript auto-polls until the row count grows, so there's no
+    // fixed-wait timing assumption. Each member renders two <li> (a desktop row + a mobile
+    // card, one hidden per viewport), so the count grows in step either way.
+    $bodyId = "member-tracking-body-{$corporationId}";
+    $rows = "#{$bodyId} > li";
+
+    $page = deviceVisit($device, '/corporation/tracking');
+    $page->assertNoSmoke();
+    $page->waitForText('Last Login');
+
+    $before = (int) $page->script("document.querySelectorAll('{$rows}').length");
+    expect($before)->toBeGreaterThan(0);
+
+    // Re-scroll to the bottom on every poll (comma expression) so the observer reliably fires
+    // even if layout hadn't settled on the first attempt; passes once the next page merged in.
+    $page->assertScript("(document.getElementById('{$bodyId}').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
+
+    snap($page, "corporation-member-tracking-infinite-scroll-{$device}");
+})->with(['desktop', 'iphone']);


### PR DESCRIPTION
## What

Migrates the corporation **Member Tracking** view from the legacy axios/Ziggy `useInfinityScrolling` loader to Inertia v3 native `<InfiniteScroll>`, and applies the light UI polish tracked in roadmap B1/B2.

## Backend

- `MemberTrackingController::index` now serves **one `members_<corporation>` scroll prop per affiliated corporation** via `Inertia::scroll(fn () => MemberTrackingResource::collection($query->paginate(pageName: "members_<corporation>")))`. Each paginator uses its own `pageName` so per-corporation scroll state never collides (same idiom as the merged corporation-wallet controller).
- The `MemberTrackingResource` transformation is preserved (Inertia scroll supports API-resource-wrapped paginators).
- Removes the now-dead `getMemberTracking` action and the `get.corporation.member_tracking` route (the only consumer was the old JS loader).

## Frontend

- `MemberTrackingComponent.vue` renders the list with `<InfiniteScroll>` inside a `scroll-region` container, targeting the row `<ul>` via `items-element`, with a `#loading` spinner and an empty state. Copied from the `AssetsComponent` / `DesktopMailList` idiom.
- The hand-rolled `grid-cols-12` table is replaced with the shared **`StickyHeaderTable` (+ `StickyHeaderTableRow` / `StickyHeaderCell`)** (per `ApplicationsTable.vue`).
- The desktop/mobile split is kept: `MemberTrackingListElement` (desktop rows) now uses the shared table cells; `MemberTrackingListElementForSmallDevices` (mobile card) keeps its layout but its inline hand-drawn `<svg>` icons are replaced with `@heroicons/vue/20/solid` components (`MapPinIcon`, `RocketLaunchIcon`, `CalendarIcon`, `ClockIcon`).

## Tests

- Adds `tests/Browser/MemberTrackingTest.php` (desktop + iPhone) asserting the next member page merges in on scroll, gated by the **Director** corp role (not superuser), with an `SsoScopes` record + 40 tracked members provisioned.
- Existing `CorporationMemberTrackingTest` feature test is unaffected (it only asserts `dispatchTransferObject`).

## Verification

- `eslint` on the 3 changed `.vue` files → 0 errors (2 pre-existing `required_scopes` prop-casing warnings, unchanged).
- `pint` on the changed `.php` files → passed.
- Not run (per task): pest, npm build, wayfinder:generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)