### PR TITLE
fix(settings): eager-load characters.refreshToken on server settings user list

### DIFF
--- a/src/Http/Controllers/Configuration/SeatPlusController.php
+++ b/src/Http/Controllers/Configuration/SeatPlusController.php
@@ -52,7 +52,9 @@ class SeatPlusController extends Controller
             'search_param' => 'string',
         ]);
 
-        $query = User::with('characters', 'characters.alliance', 'characters.corporation', 'mainCharacter.corporation');
+        // UserRessource reads each character's refreshToken (for its granted scopes), so eager-load it
+        // to avoid a lazy-loading violation under Model::preventLazyLoading().
+        $query = User::with('characters', 'characters.refreshToken', 'characters.alliance', 'characters.corporation', 'mainCharacter.corporation');
 
         if (request()->has('search_param')) {
             $query = $query->search($validatedData['search_param']);

--- a/tests/Feature/ServerSettingsTest.php
+++ b/tests/Feature/ServerSettingsTest.php
@@ -14,6 +14,11 @@ beforeEach(function () {
 });
 
 it('has users list', function () {
+    // A second user whose character/refreshToken is not pre-loaded — UserRessource reads each
+    // character's refreshToken for its scopes, so the list query must eager-load it (strict mode
+    // would otherwise raise a LazyLoadingViolationException, as it did on /configuration/settings).
+    Event::fakeFor(fn () => User::factory()->create());
+
     $response = test()->actingAs(test()->test_user)
         ->get(route('server.settings'));
 


### PR DESCRIPTION
## Problem

`/configuration/settings` (server settings user list) returned a 500:

> `LazyLoadingViolationException`: Attempted to lazy load [refreshToken] on model [CharacterInfo] but lazy loading is disabled.

`UserRessource` reads each character's `refreshToken` (to show its granted scopes), but `SeatPlusController::settings` didn't eager-load that relation — so under `Model::preventLazyLoading()` it blew up as soon as any listed user's character token wasn't already loaded.

## Fix

Add `characters.refreshToken` to the user-list eager-load.

## Test

The existing `has users list` test only exercised `test_user` (whose token is pre-loaded in setup), so it never reproduced. Added a second, not-preloaded factory user to the test — it fails without the fix and passes with it.

Pint / PHPStan / feature tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)