### PR TITLE
refactor: drop axios + Ziggy from recruitment review tabs (log + update character)

### DIFF
--- a/resources/js/Pages/Corporation/Recruitment/Tabs/LogTab.vue
+++ b/resources/js/Pages/Corporation/Recruitment/Tabs/LogTab.vue
@@ -92,7 +92,7 @@
             </ul>
           </div>
           <div class="mt-6">
-            <form @submit.prevent="form.put(route('comment.application', application.id),{ onSuccess: () => form.reset('comment') })">
+            <form @submit.prevent="form.put(addComment.url(application.id),{ onSuccess: () => form.reset('comment') })">
               <div class="flex space-x-3">
                 <div class="shrink-0">
                   <div class="relative">
@@ -153,6 +153,7 @@ import { computed } from "vue";
 import EveImage from "@/Shared/EveImage.vue";
 import Time from "@/Shared/Time.vue";
 import { useForm, usePage } from "@inertiajs/vue3";
+import { addComment } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ApplicationsController";
 
 export default {
     name: "LogTab",
@@ -215,7 +216,8 @@ export default {
         return {
             activity,
             user,
-            form
+            form,
+            addComment
         }
     }
 }

--- a/resources/js/Pages/Corporation/Recruitment/UpdateCharacterComponent.vue
+++ b/resources/js/Pages/Corporation/Recruitment/UpdateCharacterComponent.vue
@@ -56,6 +56,8 @@ import Button from "@/Shared/Layout/Button.vue";
 import {computed, ref, watch} from "vue";
 import dayjs from "dayjs";
 import Time from "@/Shared/Time.vue";
+import { getJson, post } from "@/Functions/http";
+import { getBatchUpdate, dispatchBatchUpdate } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ApplicationsController";
 
 export default {
     name: "UpdateCharacterComponent",
@@ -74,11 +76,11 @@ export default {
 
         const canUpdate = computed(() => _.isNil(batchUpdate.value.finished_at) || dayjs(batchUpdate.value.finished_at).isBefore(dayjs().subtract(1,'hour')))
 
-        const getUpdate = async () => axios.get(route('get.batch_update', props.character.character_id))
-            .then((response) => {
-                batchUpdate.value = response.data
+        const getUpdate = async () => getJson(getBatchUpdate.url(props.character.character_id))
+            .then((data) => {
+                batchUpdate.value = data
 
-                if(response.data.finished_at) {
+                if(data.finished_at) {
                     isUpdating.value = false
                 }
             })
@@ -86,7 +88,7 @@ export default {
         const updateCharacter = function () {
             isUpdating.value = true;
 
-            axios.post(route('dispatch.batch_update', props.character.character_id))
+            post(dispatchBatchUpdate.url(props.character.character_id))
         }
 
         watch(isUpdating,(newValue) => {

--- a/tests/Browser/RecruitmentReviewTest.php
+++ b/tests/Browser/RecruitmentReviewTest.php
@@ -1,0 +1,197 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Auth\Models\CharacterUser;
+use Seatplus\Auth\Models\Permissions\Permission;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\Models\Application;
+use Seatplus\Eveapi\Models\BatchUpdate;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\Recruitment\ApplicationLogs;
+
+if (! function_exists('deviceVisit')) {
+    /**
+     * Visit $url on the given viewport ("desktop" or "iphone"). Browser tests run in the core app,
+     * whose tests/Pest.php is not overlaid, so this helper is defined here (guarded) alongside the
+     * suite's other function_exists helpers rather than in tests/Pest.php.
+     */
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        // iPhone: build a persistent page at the mobile viewport the same way visit() builds the
+        // desktop one, so the page loads mobile from the start (no desktop-load-then-resize reflow,
+        // no per-call re-navigation like ->on()->iPhone15()).
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    /**
+     * Settle before screenshotting: flip lazy EVE-image portraits/logos to eager so off-screen
+     * (full-page) images fetch, wait for the network to go idle, then capture — so screenshots show
+     * resolved images instead of loading placeholders. Best-effort: a slow/absent image won't fail.
+     */
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+if (! function_exists('realCharacterId')) {
+    /**
+     * A real EVE character id (verified CEO) so images.evetech.net serves a real portrait in
+     * screenshots instead of the generic default it returns for fabricated ids. Picks one not yet
+     * used in this (RefreshDatabase-isolated) test; falls back to a random id if the pool is spent.
+     */
+    function realCharacterId(): int
+    {
+        $pool = [197343093, 1319140135, 92081232, 1191750472, 94391213, 887625289, 1435633555, 1809892636];
+        $available = array_values(array_diff($pool, CharacterInfo::query()->pluck('character_id')->all()));
+
+        return $available[0] ?? fake()->unique()->numberBetween(9000000, 98000000);
+    }
+}
+
+/*
+ * Recruitment character-review browser tests — run against the real assembled core app.
+ *
+ * Covers the (axios/Ziggy-free) review page at /corporation/recruitment/application/{id}:
+ *   - LogTab.vue: the default "Log" tab renders the application activity timeline and the
+ *     "Leave a comment" form (the comment PUT now targets a Wayfinder action url()).
+ *   - UpdateCharacterComponent.vue: the per-character "… last updated" block + "Update" button;
+ *     the update action now fetches/dispatches via Functions/http (getJson/post) + Wayfinder
+ *     instead of raw axios + Ziggy route().
+ *
+ * The acting user is made a superuser so it bypasses both the `can accept or deny applications`
+ * route permission and the CheckAffiliationForApplication middleware — a browser test only needs
+ * to reach and render the page, not exercise the affiliation resolution (covered by feature tests).
+ */
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('actingAsRecruiter')) {
+    /**
+     * Turn the logged-in character's user into a superuser recruiter, so it may open any
+     * application review page. Mirrors the superuser setup used by the recruitment feature tests.
+     */
+    function actingAsRecruiter(CharacterInfo $character): User
+    {
+        $user = User::whereMainCharacterId($character->character_id)->sole();
+        $user->givePermissionTo(Permission::findOrCreate('superuser'));
+
+        return $user;
+    }
+}
+
+if (! function_exists('makeRecruitApplication')) {
+    /**
+     * Build an open, User-type application under review: a recruit User owning a single real
+     * character (with a finished BatchUpdate so the "Update" action is eligible) plus one comment
+     * log entry authored by $reviewer. Returns [$application, $recruitCharacter].
+     *
+     * @return array{0: Application, 1: CharacterInfo}
+     */
+    function makeRecruitApplication(User $reviewer): array
+    {
+        // Recruit account: one owned character, wired up the same way actingAsCharacter() builds
+        // the logged-in user (main_character_id + CharacterUser pivot) so recruit.main_character and
+        // recruit.characters both resolve in Pages/Corporation/Recruitment/Application.vue.
+        $recruitCharacter = CharacterInfo::factory()->create(['character_id' => realCharacterId()]);
+
+        $recruit = new User;
+        $recruit->main_character_id = $recruitCharacter->character_id;
+        $recruit->save();
+
+        CharacterUser::create([
+            'user_id' => $recruit->getKey(),
+            'character_id' => $recruitCharacter->character_id,
+            'character_owner_hash' => sha1((string) $recruitCharacter->character_id),
+        ]);
+
+        // Finished > 1h ago → UpdateCharacterComponent.canUpdate is true, so both the last-updated
+        // timestamp and the "Update" button render.
+        BatchUpdate::create([
+            'batchable_id' => $recruitCharacter->character_id,
+            'batchable_type' => CharacterInfo::class,
+            'started_at' => now()->subHours(3),
+            'finished_at' => now()->subHours(2),
+        ]);
+
+        $application = Application::factory()->create([
+            'corporation_id' => CorporationInfo::factory()->create()->corporation_id,
+            'applicationable_type' => User::class,
+            'applicationable_id' => $recruit->getKey(),
+            'status' => 'open',
+        ]);
+
+        // One reviewer comment so the activity timeline renders a comment entry (its causer must
+        // resolve a main_character, which the reviewer superuser has).
+        ApplicationLogs::create([
+            'application_id' => $application->id,
+            'causer_id' => $reviewer->getKey(),
+            'causer_type' => User::class,
+            'type' => 'comment',
+            'comment' => 'Looks promising, reviewing the assets next.',
+        ]);
+
+        return [$application, $recruitCharacter];
+    }
+}
+
+it('renders the application activity log on the default Log tab', function (string $device) {
+    $recruiterCharacter = actingAsCharacter();
+    $reviewer = actingAsRecruiter($recruiterCharacter);
+
+    [$application, $recruitCharacter] = makeRecruitApplication($reviewer);
+
+    $page = deviceVisit($device, "/corporation/recruitment/application/{$application->id}");
+    $page->assertNoSmoke();
+
+    // Log is the default active tab: the timeline header, the synthetic "has applied" decision
+    // entry, and the comment form are all present without switching tabs.
+    $page->waitForText('Activity Log');
+    $page->waitForText('has applied');
+    $page->waitForText('Looks promising, reviewing the assets next.');
+    $page->assertSee('Leave a comment');
+    $page->assertSee($recruitCharacter->name);
+
+    snap($page, "recruitment-review-log-tab-{$device}");
+})->with(['desktop', 'iphone']);
+
+it('renders the per-character update action and reflects an in-flight update', function (string $device) {
+    $recruiterCharacter = actingAsCharacter();
+    $reviewer = actingAsRecruiter($recruiterCharacter);
+
+    [$application, $recruitCharacter] = makeRecruitApplication($reviewer);
+
+    $page = deviceVisit($device, "/corporation/recruitment/application/{$application->id}");
+    $page->assertNoSmoke();
+
+    // UpdateCharacterComponent renders "<name> last updated" and, since the last BatchUpdate
+    // finished > 1h ago, an "Update" button.
+    $page->waitForText("{$recruitCharacter->name} last updated");
+    $page->assertSee('Update');
+
+    snap($page, "recruitment-review-update-character-{$device}");
+
+    // Clicking Update flips the component into its in-flight state ("updating" + spinner). This
+    // exercises the migrated post()/Wayfinder dispatch path (formerly axios.post + Ziggy route()).
+    $page->click('Update');
+    $page->waitForText('updating');
+
+    snap($page, "recruitment-review-update-character-updating-{$device}");
+})->with(['desktop', 'iphone']);


### PR DESCRIPTION
## What

Migrates the recruitment character-review components off raw **axios** and **Ziggy `route()`** onto the axios-free stack (native-fetch `@/Functions/http` + Wayfinder typed actions), continuing the B2/B3 axios/Ziggy removal effort. Only `LogTab.vue` + `UpdateCharacterComponent.vue` are touched; the sibling Asset/Contract/Wallet tabs already reuse migrated shared components and are left alone.

### Changes

- **`Tabs/LogTab.vue`** — the "Leave a comment" form PUT now targets `addComment.url(application.id)` (imported from `@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ApplicationsController`) instead of `route('comment.application', …)`. Timeline markup untouched.
- **`UpdateCharacterComponent.vue`** — the batch-update poll and dispatch now use `getJson` / `post` from `@/Functions/http` against `getBatchUpdate.url()` / `dispatchBatchUpdate.url()` Wayfinder urls, replacing the two `axios.get`/`axios.post` + `route()` calls. `getJson` returns the parsed body directly (no `response.data`).

## Tests

Adds `tests/Browser/RecruitmentReviewTest.php` — opens `/corporation/recruitment/application/{id}` as a superuser recruiter and asserts:
- the default **Log** tab renders the activity timeline (`Activity Log`, the "has applied" entry, a reviewer comment) and the "Leave a comment" form;
- **UpdateCharacterComponent** renders `<name> last updated` + the `Update` button, and clicking it flips the component into its in-flight `updating` state (exercising the migrated `post()`/Wayfinder dispatch path).

Real EVE ids + factories + `snap()`, desktop + iPhone matrix, per existing browser-test conventions.

## Verification

- `eslint` on both changed Vue files: clean.
- `pint` on the new browser test: clean.
- Per repo policy, `pest` / `npm build` / `wayfinder:generate` were **not** run here (Wayfinder actions are generated in the core "Browser (vs core)" CI job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)