### PR TITLE
refactor: recruitment application tables → InfiniteScroll + redesign Application review

### DIFF
--- a/resources/js/Pages/Corporation/Recruitment/Application.vue
+++ b/resources/js/Pages/Corporation/Recruitment/Application.vue
@@ -13,7 +13,6 @@
       </template>
     </PageHeader>
 
-
     <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <li class="col-span-2">
         <TabComponent
@@ -25,204 +24,171 @@
       </li>
 
       <li class="col-span-1">
-        <div class="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
-          <div>
-            <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100">
-              <!-- Heroicon name: check -->
-              <IdentificationIcon class="h-6 w-6 text-indigo-600" />
+        <CardWithHeader>
+          <template #header>
+            <div class="flex items-center gap-4">
+              <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-indigo-100">
+                <IdentificationIcon class="h-6 w-6 text-indigo-600" />
+              </div>
+              <div>
+                <h3 class="text-lg font-medium leading-6 text-gray-900">
+                  Application of {{ recruit.main_character.name }}
+                </h3>
+                <p class="mt-1 text-sm leading-5 text-gray-500">
+                  This will decide if one or all of the following characters are allowed to join the corporation: {{ characters }}
+                </p>
+              </div>
             </div>
-            <div class="mt-3 sm:mt-5">
-              <h3 class="text-lg leading-6 font-medium text-gray-900">
-                Application of {{ recruit.main_character.name }}
-              </h3>
-              <p class="mt-1 max-w-2xl text-sm leading-5 text-gray-500">
-                This will decide if one or all of the following characters are allowed to join the corporation: {{ characters }}
-              </p>
-              <p class="mt-1 max-w-2xl text-sm leading-5 text-gray-500">
-                Remember to invite them in game as well.
-              </p>
+          </template>
+
+          <div class="space-y-6 px-4 py-5 sm:p-6">
+            <p class="text-sm leading-5 text-gray-500">
+              Remember to invite them in game as well.
+            </p>
+
+            <div class="space-y-3">
               <UpdateCharacterComponent
                 v-for="character in recruit.characters"
                 :key="character.character_id"
                 :character="character"
               />
-              <!--Decision-->
-              <div
-                v-show="application.status === 'open'"
-                class="mt-6 sm:mt-5 sm:border-t sm:border-gray-200 sm:pt-5"
-              >
-                <div
-                  role="group"
-                  aria-labelledby="label-notifications"
-                >
-                  <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-baseline">
-                    <div>
-                      <div
-                        id="label-notifications"
-                        class="text-base leading-6 font-medium text-gray-900 sm:text-sm sm:leading-5 sm:text-gray-700"
-                      >
-                        Decision
-                      </div>
-                    </div>
-                    <div class="sm:col-span-2">
-                      <div class="max-w-lg">
-                        <p class="text-sm leading-5 text-gray-500">
-                          Decide if the recruit should be accepted to corporation or not.
-                        </p>
-                        <div class="mt-4">
-                          <div class="flex items-center">
-                            <input
-                              id="accept_application"
-                              v-model="form.decision"
-                              value="accepted"
-                              name="accept_application"
-                              type="radio"
-                              class="form-radio h-4 w-4 text-indigo-600 transition duration-150 ease-in-out"
-                            >
-                            <label
-                              for="accept_application"
-                              class="ml-3"
-                            >
-                              <span class="block text-sm leading-5 font-medium text-gray-700">Accept application</span>
-                            </label>
-                          </div>
-                          <div class="mt-4 flex items-center">
-                            <input
-                              id="reject_application"
-                              v-model="form.decision"
-                              value="rejected"
-                              name="reject_application"
-                              type="radio"
-                              class="form-radio h-4 w-4 text-indigo-600 transition duration-150 ease-in-out"
-                            >
-                            <label
-                              for="reject_application"
-                              class="ml-3"
-                            >
-                              <span class="block text-sm leading-5 font-medium text-gray-700">Reject application</span>
-                            </label>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <!--Explanation-->
-              <div
-                v-if="form.decision === 'rejected' "
-                class="mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5"
-              >
-                <label
-                  for="explanation"
-                  class="block text-sm font-medium leading-5 text-gray-700 sm:mt-px sm:pt-2"
-                >
-                  Explanation
-                </label>
-                <div class="mt-1 sm:mt-0 sm:col-span-2">
-                  <div class="max-w-lg flex rounded-md shadow-xs">
-                    <textarea
-                      id="explanation"
-                      v-model="form.explanation"
-                      rows="3"
-                      class="form-textarea block w-full transition duration-150 ease-in-out sm:text-sm sm:leading-5"
-                      required
-                    />
-                  </div>
-                  <p
-                    v-if="$page.props.errors.explanation"
-                    class="mt-2 text-sm text-red-600"
-                  >
-                    {{ $page.errors.explanation[0] }}
-                  </p>
-                  <p class="mt-2 text-sm text-gray-500">
-                    Write a few sentences about the decision, in that recruiters in the future might learn from past decisions.
-                  </p>
-                </div>
-              </div>
             </div>
+
+            <!-- Decision -->
+            <form
+              v-if="isOpen"
+              class="space-y-6 border-t border-gray-200 pt-6"
+              @submit.prevent="submit"
+            >
+              <fieldset>
+                <legend class="text-sm font-medium text-gray-900">
+                  Decision
+                </legend>
+                <p class="mt-1 text-sm leading-5 text-gray-500">
+                  Decide if the recruit should be accepted to the corporation or not.
+                </p>
+                <div class="mt-4 space-y-4">
+                  <div class="flex items-center">
+                    <input
+                      id="accept_application"
+                      v-model="form.decision"
+                      value="accepted"
+                      name="decision"
+                      type="radio"
+                      class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    >
+                    <label
+                      for="accept_application"
+                      class="ml-3 block text-sm font-medium text-gray-700"
+                    >
+                      Accept application
+                    </label>
+                  </div>
+                  <div class="flex items-center">
+                    <input
+                      id="reject_application"
+                      v-model="form.decision"
+                      value="rejected"
+                      name="decision"
+                      type="radio"
+                      class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    >
+                    <label
+                      for="reject_application"
+                      class="ml-3 block text-sm font-medium text-gray-700"
+                    >
+                      Reject application
+                    </label>
+                  </div>
+                </div>
+                <p
+                  v-if="form.errors.decision"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.decision }}
+                </p>
+              </fieldset>
+
+              <!-- Explanation (required when rejecting) -->
+              <div v-if="form.decision === 'rejected'">
+                <InputWithValidation
+                  v-model="form.explanation"
+                  label="Explanation"
+                  placeholder="Why is this application rejected?"
+                  :error="form.errors.explanation ?? ''"
+                />
+                <p
+                  v-if="!form.errors.explanation"
+                  class="mt-2 text-sm text-gray-500"
+                >
+                  Write a few sentences about the decision, so recruiters in the future might learn from past decisions.
+                </p>
+              </div>
+
+              <div class="flex justify-end">
+                <Button
+                  :is-inertia-button="false"
+                  button-size="medium"
+                  @click="submit"
+                >
+                  Submit review
+                </Button>
+              </div>
+            </form>
           </div>
-          <div
-            v-show="application.status === 'open'"
-            class="mt-5 sm:mt-6"
-          >
-            <span class="flex w-full rounded-md shadow-xs">
-              <button
-                type="button"
-                class="inline-flex justify-center w-full rounded-md border border-transparent px-4 py-2 bg-indigo-600 text-base leading-6 font-medium text-white shadow-xs hover:bg-indigo-500 focus:outline-hidden focus:border-indigo-700 focus:ring-indigo transition ease-in-out duration-150 sm:text-sm sm:leading-5"
-                @click="submit"
-              >
-                Submit review
-              </button>
-            </span>
-          </div>
-        </div>
+        </CardWithHeader>
       </li>
     </ul>
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
+import { router, useForm } from "@inertiajs/vue3";
+import { IdentificationIcon } from '@heroicons/vue/24/outline';
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import HeaderButton from "@/Shared/Layout/HeaderButton.vue";
+import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
+import Button from "@/Shared/Layout/Button.vue";
+import InputWithValidation from "@/Shared/Layout/Forms/InputWithValidation.vue";
 import TabComponent from "./TabComponent.vue";
-import {IdentificationIcon} from '@heroicons/vue/24/outline'
 import UpdateCharacterComponent from "./UpdateCharacterComponent.vue";
-import {router} from "@inertiajs/vue3";
+import { reviewApplication } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ApplicationsController";
+import ImpersonateRecruit from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ImpersonateRecruit";
 
-export default {
-    name: "Application",
-    components: {
-        UpdateCharacterComponent,
-        TabComponent,
-        HeaderButton,
-        PageHeader,
-        IdentificationIcon
+const props = defineProps({
+    recruit: {
+        required: true,
+        type: Object
     },
-    props: {
-        recruit: {
-            required: true,
-            type: Object
-        },
-        application: {
-            required: true,
-            type: Object
-        },
-        watchlist: {
-            required: true,
-            type: Object
-        },
-        activeSidebarElement: {
-            required: true,
-            type: String
-        }
+    application: {
+        required: true,
+        type: Object
     },
-    data() {
-        return {
-            pageTitle: 'Application',
-            form: {
-                decision: null,
-                explanation: null
-            }
-        }
+    watchlist: {
+        required: true,
+        type: Object
     },
-    computed: {
-        characters() {
-            return _.map(this.recruit.characters, (character) => character.name ).join(', ')
-        },
-        canImpersonate() {
-            return this.recruit.id && this.application.status === 'open'
-        }
-    },
-    methods: {
-        impersonate() {
-            return router.visit(route('impersonate.recruit', this.application.id))
-        },
-        submit() {
-            return router.post(route('review.application', this.application.id), this.form);
-        }
+    activeSidebarElement: {
+        required: true,
+        type: String
     }
-}
+});
+
+const form = useForm({
+    decision: null,
+    explanation: ''
+});
+
+const isOpen = computed(() => props.application.status === 'open');
+
+const canImpersonate = computed(() => props.recruit.id && isOpen.value);
+
+const characters = computed(() => _.map(props.recruit.characters, (character) => character.name).join(', '));
+
+const impersonate = () => router.visit(ImpersonateRecruit.url(props.application.id));
+
+const submit = () => form.post(reviewApplication.url(props.application.id));
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/ActivityLogModal.vue
+++ b/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/ActivityLogModal.vue
@@ -31,6 +31,8 @@ import {computed, ref, watchEffect} from "vue";
 import LogTab from "@/Pages/Corporation/Recruitment/Tabs/LogTab.vue";
 import Button from "@/Shared/Layout/Button.vue";
 import {DialogTitle} from "@headlessui/vue";
+import { getJson } from "@/Functions/http";
+import { getActivityLog } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ApplicationsController";
 
 
 export default {
@@ -51,9 +53,10 @@ export default {
 
         watchEffect(() => {
             if(open.value && !isLoaded.value) {
-                axios.get(route('get.activity.log', props.applicationId))
-                    .then(result => application.value = result.data)
-                    .catch(error => console.log(error))
+                // Non-Inertia JSON endpoint: native fetch via http.js (drops axios) with a
+                // Wayfinder-built URL (drops Ziggy route()).
+                getJson(getActivityLog.url(props.applicationId))
+                    .then(result => application.value = result)
             }
         })
 

--- a/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/ApplicationsTable.vue
+++ b/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/ApplicationsTable.vue
@@ -1,9 +1,12 @@
 <template>
-  <StickyHeaderTable :header-titles="headerTitles">
+  <StickyHeaderTable
+    :header-titles="headerTitles"
+    :body-id="bodyId"
+  >
     <template #default="{ countColumns, columns }">
       <StickyHeaderTableRow
         v-for="applicant in applications"
-        :key="applicant"
+        :key="applicant.application_id"
         :number-columns="countColumns"
       >
         <StickyHeaderCell
@@ -26,7 +29,7 @@
           <div class="flex gap-x-2 flex-wrap">
             <CharacterComplianceElement
               v-for="character in applicant.characters"
-              :key="character"
+              :key="character.character_id"
               :character="character"
             />
           </div>
@@ -40,13 +43,13 @@
             <div class="flex justify-end">
               <Button
                 button-size="xs"
-                :href="route('get.application', applicant.application_id)"
+                :href="getApplication.url(applicant.application_id)"
               >
                 Review
               </Button>
             </div>
           </slot>
-        </stickyheadercell>
+        </StickyHeaderCell>
       </StickyHeaderTableRow>
     </template>
   </StickyHeaderTable>
@@ -59,6 +62,7 @@ import StickyHeaderCell from "@/Shared/Layout/Table/StickyHeaderCell.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import CharacterComplianceElement from "@/Pages/Corporation/MemberCompliance/CharacterComplianceElement.vue";
 import Button from "@/Shared/Layout/Button.vue";
+import { getApplication } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ApplicationsController";
 
 let headerTitles = [
     {title: 'Main Character', columnSpan: 3},
@@ -75,11 +79,18 @@ export default {
         applications: {
             required: true,
             type: Array
+        },
+        // Optional id for the row <ul> so an ancestor <InfiniteScroll items-element> can target it.
+        bodyId: {
+            required: false,
+            type: String,
+            default: null
         }
     },
     setup() {
         return {
-            headerTitles
+            headerTitles,
+            getApplication
         }
     }
 }

--- a/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/ClosedTable.vue
+++ b/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/ClosedTable.vue
@@ -1,19 +1,29 @@
 <template>
-  <InfiniteLoadingHelper
-    v-slot="{results}"
-    route-name="closed.corporation.applications"
-    :params="{corporation_id: corporationId}"
+  <!-- scroll-region: lets Inertia track/restore this custom scroll container's
+       position so <InfiniteScroll> merges the next page without jumping to top. -->
+  <div
+    class="relative max-h-96 overflow-y-auto"
+    scroll-region=""
   >
-    <ApplicationsTable :applications="results">
-      <template #default="{ applicant }">
-        <ActivityLogModal :application-id="applicant.application_id" />
-      </template>
-    </ApplicationsTable>
-  </InfiniteLoadingHelper>
+    <InfiniteScroll
+      :data="scrollKey"
+      :items-element="`#${bodyId}`"
+      preserve-url
+    >
+      <ApplicationsTable
+        :applications="applications"
+        :body-id="bodyId"
+      >
+        <template #default="{ applicant }">
+          <ActivityLogModal :application-id="applicant.application_id" />
+        </template>
+      </ApplicationsTable>
+    </InfiniteScroll>
+  </div>
 </template>
 
 <script>
-import InfiniteLoadingHelper from "@/Shared/InfiniteLoadingHelper.vue";
+import { InfiniteScroll } from "@inertiajs/vue3";
 import ApplicationsTable from "./ApplicationsTable.vue";
 import ActivityLogModal from "./ActivityLogModal.vue";
 
@@ -22,11 +32,25 @@ export default {
     components: {
         ActivityLogModal,
         ApplicationsTable,
-        InfiniteLoadingHelper},
+        InfiniteScroll,
+    },
     props: {
         corporationId: {
             required: true,
             type: Number
+        }
+    },
+    computed: {
+        // Closed applications are delivered as a page scroll prop keyed per corporation
+        // (GetRecruitmentIndexController), consumed via <InfiniteScroll :data>.
+        scrollKey() {
+            return `closed_${this.corporationId}`
+        },
+        bodyId() {
+            return `closed-body-${this.corporationId}`
+        },
+        applications() {
+            return this.$page.props[this.scrollKey]?.data ?? []
         }
     }
 }

--- a/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/PendingTable.vue
+++ b/resources/js/Pages/Corporation/Recruitment/ApplicationsTable/PendingTable.vue
@@ -1,23 +1,33 @@
 <template>
-  <InfiniteLoadingHelper
-    :key="routeParams"
-    v-slot="{results}"
-    route-name="open.corporation.applications"
-    :params="routeParams"
+  <!-- scroll-region: lets Inertia track/restore this custom scroll container's
+       position so <InfiniteScroll> merges the next page without jumping to top. -->
+  <div
+    class="relative max-h-96 overflow-y-auto"
+    scroll-region=""
   >
-    <ApplicationsTable :applications="filterPendings(results)" />
-  </InfiniteLoadingHelper>
+    <InfiniteScroll
+      :key="scrollKey"
+      :data="scrollKey"
+      :items-element="`#${bodyId}`"
+      preserve-url
+    >
+      <ApplicationsTable
+        :applications="applications"
+        :body-id="bodyId"
+      />
+    </InfiniteScroll>
+  </div>
 </template>
 
 <script>
-import InfiniteLoadingHelper from "@/Shared/InfiniteLoadingHelper.vue";
+import { InfiniteScroll } from "@inertiajs/vue3";
 import ApplicationsTable from "@/Pages/Corporation/Recruitment/ApplicationsTable/ApplicationsTable.vue";
 
 export default {
     name: "PendingTable",
     components: {
         ApplicationsTable,
-         InfiniteLoadingHelper,
+        InfiniteScroll,
     },
     props: {
         stepCount: {
@@ -30,16 +40,16 @@ export default {
         }
     },
     computed: {
-        routeParams() {
-            return {
-                corporation_id: this.corporationId,
-                decision_count: this.stepCount
-            }
-        }
-    },
-    methods: {
-        filterPendings(pendings) {
-            return _.filter(pendings, {decision_count: this.stepCount})
+        // Open applications are delivered as a page scroll prop keyed per corporation +
+        // review step (GetRecruitmentIndexController), consumed via <InfiniteScroll :data>.
+        scrollKey() {
+            return `open_${this.corporationId}_${this.stepCount}`
+        },
+        bodyId() {
+            return `open-body-${this.corporationId}-${this.stepCount}`
+        },
+        applications() {
+            return this.$page.props[this.scrollKey]?.data ?? []
         }
     }
 }

--- a/resources/js/Pages/Corporation/Recruitment/CorporationRecruitment.vue
+++ b/resources/js/Pages/Corporation/Recruitment/CorporationRecruitment.vue
@@ -35,7 +35,9 @@
         @select="changeActiveTab"
       />
 
-      <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg relative max-h-96 overflow-y-auto">
+      <!-- The table components own their own scroll-region container (needed by
+           <InfiniteScroll>), so this wrapper must not add a second scroll container. -->
+      <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg relative">
         <PendingTable
           v-if="isPending"
           :step-count="stepIndex"

--- a/src/Http/Controllers/Corporation/Recruitment/GetRecruitmentIndexController.php
+++ b/src/Http/Controllers/Corporation/Recruitment/GetRecruitmentIndexController.php
@@ -31,8 +31,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
+use Inertia\ScrollProp;
+use Seatplus\Eveapi\Models\Application;
 use Seatplus\Eveapi\Models\Recruitment\Enlistments;
 use Seatplus\Web\Http\Controllers\Controller;
+use Seatplus\Web\Http\Resources\ApplicationRessource;
 
 class GetRecruitmentIndexController extends Controller
 {
@@ -44,11 +47,74 @@ class GetRecruitmentIndexController extends Controller
     {
         $can_manage_recruitment = auth()->user()->can(self::MANAGEPERMISSION);
 
+        $enlistments = $this->getEnlistments();
+
         return Inertia::render('Corporation/Recruitment/RecruitmentIndex', [
             'canManageRecruitment' => $can_manage_recruitment,
-            'enlistments' => $this->getEnlistments(),
+            'enlistments' => $enlistments,
             'activeSidebarElement' => 'corporation.recruitment',
+            // One infinite-scroll prop per (corporation × review step) for open applications
+            // plus one per corporation for closed applications. Each paginator uses its own
+            // pageName so their scroll state never collides; the frontend <InfiniteScroll>
+            // reads it via the matching `open_{corporation}_{step}` / `closed_{corporation}`
+            // key. Scroll props are deferred, so only the table the recruiter is looking at
+            // actually resolves — replacing the per-list axios endpoints.
+            ...$this->applicationScrollProps($enlistments),
         ]);
+    }
+
+    /**
+     * Build the per-enlistment infinite-scroll props for open (per review step) and
+     * closed applications.
+     *
+     * @return array<string, ScrollProp>
+     */
+    private function applicationScrollProps(Collection $enlistments): array
+    {
+        $props = [];
+
+        foreach ($enlistments as $enlistment) {
+            $corporationId = $enlistment->corporation_id;
+
+            foreach (range(0, max($enlistment->steps_count - 1, 0)) as $decisionCount) {
+                $key = "open_{$corporationId}_{$decisionCount}";
+
+                $props[$key] = Inertia::scroll(
+                    fn () => ApplicationRessource::collection(
+                        $this->openApplicationsQuery($corporationId, $decisionCount)->paginate(pageName: $key)
+                    ),
+                );
+            }
+
+            $closedKey = "closed_{$corporationId}";
+
+            $props[$closedKey] = Inertia::scroll(
+                fn () => ApplicationRessource::collection(
+                    $this->closedApplicationsQuery($corporationId)->paginate(pageName: $closedKey)
+                ),
+            );
+        }
+
+        return $props;
+    }
+
+    private function openApplicationsQuery(int $corporationId, int $decisionCount): Builder
+    {
+        return Application::query()
+            ->with('logEntries')
+            ->whereHas('logEntries', function (Builder $query) {
+                $query->where('type', 'decision');
+            }, '=', $decisionCount)
+            ->ofCorporation($corporationId)
+            ->whereStatus('open');
+    }
+
+    private function closedApplicationsQuery(int $corporationId): Builder
+    {
+        return Application::query()
+            ->ofCorporation($corporationId)
+            ->latest('updated_at')
+            ->where('status', '<>', 'open');
     }
 
     private function getEnlistments(): Collection

--- a/tests/Browser/RecruitmentApplicationsTest.php
+++ b/tests/Browser/RecruitmentApplicationsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Auth\Models\CharacterUser;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Application;
+use Seatplus\Eveapi\Models\Recruitment\Enlistments;
+
+/*
+ * Recruitment applications browser test, run against the assembled core app.
+ *
+ * A recruiter (in-game Director corp role → the affiliation path GetRecruitmentIndexController
+ * and CheckAffiliationForApplication both accept, plus the `can accept or deny applications`
+ * permission) opens an enlistment for their own corporation and looks at the applications.
+ *
+ * The pending / closed tables are now native Inertia <InfiniteScroll> lists over per-corporation
+ * scroll props (open_<corp>_<step> / closed_<corp>) — no axios. This proves both tables render
+ * their scroll body and merge at least the first page, and that the redesigned review page loads.
+ * Provisioning helpers (actingAsCharacter / giveCorporationRole) live in core's tests/Browser/Pest.php.
+ */
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('deviceVisit')) {
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+if (! function_exists('userOfCharacter')) {
+    function userOfCharacter(int $characterId): User
+    {
+        return CharacterUser::query()->where('character_id', $characterId)->firstOrFail()->user;
+    }
+}
+
+if (! function_exists('makeApplicationForCorporation')) {
+    /** Seed a distinct applicant user (with characters) and an application to $corporationId. */
+    function makeApplicationForCorporation(int $corporationId, string $status): Application
+    {
+        $applicant = User::factory()->create();
+
+        return Application::factory()->create([
+            'corporation_id' => $corporationId,
+            'applicationable_type' => User::class,
+            'applicationable_id' => $applicant->getKey(),
+            'status' => $status,
+        ]);
+    }
+}
+
+it('renders the pending and closed application tables and the review page', function (string $device) {
+    $character = actingAsCharacter();
+    $corporationId = $character->corporation->corporation_id;
+
+    // Director corp role grants recruitment access + corp affiliation; the permission mirrors the
+    // real recruiter grant and the `can accept or deny applications` gate on the routes.
+    giveCorporationRole($character);
+    userOfCharacter($character->character_id)
+        ->givePermissionTo(Permission::findOrCreate('can accept or deny applications'));
+
+    // Open the corporation for recruitment (single default "Open" step → the index shows an
+    // "Open" tab and a "Closed" tab).
+    Enlistments::create([
+        'corporation_id' => $corporationId,
+        'type' => 'user',
+    ]);
+
+    // One open application (0 decisions → open_<corp>_0) and one closed one (closed_<corp>).
+    $openApplication = makeApplicationForCorporation($corporationId, 'open');
+    makeApplicationForCorporation($corporationId, 'rejected');
+
+    $page = deviceVisit($device, '/corporation/recruitment');
+    $page->assertNoSmoke();
+
+    // The enlistment card renders the corporation directly (EntityBlock, no async id lookup).
+    $page->waitForText($character->corporation->name);
+
+    // Pending table: its <InfiniteScroll> scroll body loads at least the open application's row.
+    // assertScript auto-polls until the deferred open_<corp>_0 scroll prop has merged in.
+    $page->assertScript("document.querySelectorAll('#open-body-{$corporationId}-0 > div').length > 0");
+
+    // The closed tab is a hover/click nav on desktop; on mobile it is a native <select>, which
+    // Playwright drives differently — assert the closed table via the desktop nav only.
+    if ($device === 'desktop') {
+        $page->click('Closed');
+        $page->assertScript("document.querySelectorAll('#closed-body-{$corporationId} > div').length > 0");
+        $page->assertSee('Activity Log');
+    }
+
+    snap($page, "recruitment-applications-{$device}");
+
+    // Redesigned review page: CardWithHeader + useForm decision form.
+    $review = deviceVisit($device, "/corporation/recruitment/application/{$openApplication->id}");
+    $review->assertNoSmoke();
+    $review->waitForText('Decision');
+    $review->assertSee('Accept application');
+    $review->assertSee('Reject application');
+    $review->assertSee('Submit review');
+
+    snap($review, "recruitment-application-review-{$device}");
+})->with(['desktop', 'iphone']);


### PR DESCRIPTION
## Scope

Modernises the least-consistent corner of the app — the corporation **recruitment application tables** — and drops axios/Ziggy from them.

## Pending & Closed tables → native `<InfiniteScroll>`

- `PendingTable.vue` / `ClosedTable.vue` no longer use the axios `InfiniteLoadingHelper`. They now render Inertia's native `<InfiniteScroll>` over page-level scroll props built by `GetRecruitmentIndexController`:
  - `open_<corporation>_<step>` — one per corporation × review step.
  - `closed_<corporation>` — one per corporation.
  - Each is an `Inertia::scroll(fn () => ApplicationRessource::collection(…->paginate(pageName:)))` (deferred, so only the table the recruiter is looking at resolves). This replaces the per-list `open.corporation.applications` / `closed.corporation.applications` axios endpoints for the UI.
- Each table owns its `scroll-region` container and targets the row `<ul>` via `items-element` (`#open-body-…` / `#closed-body-…`), mirroring the migrated wallet lists. `CorporationRecruitment.vue`'s wrapper no longer adds a second scroll container.

## Bugs fixed

- **Malformed closing tag** in `ApplicationsTable.vue`: `</stickyheadercell>` (lowercase) → `<StickyHeaderCell>`.
- **Broken error binding** in `Application.vue`: the rejection explanation read `$page.errors.explanation` (wrong — `errors` lives under `$page.props`), so the validation message never rendered. Now uses `form.errors.explanation` via `useForm`.
- **Buggy list key** in `ApplicationsTable.vue`: `:key="applicant"` (the whole object) → `:key="applicant.application_id"`.

## `Application.vue` — full redesign

- Rebuilt the hand-rolled inline modal-panel markup (`inline-block align-bottom … shadow-xl transform …`) as a proper `CardWithHeader` form.
- Dropped the v2 plugin classes (`form-radio`, `form-textarea`) and the hand-rolled indigo submit button; now uses modern Tailwind, shared `Forms/InputWithValidation.vue` and the shared `Button`.
- Replaced raw `router.post` with Inertia `useForm` (`form.errors`).
- Replaced `route()` (Ziggy) for review + impersonate with Wayfinder actions.
- Preserved the submit endpoints/fields (`review.application`, `impersonate.recruit`).

## axios/Ziggy removal

- `ActivityLogModal.vue`: raw `axios` + `route()` → `getJson` (`Functions/http`) + Wayfinder `getActivityLog`.
- `ApplicationsTable.vue`: `route('get.application', …)` → Wayfinder `getApplication`.

## Backend

- `GetRecruitmentIndexController` now provides the application scroll props. The legacy JSON list endpoints (`getOpenCorporationApplications` / `getClosedCorporationApplications`) are left untouched (signatures preserved; still covered by `RecruitmentLifeCycleTest`); the UI simply no longer calls them.

## Tests

- Added `tests/Browser/RecruitmentApplicationsTest.php` (desktop + iPhone): a Director/recruiter opens an enlistment; the pending and closed `<InfiniteScroll>` tables render their scroll bodies and the redesigned review page loads.

## Verification

- `eslint` on all changed `.vue` — clean.
- `pint` on changed `.php` — clean.
- `phpstan` on the changed controller — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)