### PR TITLE
feat(recruitment): manage a corporation's required SSO scopes from Manage Recruitment

### DIFF
--- a/resources/js/Pages/Recruitment/Manage/Index.vue
+++ b/resources/js/Pages/Recruitment/Manage/Index.vue
@@ -93,6 +93,7 @@
       :key="posting.corporation_id"
       :posting="posting"
       :control-groups="controlGroups"
+      :available-scopes="availableScopes"
     />
   </div>
 </template>
@@ -118,6 +119,10 @@ const props = defineProps({
   openUrl: {
     required: true,
     type: String,
+  },
+  availableScopes: {
+    required: true,
+    type: Object,
   },
 });
 

--- a/resources/js/Pages/Recruitment/Manage/ManagePostingCard.vue
+++ b/resources/js/Pages/Recruitment/Manage/ManagePostingCard.vue
@@ -166,6 +166,43 @@
       </div>
     </div>
 
+    <div class="border-t border-gray-100 pt-3 space-y-3">
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-500"
+        @click="scopesOpen = !scopesOpen"
+      >
+        {{ scopesOpen ? 'Hide' : 'Manage' }} required SSO scopes
+        <span
+          v-if="form.selected_scopes.length > 0"
+          class="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700"
+          title="ESI scopes characters must grant for this corporation"
+        >
+          {{ form.selected_scopes.length }} required
+        </span>
+      </button>
+
+      <div
+        v-if="scopesOpen"
+        class="space-y-4"
+      >
+        <p class="text-xs text-gray-500">
+          Characters must have granted these ESI scopes to be compliant for this corporation — checked
+          both while reviewing an applicant and while observing an employee. Clearing every scope removes
+          the corporation from Observation.
+        </p>
+
+        <CharacterScopes
+          v-model:selected-scopes="form.selected_scopes"
+          :scopes="availableScopes.character"
+        />
+        <CorporationScopes
+          v-model:selected-scopes="form.selected_scopes"
+          :scopes="availableScopes.corporation"
+        />
+      </div>
+    </div>
+
     <div class="flex items-center justify-between pt-2 border-t border-gray-100">
       <button
         type="button"
@@ -195,6 +232,8 @@ import EveImage from "@/Shared/EveImage.vue";
 import EsiMultiselect from "@/Shared/Components/EsiMultiselect.vue";
 import Autosuggest from "@/Shared/Components/Autosuggest.vue";
 import DismissibleButton from "@/Shared/Layout/Buttons/DismissibleButton.vue";
+import CharacterScopes from "@/Pages/Configuration/Scopes/CharacterScopes.vue";
+import CorporationScopes from "@/Pages/Configuration/Scopes/CorporationScopes.vue";
 
 const props = defineProps({
   posting: {
@@ -205,9 +244,13 @@ const props = defineProps({
     required: true,
     type: Array,
   },
+  availableScopes: {
+    required: true,
+    type: Object,
+  },
 });
 
-// One form covers the whole posting configuration: its review stages and its watchlist.
+// One form covers the whole posting configuration: its review stages, watchlist and required scopes.
 const form = useForm({
   stages: props.posting.stages.map((stage) => ({
     label: stage.label,
@@ -216,11 +259,13 @@ const form = useForm({
   systems: props.posting.watched.systems,
   regions: props.posting.watched.regions,
   items: props.posting.watched.items,
+  selected_scopes: props.posting.required_scopes ?? [],
 });
 
 const closeForm = useForm({});
 
 const watchlistOpen = ref(false);
+const scopesOpen = ref(false);
 // Re-key the items autosuggest after each selection so it clears its input.
 const itemsKey = ref(0);
 

--- a/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
+++ b/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
@@ -8,6 +8,7 @@ use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Auth\Models\Permissions\Role;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\SsoScopes;
 use Seatplus\Web\Http\Actions\Corporation\Recruitment\WatchedArrayAction;
 use Seatplus\Web\Http\Controllers\Controller;
 use Seatplus\Web\Models\Recruitment\Enlistment;
@@ -37,6 +38,7 @@ class ManageRecruitmentController extends Controller
         $postings = Enlistment::query()
             ->with([
                 'corporation.alliance',
+                'corporation.ssoScopes',
                 'reviewRounds' => fn (HasMany $query) => $query->orderBy('position'),
             ])
             ->when(! $isSuperuser, fn (Builder $query) => $query->whereIn('corporation_id', $manageableIds))
@@ -44,6 +46,7 @@ class ManageRecruitmentController extends Controller
             ->map(function (Enlistment $posting) {
                 /** @var CorporationInfo $corporation */
                 $corporation = $posting->corporation;
+                $ssoScopes = $corporation->ssoScopes;
 
                 return [
                     'corporation_id' => $posting->corporation_id,
@@ -61,6 +64,8 @@ class ManageRecruitmentController extends Controller
                     'save_url' => route('recruitment.posting.save', $posting->corporation_id),
                     // Item/location watchlist for observing applicant (and later employee) assets & contracts.
                     'watched' => (new WatchedArrayAction)->execute($posting->corporation_id),
+                    // The corporation's currently required SSO scopes (compliance + application), edited here.
+                    'required_scopes' => $ssoScopes instanceof SsoScopes ? ($ssoScopes->selected_scopes ?? []) : [],
                 ];
             })
             ->all();
@@ -70,6 +75,8 @@ class ManageRecruitmentController extends Controller
             // Control groups available to gate a stage; a stage with no group falls back to the flat
             // recruiter permission.
             'controlGroups' => Role::query()->orderBy('name')->get(['id', 'name']),
+            // The full catalogue of ESI scopes a corporation can require, for the scope picker.
+            'availableScopes' => config('eveapi.scopes'),
             'openUrl' => route('recruitment.posting.open'),
         ]);
     }

--- a/src/Http/Controllers/Recruitment/PostingController.php
+++ b/src/Http/Controllers/Recruitment/PostingController.php
@@ -6,10 +6,12 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\SsoScopes;
 use Seatplus\Web\Http\Actions\Corporation\Recruitment\UpdateWatchlistAction;
 use Seatplus\Web\Http\Controllers\Controller;
 use Seatplus\Web\Models\Recruitment\Enlistment;
 use Seatplus\Web\Services\DispatchCorporationOrAllianceInfoJob;
+use Seatplus\Web\Services\SsoSettings\UpdateOrCreateSsoSettings;
 
 /**
  * HR/recruiter posting management: open or update a posting, close it, and configure its structured
@@ -80,6 +82,9 @@ class PostingController extends Controller
             'items' => ['array'],
             'items.*.watchable_id' => ['required'],
             'items.*.watchable_type' => ['required'],
+            // The corporation's required SSO scopes (managed here as the corp 'default' type).
+            'selected_scopes' => ['array'],
+            'selected_scopes.*' => ['string'],
         ]);
 
         $enlistment = Enlistment::query()->findOrFail($corporation_id);
@@ -97,7 +102,30 @@ class PostingController extends Controller
 
         $watchlist->execute($corporation_id, $validated);
 
+        $this->saveRequiredScopes($corporation_id, $validated['selected_scopes'] ?? []);
+
         return back()->with('success', 'Posting saved');
+    }
+
+    /**
+     * Persist (or clear) the corporation's required SSO scopes as the corp 'default' type. Clearing
+     * removes the record entirely, so the corporation drops out of the SSO-gated observation list.
+     *
+     * @param  array<int, string>  $selectedScopes
+     */
+    private function saveRequiredScopes(int $corporation_id, array $selectedScopes): void
+    {
+        if ($selectedScopes === []) {
+            SsoScopes::query()->where('morphable_id', $corporation_id)->delete();
+
+            return;
+        }
+
+        (new UpdateOrCreateSsoSettings([
+            'selectedScopes' => $selectedScopes,
+            'selectedEntities' => [['id' => $corporation_id, 'category' => 'corporation']],
+            'type' => 'default',
+        ]))->execute();
     }
 
     private function authorizeCorporation(int $corporationId): void

--- a/tests/Feature/Recruitment/ManageRecruitmentTest.php
+++ b/tests/Feature/Recruitment/ManageRecruitmentTest.php
@@ -2,6 +2,7 @@
 
 use Inertia\Testing\AssertableInertia as Assert;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\SsoScopes;
 use Seatplus\Web\Models\Recruitment\Enlistment;
 use Seatplus\Web\Models\Recruitment\EnlistmentReviewRound;
 
@@ -20,7 +21,9 @@ it('renders the manage workspace with the manageable postings', function () {
         ->assertInertia(fn (Assert $page) => $page
             ->component('Recruitment/Manage/Index')
             ->has('postings', 1)
+            ->has('postings.0.required_scopes')
             ->has('controlGroups')
+            ->has('availableScopes')
         );
 });
 
@@ -51,6 +54,45 @@ it('replaces the review stages of a posting', function () {
 
     expect(EnlistmentReviewRound::query()->where('corporation_id', $corp->corporation_id)->orderBy('position')->pluck('label')->all())
         ->toBe(['Screen', 'Final']);
+});
+
+it('saves the corporation required SSO scopes as the default type', function () {
+    $corp = CorporationInfo::factory()->create();
+    Enlistment::query()->create(['corporation_id' => $corp->corporation_id, 'type' => 'user']);
+    EnlistmentReviewRound::factory()->create(['corporation_id' => $corp->corporation_id, 'position' => 0, 'label' => 'Open']);
+
+    test()->actingAs(test()->test_user)
+        ->put(route('recruitment.posting.save', $corp->corporation_id), [
+            'stages' => [['label' => 'Open', 'role_id' => null]],
+            'selected_scopes' => ['esi-assets.read_assets.v1'],
+        ])
+        ->assertRedirect();
+
+    $scopes = SsoScopes::query()->where('morphable_id', $corp->corporation_id)->first();
+
+    expect($scopes)->not->toBeNull()
+        ->and($scopes->type)->toBe('default')
+        ->and($scopes->selected_scopes)->toContain('esi-assets.read_assets.v1');
+});
+
+it('removes the required SSO scopes when the selection is cleared', function () {
+    $corp = CorporationInfo::factory()->create();
+    Enlistment::query()->create(['corporation_id' => $corp->corporation_id, 'type' => 'user']);
+    EnlistmentReviewRound::factory()->create(['corporation_id' => $corp->corporation_id, 'position' => 0, 'label' => 'Open']);
+    SsoScopes::factory()->create([
+        'morphable_id' => $corp->corporation_id,
+        'morphable_type' => CorporationInfo::class,
+        'type' => 'default',
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->put(route('recruitment.posting.save', $corp->corporation_id), [
+            'stages' => [['label' => 'Open', 'role_id' => null]],
+            'selected_scopes' => [],
+        ])
+        ->assertRedirect();
+
+    expect(SsoScopes::query()->where('morphable_id', $corp->corporation_id)->exists())->toBeFalse();
 });
 
 it('closes a posting and cascades its stages', function () {


### PR DESCRIPTION
## What

Adds a **Required SSO scopes** section to each posting in **Manage Recruitment**, so a recruiter can set the corporation's required ESI scopes right where they manage its posting — instead of only in the superuser **Settings → Scopes** area.

- Saved as the corp **`default`** `SsoScopes` (reuses `UpdateOrCreateSsoSettings`).
- **Clearing** the selection deletes the record → the corp drops out of the SSO-gated Observation list.
- Reuses the existing `CharacterScopes` / `CorporationScopes` pickers + `config('eveapi.scopes')`.
- Director / `can open or close corporations for recruitment`-gated (same as the rest of Manage).

## Scope of this change (and what's intentionally left in Settings)

These are the **corporation's** compliance scopes — they gate **ongoing member compliance** in Observation, not just applications — so the UI labels them that way to avoid the "application-only" misread.

**Alliance** and **global** scopes stay in **Settings → Scopes** (broader blast radius → admin-gated). To add alliance scope requirements, select the alliance entity there.

## Tests

`ManageRecruitmentTest`: page exposes `required_scopes` + `availableScopes`; saving persists the corp `default` scopes; clearing removes the record. Pint / PHPStan / 100% type-coverage / ESLint green.

> Base is the observation branch because Manage Recruitment lives there (not yet on 5.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)