### PR TITLE
refactor: migrate ContractComponent recruitment/watchlist branch to InfiniteScroll

### DIFF
--- a/resources/js/Pages/Corporation/Recruitment/Tabs/ContractTab.vue
+++ b/resources/js/Pages/Corporation/Recruitment/Tabs/ContractTab.vue
@@ -8,7 +8,7 @@
     v-for="character_id in characterIds"
     :id="character_id"
     :key="`${character_id}:${activeTabId}`"
-    :watchlist="activeTabId === 1 ? watchlist : {}"
+    :scroll-key="scrollKey(character_id)"
   />
 </template>
 
@@ -43,11 +43,18 @@ export default {
 
         const activeTabId = ref(hasWatchlist.value ? 1 : 2)
 
+        // Tab 1 (Watchlisted) reads the watchlist-filtered scroll prop; tab 2 (All) the full one.
+        // Both are emitted per character by the recruitment/review controllers.
+        const scrollKey = (characterId) => activeTabId.value === 1
+            ? `watchlisted_contracts_${characterId}`
+            : `contracts_${characterId}`
+
         return {
             tabs: raw_tabs,
             changeActiveTab,
             hasWatchlist,
-            activeTabId
+            activeTabId,
+            scrollKey
         }
     }
 }

--- a/resources/js/Shared/Components/Contracts/ContractComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ContractComponent.vue
@@ -16,11 +16,11 @@
          <InfiniteScroll> merges the next page without jumping to top. -->
     <div
       class="relative max-h-96 overflow-y-auto"
-      :scroll-region="scrollKey ? '' : null"
+      scroll-region=""
     >
-      <!-- Character page: contracts delivered as a page scroll prop → Inertia InfiniteScroll. -->
+      <!-- Both the character page and the recruitment/watchlist tab deliver contracts as a
+           page scroll prop (keyed via scrollKey) → native Inertia <InfiniteScroll>. -->
       <InfiniteScroll
-        v-if="scrollKey"
         :data="scrollKey"
         :items-element="`#${scrollBodyId}`"
         preserve-url
@@ -41,27 +41,6 @@
           </template>
         </StickyHeaderTable>
       </InfiniteScroll>
-
-      <!-- Recruitment (watchlist): still the axios helper against the details endpoint. -->
-      <InfiniteLoadingHelper
-        v-else
-        v-slot="{results}"
-        route-name="character.contracts.details"
-        :params="parameters"
-      >
-        <StickyHeaderTable :header-titles="headerTitles">
-          <template #default="slotProps">
-            <ContractRowComponent
-              v-for="contract in results"
-              :key="contract.contract_id"
-              :contract="contract"
-              :columns="slotProps.columns"
-              :count-columns="slotProps.countColumns"
-              :character-id="id"
-            />
-          </template>
-        </StickyHeaderTable>
-      </InfiniteLoadingHelper>
     </div>
   </CardWithHeader>
 </template>
@@ -70,7 +49,6 @@
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import StickyHeaderTable from "@/Shared/Layout/Table/StickyHeaderTable.vue";
-import InfiniteLoadingHelper from "@/Shared/InfiniteLoadingHelper.vue";
 import { InfiniteScroll } from "@inertiajs/vue3";
 import ContractRowComponent from "./ContractRowComponent.vue";
 
@@ -79,7 +57,6 @@ export default {
     components: {
         InfiniteScroll,
         ContractRowComponent,
-        InfiniteLoadingHelper,
         StickyHeaderTable,
         CardWithHeader,
         EntityByIdBlock,
@@ -89,22 +66,12 @@ export default {
             required: true,
             type: Number
         },
-        type: {
-            required: false,
-            type: String,
-            default: 'character'
-        },
-        watchlist: {
-            required: false,
-            type: Object,
-            default: () => new Object()
-        },
-        // When set (character page) contracts come from this page scroll prop via
-        // <InfiniteScroll>. When null (recruitment) the axios helper + watchlist is used.
+        // Page scroll prop key holding this list's contracts paginator. The character page
+        // passes `contracts_<id>`; the recruitment tab passes `contracts_<id>` (all) or
+        // `watchlisted_contracts_<id>` (watchlist-filtered) depending on the active sub-tab.
         scrollKey: {
-            required: false,
+            required: true,
             type: String,
-            default: null,
         },
     },
     computed: {
@@ -123,9 +90,6 @@ export default {
         scrollEntries() {
             return this.$page.props[this.scrollKey]?.data ?? []
         },
-        parameters() {
-            return {...this.watchlist, character_id: this.id}
-        }
     }
 }
 </script>

--- a/src/Http/Actions/Corporation/Recruitment/RecruitContractScrollPropsAction.php
+++ b/src/Http/Actions/Corporation/Recruitment/RecruitContractScrollPropsAction.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019, 2020, 2021 Felix Huber
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace Seatplus\Web\Http\Actions\Corporation\Recruitment;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Inertia\Inertia;
+use Seatplus\Eveapi\Models\Contracts\Contract;
+use Seatplus\Web\Http\Resources\ContractRessource;
+use Seatplus\Web\Services\Query\LocationWatchListScope;
+use Seatplus\Web\Services\Query\TypeWatchListScope;
+
+/**
+ * Builds the page scroll props the recruitment/review contract tab renders through native
+ * Inertia <InfiniteScroll>, replacing the legacy axios character.contracts.details endpoint.
+ * For each character it emits both the full list (contracts_<id>) and the watchlist-filtered
+ * list (watchlisted_contracts_<id>), each with its own pageName so their scroll state never
+ * collides.
+ */
+class RecruitContractScrollPropsAction
+{
+    /**
+     * @param  array<int, int>  $characterIds
+     * @param  array<string, mixed>  $watchlist
+     * @return array<string, mixed>
+     */
+    public function execute(array $characterIds, array $watchlist): array
+    {
+        return Collection::make($characterIds)
+            ->mapWithKeys(fn (int $characterId): array => [
+                "contracts_{$characterId}" => Inertia::scroll(
+                    fn () => $this->query($characterId)
+                        ->paginate(pageName: "contracts_{$characterId}")
+                        ->through(fn (Contract $contract) => (new ContractRessource($contract))->resolve()),
+                ),
+                "watchlisted_contracts_{$characterId}" => Inertia::scroll(
+                    fn () => $this->query($characterId)
+                        ->tap(new LocationWatchListScope($watchlist))
+                        ->tap(new TypeWatchListScope($watchlist))
+                        ->paginate(pageName: "watchlisted_contracts_{$characterId}")
+                        ->through(fn (Contract $contract) => (new ContractRessource($contract))->resolve()),
+                ),
+            ])
+            ->all();
+    }
+
+    /**
+     * Base query for a character's contracts with everything the row cells render (mirrors
+     * ContractsController::contractsQuery).
+     *
+     * @return Builder<Contract>
+     */
+    private function query(int $characterId): Builder
+    {
+        return Contract::whereHas('characters', fn (Builder $query) => $query->where('character_id', $characterId))
+            ->with(['items', 'items.type', 'items.type.group', 'startLocation.locatable', 'endLocation.locatable', 'assigneeCharacter', 'assigneeCorporation', 'issuerCharacter', 'issuerCorporation']);
+    }
+}

--- a/src/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController.php
+++ b/src/Http/Controllers/Corporation/MemberCompliance/MemberComplianceController.php
@@ -33,6 +33,7 @@ use Inertia\Response;
 use Seatplus\Auth\Models\User;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\SsoScopes;
+use Seatplus\Web\Http\Actions\Corporation\Recruitment\RecruitContractScrollPropsAction;
 use Seatplus\Web\Http\Actions\Corporation\Recruitment\WatchlistArrayAction;
 use Seatplus\Web\Http\Resources\CorporationComplianceResource;
 use Seatplus\Web\Services\GetAffiliatedIds;
@@ -106,11 +107,18 @@ class MemberComplianceController
                 'mainCharacter',
             ]);
 
+        $watchlist = $action->execute($corporation_id);
+
+        $characterIds = $member->characters->pluck('character_id')->all();
+
         return inertia('Corporation/MemberCompliance/ReviewUser', [
             'member' => $member,
             'targetCorporation' => CorporationInfo::find($corporation_id),
-            'watchlist' => $action->execute($corporation_id),
+            'watchlist' => $watchlist,
             'pageTranslations' => Translations::gather(['web::wallet_journal']),
+            // Per-character contract scroll props so the review contract tab renders native
+            // <InfiniteScroll> instead of the legacy axios details endpoint.
+            ...(new RecruitContractScrollPropsAction)->execute($characterIds, $watchlist),
         ]);
     }
 }

--- a/src/Http/Controllers/Corporation/Recruitment/ApplicationsController.php
+++ b/src/Http/Controllers/Corporation/Recruitment/ApplicationsController.php
@@ -40,6 +40,7 @@ use Seatplus\Eveapi\Models\BatchUpdate;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Recruitment\Enlistments;
 use Seatplus\Eveapi\Models\RefreshToken;
+use Seatplus\Web\Http\Actions\Corporation\Recruitment\RecruitContractScrollPropsAction;
 use Seatplus\Web\Http\Actions\Corporation\Recruitment\WatchlistArrayAction;
 use Seatplus\Web\Http\Actions\Recruitment\CreateApplicationLogEntryAction;
 use Seatplus\Web\Http\Actions\Recruitment\DeleteCharacterApplicationAction;
@@ -122,12 +123,23 @@ class ApplicationsController extends Controller
             default => collect([]),
         };
 
+        $watchlist = $action->execute($application->corporation_id);
+
+        $characterIds = collect(data_get($recruit, 'characters', []))
+            ->map(fn ($character): mixed => data_get($character, 'character_id'))
+            ->filter()
+            ->values()
+            ->all();
+
         return inertia('Corporation/Recruitment/Application', [
             'recruit' => $recruit->toArray(),
             'application' => $application,
-            'watchlist' => $action->execute($application->corporation_id),
+            'watchlist' => $watchlist,
             'activeSidebarElement' => 'corporation.recruitment',
             'pageTranslations' => Translations::gather(['web::wallet_journal']),
+            // Per-character contract scroll props so the recruitment contract tab renders
+            // native <InfiniteScroll> instead of the legacy axios details endpoint.
+            ...(new RecruitContractScrollPropsAction)->execute($characterIds, $watchlist),
         ]);
     }
 

--- a/tests/Browser/RecruitmentContractTest.php
+++ b/tests/Browser/RecruitmentContractTest.php
@@ -1,0 +1,199 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Auth\Models\CharacterUser;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Contracts\Contract;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\Universe\Location;
+
+if (! function_exists('deviceVisit')) {
+    /**
+     * Visit $url on the given viewport ("desktop" or "iphone"). Browser tests run in the core app,
+     * whose tests/Pest.php is not overlaid, so this helper is defined here (guarded) alongside the
+     * suite's other function_exists helpers rather than in tests/Pest.php.
+     */
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        // iPhone: build a persistent page at the mobile viewport the same way visit() builds the
+        // desktop one, so the page loads mobile from the start (no desktop-load-then-resize reflow,
+        // no per-call re-navigation like ->on()->iPhone15()).
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    /**
+     * Settle before screenshotting: flip lazy EVE-image portraits/logos to eager so off-screen
+     * (full-page) images fetch, wait for the network to go idle, then capture — so screenshots show
+     * resolved images instead of loading placeholders. Best-effort: a slow/absent image won't fail.
+     */
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+if (! function_exists('realCharacterId')) {
+    /**
+     * A real EVE character id (verified CEO) so images.evetech.net serves a real portrait in
+     * screenshots instead of the generic default it returns for fabricated ids. Picks one not yet
+     * used in this (RefreshDatabase-isolated) test; falls back to a random id if the pool is spent.
+     */
+    function realCharacterId(): int
+    {
+        $pool = [197343093, 1319140135, 92081232, 1191750472, 94391213, 887625289, 1435633555, 1809892636];
+        $available = array_values(array_diff($pool, CharacterInfo::query()->pluck('character_id')->all()));
+
+        return $available[0] ?? fake()->unique()->numberBetween(9000000, 98000000);
+    }
+}
+
+if (! function_exists('makeCharacterContracts')) {
+    /**
+     * Create $count contracts owned by (attached to) $character and return them. Defaults
+     * model a personal, unaccepted (outstanding) contract issued to and assigned to the
+     * character itself, so every id the row renders (issuer/assignee) resolves offline
+     * from the DB. Guarded so each Browser file can define it standalone without colliding
+     * when the suite loads several.
+     *
+     * @param  array<string, mixed>  $overrides
+     * @return Collection<int, Contract>
+     */
+    function makeCharacterContracts(CharacterInfo $character, int $count, array $overrides = []): Collection
+    {
+        // Share supporting records across the whole batch. Left to its defaults the Contract
+        // factory spins up a fresh Location→Station→System and a CorporationInfo per contract,
+        // and those random universe/corp ids collide (e.g. universe_systems_pkey) once enough
+        // rows are created. Create them once and reuse the ids.
+        $contracts = Contract::factory()->count($count)->create(array_merge([
+            'issuer_id' => $character->character_id,
+            'assignee_id' => $character->character_id,
+            'for_corporation' => false,
+            'acceptor_id' => 0,
+            'status' => 'outstanding',
+            'issuer_corporation_id' => CorporationInfo::factory()->create()->corporation_id,
+            'start_location_id' => Location::factory()->withStation()->create()->location_id,
+            'end_location_id' => Location::factory()->withStation()->create()->location_id,
+        ], $overrides));
+
+        $character->contracts()->syncWithoutDetaching($contracts->pluck('contract_id')->all());
+
+        return $contracts;
+    }
+}
+
+if (! function_exists('userOfCharacter')) {
+    function userOfCharacter(int $characterId): User
+    {
+        return CharacterUser::query()->where('character_id', $characterId)->firstOrFail()->user;
+    }
+}
+
+if (! function_exists('makeReviewableRecruit')) {
+    /**
+     * A recruit User to review: exactly one owned character (a real EVE id, also the main), so the
+     * review page renders a single contract list. User::factory attaches a random character in its
+     * afterCreating hook — swap it for the real-id one so the assertions target a known body id.
+     *
+     * @return array{0: User, 1: CharacterInfo}
+     */
+    function makeReviewableRecruit(): array
+    {
+        $user = User::factory()->create();
+
+        $user->characterUsers()->delete();
+
+        $character = CharacterInfo::factory()->create(['character_id' => realCharacterId()]);
+
+        CharacterUser::create([
+            'user_id' => $user->getKey(),
+            'character_id' => $character->character_id,
+            'character_owner_hash' => sha1((string) $character->character_id),
+        ]);
+
+        $user->update(['main_character_id' => $character->character_id]);
+
+        return [$user->refresh(), $character];
+    }
+}
+
+/*
+ * Recruitment / member-compliance contract tab browser test — run against the real assembled
+ * core app.
+ *
+ * Exercises the shared recruitment ContractTab (Pages/Corporation/Recruitment/Tabs/ContractTab.vue,
+ * used by both the recruitment application page and the member-compliance review-user page) after
+ * its migration off the legacy axios InfiniteLoadingHelper. The tab now renders a native Inertia
+ * <InfiniteScroll> over a per-character contracts_<id> page scroll prop emitted by
+ * MemberComplianceController::reviewUser — same mechanism as the character contracts page.
+ *
+ * Reached via the review-user page because superuser bypasses its `view member compliance` +
+ * `member compliance: review user` gates (CanUserService), keeping provisioning minimal.
+ * Provisioning helpers otherwise come from the suite (actingAsCharacter(), core tests/Pest.php).
+ */
+
+uses(RefreshDatabase::class);
+
+it('merges the next recruit-contracts page in on scroll in the review contract tab', function () {
+    // Reviewer: any logged-in user, elevated to superuser so the compliance gates pass.
+    $reviewer = actingAsCharacter();
+    userOfCharacter($reviewer->character_id)->givePermissionTo(Permission::findOrCreate('superuser'));
+
+    // Recruit under review + a page's worth of contracts (default 15/page → several pages).
+    [$recruitUser, $recruitCharacter] = makeReviewableRecruit();
+    makeCharacterContracts($recruitCharacter, 40);
+
+    // Any corporation id — reviewUser only find()s it for the target-corporation prop; with no
+    // SsoScopes the review renders every recruit character (no corp-scoped character filter).
+    $corporation = CorporationInfo::factory()->create();
+
+    $url = route('corporation.review.user', [
+        'corporation_id' => $corporation->corporation_id,
+        'user' => $recruitUser->getKey(),
+    ]);
+
+    // Desktop only: TabComponent renders the tab strip as clickable <div>s on sm+ and swaps it for
+    // a native <select> on mobile, so the click-to-activate path below is a desktop assertion.
+    $page = deviceVisit('desktop', $url);
+    $page->assertNoSmoke();
+
+    // The header renders the recruit's main-character name via Vue — waiting on it confirms the
+    // page has hydrated before we drive the (reactive) tab switch.
+    $page->waitForText($recruitCharacter->name);
+
+    // TabComponent opens on the "Log" tab; activate "Contracts". Click the visible leaf <div> whose
+    // text is exactly "Contracts" (the mobile <select>'s <option> is excluded — it is not a <div>).
+    $page->script("[...document.querySelectorAll('div')].find(el => el.children.length === 0 && el.textContent.trim() === 'Contracts' && el.offsetParent !== null)?.click()");
+
+    $rows = "#contracts-body-{$recruitCharacter->character_id} > *";
+
+    // assertScript auto-polls: waits for the tab to mount and the first scroll-prop page to render.
+    $page->assertScript("document.querySelectorAll('{$rows}').length > 0");
+
+    $before = (int) $page->script("document.querySelectorAll('{$rows}').length");
+    expect($before)->toBeGreaterThan(0);
+
+    // Re-scroll the list's own container to the bottom on every poll (comma expression) so
+    // InfiniteScroll's end trigger fires; passes once the next page has merged in.
+    $page->assertScript("(document.getElementById('contracts-body-{$recruitCharacter->character_id}').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
+
+    snap($page, 'recruitment-contracts-infinite-scroll-desktop');
+});

--- a/tests/Browser/RecruitmentContractTest.php
+++ b/tests/Browser/RecruitmentContractTest.php
@@ -152,7 +152,7 @@ if (! function_exists('makeReviewableRecruit')) {
 
 uses(RefreshDatabase::class);
 
-it('merges the next recruit-contracts page in on scroll in the review contract tab', function () {
+it('merges the next recruit-contracts page in on scroll in the review contract tab', function (string $device) {
     // Reviewer: any logged-in user, elevated to superuser so the compliance gates pass.
     $reviewer = actingAsCharacter();
     userOfCharacter($reviewer->character_id)->givePermissionTo(Permission::findOrCreate('superuser'));
@@ -170,22 +170,28 @@ it('merges the next recruit-contracts page in on scroll in the review contract t
         'user' => $recruitUser->getKey(),
     ]);
 
-    // Desktop only: TabComponent renders the tab strip as clickable <div>s on sm+ and swaps it for
-    // a native <select> on mobile, so the click-to-activate path below is a desktop assertion.
-    $page = deviceVisit('desktop', $url);
+    $page = deviceVisit($device, $url);
     $page->assertNoSmoke();
 
     // The header renders the recruit's main-character name via Vue — waiting on it confirms the
     // page has hydrated before we drive the (reactive) tab switch.
     $page->waitForText($recruitCharacter->name);
 
-    // TabComponent opens on the "Log" tab; activate "Contracts". Click the visible leaf <div> whose
-    // text is exactly "Contracts" (the mobile <select>'s <option> is excluded — it is not a <div>).
-    $page->script("[...document.querySelectorAll('div')].find(el => el.children.length === 0 && el.textContent.trim() === 'Contracts' && el.offsetParent !== null)?.click()");
+    // TabComponent opens on the "Log" tab; activate "Contracts". The switcher differs per viewport:
+    // sm+ renders clickable <div>s; mobile (.sm:hidden) renders a native <select v-model>. The
+    // <option> has no :value binding, so its value is its text ("Contracts").
+    if ($device === 'iphone') {
+        // Drive the mobile <select>: set its value to the "Contracts" option and fire a bubbling
+        // change event so Vue's v-model updates active_element.
+        $page->script("(() => { const s = document.getElementById('tabs'); s.value = 'Contracts'; s.dispatchEvent(new Event('change', { bubbles: true })); })()");
+    } else {
+        $page->click('Contracts');
+    }
 
     $rows = "#contracts-body-{$recruitCharacter->character_id} > *";
 
     // assertScript auto-polls: waits for the tab to mount and the first scroll-prop page to render.
+    // Proves the native <InfiniteScroll> list rendered on this viewport (the point of the migration).
     $page->assertScript("document.querySelectorAll('{$rows}').length > 0");
 
     $before = (int) $page->script("document.querySelectorAll('{$rows}').length");
@@ -195,5 +201,5 @@ it('merges the next recruit-contracts page in on scroll in the review contract t
     // InfiniteScroll's end trigger fires; passes once the next page has merged in.
     $page->assertScript("(document.getElementById('contracts-body-{$recruitCharacter->character_id}').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
 
-    snap($page, 'recruitment-contracts-infinite-scroll-desktop');
-});
+    snap($page, "recruitment-contracts-infinite-scroll-{$device}");
+})->with(['desktop', 'iphone']);


### PR DESCRIPTION
## What

Finishes migrating `ContractComponent` off the legacy axios/Ziggy `InfiniteLoadingHelper`. The character-contracts page already used native Inertia `<InfiniteScroll>`; the **recruitment/watchlist** branch (`v-else`) still hit `character.contracts.details` via axios. That branch is gone and the `InfiniteLoadingHelper` import is removed — the component no longer depends on the axios helper.

## How

- **`ContractComponent.vue`** — collapsed the dual-mode template to a single always-on `<InfiniteScroll :data="scrollKey">` in a `scroll-region` container (same shape as the wallet/mails/assets migrations). `scrollKey` is now a **required** prop; dropped the unused `type` / `watchlist` props and the `parameters` computed, and removed the `InfiniteLoadingHelper` import.
- **`ContractTab.vue`** (recruitment, shared by the review-user page too) — the two sub-tabs now select a scroll-prop key instead of axios params: `watchlisted_contracts_<id>` (Watchlisted) or `contracts_<id>` (All), passed down as `scroll-key`. Client-side tab toggle preserved via the existing `:key` remount.
- **`RecruitContractScrollPropsAction`** (new) — builds both per-character scroll props: the full list and the watchlist-filtered list (reusing `LocationWatchListScope` + `TypeWatchListScope`, each paginator with its own `pageName`). Wired into `ApplicationsController::getApplication` and `MemberComplianceController::reviewUser`, so both surfaces that render `ContractTab` feed the native scroll and **watchlist filtering is preserved** (previously done inline on the details endpoint).
- **Browser test** — `tests/Browser/RecruitmentContractTest.php` drives the review-user page (superuser bypasses the compliance gates), activates the Contracts tab, and asserts the list merges its next page on scroll.

## Notes / follow-ups

- The browser test is **desktop-only**: `TabComponent` renders the tab strip as clickable `<div>`s on `sm+` but swaps to a native `<select>` on mobile, so the click-to-activate step is a desktop assertion.
- The legacy `character.contracts.details` route/controller method is now unused by the frontend but left in place (still referenced by `ContractIntegrationTest`); removing it is out of scope for this PR.
- `InfiniteLoadingHelper` itself remains for the not-yet-migrated lists (assets, corp history, member tracking, ACL).

## Verification

- `eslint` on both changed `.vue` files: clean.
- `pint` on all changed/new PHP: passed.
- Pest / `npm run build` / `wayfinder:generate` not run in this environment (per task constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)