### PR TITLE
refactor: recruitment corporation list + index → InfiniteScroll + redesign

### DIFF
--- a/resources/js/Pages/Corporation/Recruitment/CorporationList.vue
+++ b/resources/js/Pages/Corporation/Recruitment/CorporationList.vue
@@ -1,104 +1,120 @@
 <template>
-  <ul class="grid grid-cols-1 gap-6 px-4 sm:px-6">
-    <li
-      v-for="corporation in result"
-      :key="corporation.corporation_id"
-      class="col-span-1 bg-white rounded-lg shadow-sm"
+  <div>
+    <!-- Native Inertia v3 infinite scroll over the page-level `corporations` scroll prop
+         (affiliated, not-yet-enlisted corporations paginated with pageName 'corporations').
+         Replaces the axios/Ziggy useInfinityScrolling loader. -->
+    <InfiniteScroll
+      data="corporations"
+      items-element="#recruitment-corporation-list"
+      :buffer="500"
+      preserve-url
     >
-      <div class="w-full flex items-center justify-between p-6 space-x-6">
-        <div class="flex-1 truncate">
-          <div class="flex items-center space-x-3">
-            <h3 class="text-gray-900 text-sm leading-5 font-medium truncate">
-              {{ corporation.name }}
-            </h3>
-            <span
-              v-if="corporation.alliance"
-              class="shrink-0 inline-block px-2 py-0.5 text-teal-800 text-xs leading-4 font-medium bg-teal-100 rounded-full"
-            >{{ corporation.alliance }}</span>
-          </div>
-          <p class="mt-1 text-gray-500 text-sm leading-5 truncate">
-            How should scopes be applied?
-          </p>
-        </div>
-        <EveImage
-          :object="corporation"
-          :size="256"
-          tailwind_class="w-10 h-10 bg-gray-300 rounded-full shrink-0"
-        />
-      </div>
-      <div class="border-t border-gray-200">
-        <div class="-mt-px flex">
-          <div class="w-0 flex-1 flex border-r border-gray-200">
-            <button
-              class="relative -mr-px w-0 flex-1 inline-flex items-center justify-center py-4 text-sm leading-5 text-gray-700 font-medium border border-transparent rounded-bl-lg hover:text-gray-500 focus:outline-hidden focus:ring-blue focus:border-blue-300 focus:z-10 transition ease-in-out duration-150"
-              @click="create(corporation, 'character')"
-            >
-              <svg
-                class="w-5 h-5 text-gray-400"
-                viewBox="0 0 20 20"
-                fill="currentColor"
+      <ul
+        id="recruitment-corporation-list"
+        class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3"
+      >
+        <li
+          v-for="corporation in corporations"
+          :key="corporation.corporation_id"
+        >
+          <CardWithHeader>
+            <template #header>
+              <EntityBlock :entity="corporation" />
+            </template>
+
+            <div class="grid grid-cols-2 divide-x divide-gray-200">
+              <Button
+                :href="openRecruitment.url()"
+                method="post"
+                :data="{ corporation_id: corporation.corporation_id, type: 'character' }"
+                class="w-full justify-center gap-x-2 rounded-none border-0 py-4 shadow-none"
               >
-                <path
-                  fill-rule="evenodd"
-                  d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                  clip-rule="evenodd"
+                <UserIcon
+                  class="h-5 w-5 text-gray-400"
+                  aria-hidden="true"
                 />
-              </svg>
-              <span class="ml-3">Recruits only</span>
-            </button>
-          </div>
-          <div class="-ml-px w-0 flex-1 flex">
-            <button
-              class="relative w-0 flex-1 inline-flex items-center justify-center py-4 text-sm leading-5 text-gray-700 font-medium border border-transparent rounded-br-lg hover:text-gray-500 focus:outline-hidden focus:ring-blue focus:border-blue-300 focus:z-10 transition ease-in-out duration-150"
-              @click="create(corporation, 'user')"
-            >
-              <svg
-                class="w-5 h-5 text-gray-400"
-                viewBox="0 0 20 20"
-                fill="currentColor"
+                Recruits only
+              </Button>
+              <Button
+                :href="openRecruitment.url()"
+                method="post"
+                :data="{ corporation_id: corporation.corporation_id, type: 'user' }"
+                class="w-full justify-center gap-x-2 rounded-none border-0 py-4 shadow-none"
               >
-                <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
-              </svg>
-              <span class="ml-3">All Characters</span>
-            </button>
-          </div>
+                <UsersIcon
+                  class="h-5 w-5 text-gray-400"
+                  aria-hidden="true"
+                />
+                All characters
+              </Button>
+            </div>
+          </CardWithHeader>
+        </li>
+      </ul>
+
+      <template #loading>
+        <div class="relative block w-full py-6 text-center">
+          <svg
+            class="animate-spin mx-auto h-8 w-8 text-gray-400"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          <span class="mt-2 block text-sm font-medium text-gray-500">
+            loading more corporations…
+          </span>
         </div>
-      </div>
-    </li>
-    <div ref="scrollComponent" />
-  </ul>
+      </template>
+    </InfiniteScroll>
+
+    <p
+      v-if="corporations.length === 0"
+      class="px-4 py-8 text-center text-sm text-gray-500"
+    >
+      No corporations available to open for recruitment.
+    </p>
+  </div>
 </template>
 
 <script>
+import { InfiniteScroll } from "@inertiajs/vue3";
+import { UserIcon, UsersIcon } from "@heroicons/vue/24/outline";
+import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
+import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
+import Button from "@/Shared/Layout/Button.vue";
+import { create as openRecruitment } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/EnlistmentsController";
 
-import EveImage from "@/Shared/EveImage.vue"
-import {useInfinityScrolling} from "@/Functions/useInfinityScrolling";
-import {router} from "@inertiajs/vue3";
 export default {
-  name: "CorporationList",
-  components: {EveImage,
-    //InfiniteLoading
-  },
-  props: {
-    parameters: {
-      required: true,
-      type: Object
-    }
-  },
-  setup(props) {
-
-    return useInfinityScrolling('get.affiliated.corporations', props.parameters)
-
-  },
-  methods: {
-    create(corporation, type) {
-
-      router.post(route('create.corporation.recruitment'), {corporation_id: corporation.corporation_id, type: type})
-    }
-  }
+    name: "CorporationList",
+    components: {
+        InfiniteScroll,
+        CardWithHeader,
+        EntityBlock,
+        Button,
+        UserIcon,
+        UsersIcon,
+    },
+    setup() {
+        return { openRecruitment };
+    },
+    computed: {
+        corporations() {
+            return this.$page.props.corporations?.data ?? [];
+        },
+    },
 }
 </script>
-
-<style scoped>
-
-</style>

--- a/resources/js/Pages/Corporation/Recruitment/CorporationRecruitment.vue
+++ b/resources/js/Pages/Corporation/Recruitment/CorporationRecruitment.vue
@@ -1,31 +1,19 @@
 <template>
-  <!-- Be sure to use this with a layout container that is full-width on mobile -->
-  <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg my-5">
-    <div class="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
-      <div class="-ml-4 -mt-4 flex justify-between items-center flex-wrap sm:flex-nowrap">
-        <div class="ml-4 mt-4">
-          <EntityBlock :entity="enlistment.corporation" />
-        </div>
+  <CardWithHeader class="my-5">
+    <template #header>
+      <div class="flex flex-wrap items-center justify-between gap-4 sm:flex-nowrap">
+        <EntityBlock :entity="enlistment.corporation" />
 
-        <div
+        <Button
           v-if="enlistment.can_manage"
-          class="ml-4 mt-4 shrink-0 flex space-x-3"
+          :href="editEnlistment.url({ corporation_id: enlistment.corporation_id })"
+          method="get"
+          class="shrink-0"
         >
-          <span class="inline-flex rounded-md shadow-xs">
-
-            <Link
-              :href="route('edit.enlistment', enlistment.corporation_id)"
-              method="get"
-              as="button"
-              type="button"
-              class="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-50 focus:outline-hidden focus:ring-2 focus:border-indigo-300 focus:ring-offset-2 focus:ring-indigo active:bg-indigo-200"
-            >
-              Edit Enlistment
-            </Link>
-          </span>
-        </div>
+          Edit Enlistment
+        </Button>
       </div>
-    </div>
+    </template>
 
     <div class="px-4 py-5 sm:p-6 space-y-4 sm:space-y-6">
       <!--TODO: add finished applications-->
@@ -35,7 +23,7 @@
         @select="changeActiveTab"
       />
 
-      <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg relative max-h-96 overflow-y-auto">
+      <div class="relative max-h-96 overflow-y-auto rounded-lg">
         <PendingTable
           v-if="isPending"
           :step-count="stepIndex"
@@ -47,28 +35,35 @@
         />
       </div>
     </div>
-  </div>
+  </CardWithHeader>
 </template>
 
 <script>
 
-import { Link } from "@inertiajs/vue3";
+import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
+import Button from "@/Shared/Layout/Button.vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import BarWithUnderline from "@/Shared/Layout/Tabs/BarWithUnderline.vue";
 import PendingTable from "./ApplicationsTable/PendingTable.vue";
 import ClosedTable from "./ApplicationsTable/ClosedTable.vue";
+import { edit as editEnlistment } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/EnlistmentsController";
 
 export default {
     name: "CorporationRecruitment",
     components: {
+        CardWithHeader,
+        Button,
         ClosedTable,
         PendingTable,
-        BarWithUnderline, EntityBlock, Link },
+        BarWithUnderline, EntityBlock },
     props: {
         enlistment: {
             required: true,
             type: Object
         },
+    },
+    setup() {
+        return { editEnlistment };
     },
     data() {
         return {

--- a/resources/js/Pages/Corporation/Recruitment/RecruitmentIndex.vue
+++ b/resources/js/Pages/Corporation/Recruitment/RecruitmentIndex.vue
@@ -17,6 +17,16 @@
       :enlistment="enlistment"
     />
 
+    <section
+      v-if="canManageRecruitment"
+      class="space-y-3"
+    >
+      <h2 class="px-4 text-sm font-medium text-gray-500 sm:px-0">
+        Open a corporation for recruitment
+      </h2>
+      <CorporationList />
+    </section>
+
     <teleport to="#destination">
       <CreateEnlistmentModal v-model="create_enlistment" />
     </teleport>
@@ -28,10 +38,11 @@ import PageHeader from "@/Shared/Layout/PageHeader.vue"
 import HeaderButton from "@/Shared/Layout/HeaderButton.vue"
 import CreateEnlistmentModal from "./CreateEnlistmentModal.vue";
 import CorporationRecruitment from "@/Pages/Corporation/Recruitment/CorporationRecruitment.vue";
+import CorporationList from "@/Pages/Corporation/Recruitment/CorporationList.vue";
 
 export default {
     name: "RecruitmentIndex",
-    components: {CorporationRecruitment, CreateEnlistmentModal, HeaderButton, PageHeader},
+    components: {CorporationList, CorporationRecruitment, CreateEnlistmentModal, HeaderButton, PageHeader},
     props: {
         canManageRecruitment: {
             required: true,

--- a/src/Http/Controllers/Corporation/Recruitment/GetRecruitmentIndexController.php
+++ b/src/Http/Controllers/Corporation/Recruitment/GetRecruitmentIndexController.php
@@ -27,12 +27,15 @@
 namespace Seatplus\Web\Http\Controllers\Corporation\Recruitment;
 
 use DB;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\Recruitment\Enlistments;
 use Seatplus\Web\Http\Controllers\Controller;
+use Seatplus\Web\Http\Resources\CorporationInfoRessource;
 
 class GetRecruitmentIndexController extends Controller
 {
@@ -42,25 +45,31 @@ class GetRecruitmentIndexController extends Controller
 
     public function __invoke(): Response
     {
-        $can_manage_recruitment = auth()->user()->can(self::MANAGEPERMISSION);
-
-        return Inertia::render('Corporation/Recruitment/RecruitmentIndex', [
-            'canManageRecruitment' => $can_manage_recruitment,
-            'enlistments' => $this->getEnlistments(),
-            'activeSidebarElement' => 'corporation.recruitment',
-        ]);
-    }
-
-    private function getEnlistments(): Collection
-    {
-
-        $isSuperuser = auth()->user()->can('superuser');
+        $user = auth()->user();
+        $isSuperuser = $user->can('superuser');
+        $canManageRecruitment = $user->can(self::MANAGEPERMISSION);
 
         $manageableIds = $this->getAffiliatedIds->get(
             permissions: [self::MANAGEPERMISSION],
             corporationRoles: ['Director'],
-            user: auth()->user()
+            user: $user,
         );
+
+        return Inertia::render('Corporation/Recruitment/RecruitmentIndex', [
+            'canManageRecruitment' => $canManageRecruitment,
+            'enlistments' => $this->getEnlistments($isSuperuser, $manageableIds),
+            // Corporations the manager may open for recruitment (i.e. affiliated + not yet
+            // enlisted) as a native Inertia infinite-scroll prop, replacing the old
+            // axios/Ziggy useInfinityScrolling loader inside CorporationList.vue.
+            'corporations' => Inertia::scroll(
+                fn (): LengthAwarePaginator => $this->getEnlistableCorporations($isSuperuser, $manageableIds),
+            ),
+            'activeSidebarElement' => 'corporation.recruitment',
+        ]);
+    }
+
+    private function getEnlistments(bool $isSuperuser, array $manageableIds): Collection
+    {
 
         $recruiterIds = $this->getAffiliatedIds->get(
             permissions: [self::RECRUITERPERMISSION],
@@ -85,5 +94,17 @@ class GetRecruitmentIndexController extends Controller
 
             return $manageable->concat($recruitable);
         });
+    }
+
+    private function getEnlistableCorporations(bool $isSuperuser, array $manageableIds): LengthAwarePaginator
+    {
+        return CorporationInfo::query()
+            ->select('corporation_infos.*')
+            ->when(! $isSuperuser, fn (Builder $query) => $query->whereIn('corporation_id', $manageableIds))
+            ->whereNotIn('corporation_id', Enlistments::query()->select('corporation_id'))
+            ->with('alliance')
+            ->orderBy('name')
+            ->paginate(pageName: 'corporations')
+            ->through(fn (CorporationInfo $corporation): array => (new CorporationInfoRessource($corporation))->resolve());
     }
 }

--- a/tests/Browser/RecruitmentListTest.php
+++ b/tests/Browser/RecruitmentListTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Auth\Models\CharacterUser;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+
+/*
+ * Recruitment landing (/corporation/recruitment) browser test. The affiliated-corporation
+ * picker (CorporationList.vue) is now an Inertia <InfiniteScroll> over the `corporations`
+ * scroll prop instead of the axios/Ziggy useInfinityScrolling loader, and the cards are
+ * rebuilt on the shared CardWithHeader + Button. A superuser passes the recruitment gate
+ * and marks every not-yet-enlisted corporation as enlistable, so the cards render without
+ * wiring up affiliations. Provisioning via actingAsCharacter() (core tests/Pest.php).
+ */
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('deviceVisit')) {
+    /**
+     * Visit $url on the given viewport ("desktop" or "iphone"). Browser tests run in the core app,
+     * whose tests/Pest.php is not overlaid, so this helper is defined here (guarded) alongside the
+     * suite's other function_exists helpers rather than in tests/Pest.php.
+     */
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    /**
+     * Settle before screenshotting: flip lazy EVE-image portraits/logos to eager so off-screen
+     * (full-page) images fetch, wait for the network to go idle, then capture — so screenshots show
+     * resolved images instead of loading placeholders. Best-effort: a slow/absent image won't fail.
+     */
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+if (! function_exists('userOfCharacter')) {
+    function userOfCharacter(int $characterId): User
+    {
+        return CharacterUser::query()->where('character_id', $characterId)->firstOrFail()->user;
+    }
+}
+
+it('renders the affiliated corporation list for a recruitment manager', function (string $device) {
+    $character = actingAsCharacter();
+
+    // Superuser: passes the CheckAuthorization recruitment gate (CanUserService bypass) and
+    // makes every not-yet-enlisted corporation enlistable, so the picker cards render.
+    userOfCharacter($character->character_id)
+        ->givePermissionTo(Permission::findOrCreate('superuser'));
+
+    // Real NPC corporation ids so images.evetech.net serves real logos in the screenshot.
+    $corporation = CorporationInfo::factory()->create([
+        'corporation_id' => 1000107,
+        'name' => 'Science and Trade Institute',
+    ]);
+
+    CorporationInfo::factory()->create([
+        'corporation_id' => 1000035,
+        'name' => 'Caldari Provisions',
+    ]);
+
+    $page = deviceVisit($device, '/corporation/recruitment');
+    $page->assertNoSmoke();
+
+    // Page shell + the picker section the redesigned CorporationList lives under.
+    $page->waitForText('Corporation Recruitment');
+    $page->waitForText('Open a corporation for recruitment');
+
+    // A corporation card with its two footer actions (Button + heroicons).
+    $page->waitForText($corporation->name);
+    $page->assertSee('Recruits only');
+    $page->assertSee('All characters');
+
+    // The infinite-scroll row list is present with at least the seeded corporations.
+    $page->assertScript("document.querySelectorAll('#recruitment-corporation-list > li').length >= 2");
+
+    snap($page, "recruitment-corporation-list-{$device}");
+})->with(['desktop', 'iphone']);

--- a/tests/Feature/RecruitmentLifeCycleTest.php
+++ b/tests/Feature/RecruitmentLifeCycleTest.php
@@ -167,7 +167,14 @@ test('senior hr sees recruitment component', function () {
     test()->actingAs(test()->test_user->refresh())
         ->get(route('corporation.recruitment'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->component('Corporation/Recruitment/RecruitmentIndex'));
+        ->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Corporation/Recruitment/RecruitmentIndex')
+                ->where('canManageRecruitment', true)
+                // Corporations a manager may open for recruitment are served as a native
+                // Inertia infinite-scroll prop (replacing the old axios/Ziggy loader).
+                ->has('corporations')
+        );
 });
 
 test('junior hr sees recruitment component', function () {


### PR DESCRIPTION
## What

Modernises the recruitment corporation surfaces (`resources/js/Pages/Corporation/Recruitment/`): drops the axios/Ziggy `useInfinityScrolling` loader and the bespoke Tailwind-UI markup, rebuilding on the shared design system (CardWithHeader / Button / EntityBlock) with native Inertia v3 infinite scroll and Wayfinder routes.

## Changes

- **`CorporationList.vue`** — was an orphaned, fully-bespoke "cards with footer actions" grid loaded via `useInfinityScrolling` (axios + Ziggy `route()`), with inline SVGs, commented-out dead code and the invalid `focus:ring-blue` v2 alias. Now:
  - native `<InfiniteScroll data="corporations">` over a page-level `Inertia::scroll()` prop (mirrors `AssetsComponent.vue`);
  - cards rebuilt on `CardWithHeader` + `EntityBlock` + shared `Button`;
  - inline SVGs → `@heroicons/vue` (`UserIcon` / `UsersIcon`);
  - dead code + `focus:ring-blue` removed;
  - "open recruitment" POST via the Wayfinder `create` action (no `route()`, no axios).
- **`CorporationRecruitment.vue`** — hand-rolled card + inline `<Link>`-as-button + `route('edit.enlistment', …)` rebuilt on `CardWithHeader` + `Button`; the Edit action now uses the Wayfinder `edit` action. `BarWithUnderline` retained.
- **`RecruitmentIndex.vue`** — renders the redesigned `CorporationList` picker for managers (`canManageRecruitment`). It had no `route()` calls to migrate.
- **`GetRecruitmentIndexController`** — serves the enlistable (affiliated + not-yet-enlisted) corporations as an `Inertia::scroll()` prop with `pageName: 'corporations'`, matching the `ContractsController` scroll pattern. Controller edit kept minimal.
- **Tests** — `RecruitmentLifeCycleTest` now asserts the new `corporations` scroll prop for a manager; new `tests/Browser/RecruitmentListTest.php` visits `/corporation/recruitment` and asserts the corporation cards render (desktop + iPhone, real EVE ids + factories + `snap()`).

## Notes

- `@/actions/...` and `@/routes/...` are gitignored + generated; CI runs `wayfinder:generate` in the "Browser (vs core)" job before the build.
- eslint (changed `.vue`) and Pint (changed `.php`) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)