### PR TITLE
refactor: Member Tracking → Inertia InfiniteScroll (drop axios/Ziggy)

### DIFF
--- a/resources/js/Pages/Corporation/MemberTracking/MemberTrackingComponent.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTrackingComponent.vue
@@ -9,7 +9,12 @@
       </div>
     </template>
 
-    <div class="relative max-h-96 overflow-y-auto">
+    <!-- scroll-region: lets Inertia track/restore this custom scroll container's
+         position, so <InfiniteScroll> merges the next page without jumping to top. -->
+    <div
+      class="relative max-h-96 overflow-y-auto"
+      scroll-region=""
+    >
       <div class="hidden sm:grid grid-cols-12 gap-x-0 gap-y-1 grid-flow-row z-10 sticky top-0 border-t border-b border-gray-200 bg-gray-50 text-sm font-medium text-gray-500">
         <div class="px-3 py-1 col-span-4">
           Name
@@ -28,20 +33,59 @@
         </div>
       </div>
 
-      <ul class="relative z-0">
-        <MemberTrackingListElementForSmallDevices
-          v-for="member in result"
-          :key="member.character_id"
-          :member="member"
-        />
-        <MemberTrackingListElement
-          v-for="(member, index) in result"
-          :key="member.character_id"
-          :member="member"
-          :even="index%2"
-        />
-        <div ref="scrollComponent" />
-      </ul>
+      <!-- Native Inertia v3 infinite scroll over the page-level `members_<corporation>`
+           scroll prop (MemberTrackingController::index), replacing the axios/Ziggy
+           useInfinityScrolling loader. -->
+      <InfiniteScroll
+        :data="scrollKey"
+        :items-element="`#${scrollBodyId}`"
+        preserve-url
+      >
+        <ul
+          :id="scrollBodyId"
+          class="relative z-0"
+        >
+          <MemberTrackingListElementForSmallDevices
+            v-for="member in members"
+            :key="`mobile-${member.character_id}`"
+            :member="member"
+          />
+          <MemberTrackingListElement
+            v-for="(member, index) in members"
+            :key="member.character_id"
+            :member="member"
+            :even="index % 2"
+          />
+        </ul>
+
+        <template #loading>
+          <div class="relative block w-full py-6 text-center">
+            <svg
+              class="animate-spin mx-auto h-8 w-8 text-gray-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              />
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            <span class="mt-2 block text-sm font-medium text-gray-500">
+              loading more members…
+            </span>
+          </div>
+        </template>
+      </InfiniteScroll>
     </div>
   </CardWithHeader>
 </template>
@@ -50,14 +94,17 @@
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import MemberTrackingListElement from "./MemberTrackingListElement.vue";
-import {useInfinityScrolling} from "@/Functions/useInfinityScrolling";
 import MemberTrackingListElementForSmallDevices from "./MemberTrackingListElementForSmallDevices.vue";
+import { InfiniteScroll } from "@inertiajs/vue3";
 
 export default {
     name: "MemberTrackingComponent",
     components: {
+        InfiniteScroll,
         MemberTrackingListElementForSmallDevices,
-        MemberTrackingListElement, EntityBlock, CardWithHeader
+        MemberTrackingListElement,
+        EntityBlock,
+        CardWithHeader
     },
     props: {
         corporation: {
@@ -65,9 +112,18 @@ export default {
             type: Object
         },
     },
-    setup(props) {
-
-        return useInfinityScrolling('get.corporation.member_tracking', {corporation_id: props.corporation.corporation_id})
+    computed: {
+        // The members list is delivered as a page scroll prop keyed per corporation
+        // (MemberTrackingController::index) and consumed by <InfiniteScroll :data="scrollKey">.
+        scrollKey() {
+            return `members_${this.corporation.corporation_id}`
+        },
+        scrollBodyId() {
+            return `members-body-${this.corporation.corporation_id}`
+        },
+        members() {
+            return this.$page.props[this.scrollKey]?.data ?? []
+        }
     }
 }
 </script>

--- a/routes/Routes/Corporation/MemberTracking.php
+++ b/routes/Routes/Corporation/MemberTracking.php
@@ -34,8 +34,4 @@ Route::prefix('tracking')
         Route::middleware(CheckAuthorization::class.':view member tracking,director')
             ->get('', [MemberTrackingController::class, 'index'])
             ->name('corporation.member_tracking');
-
-        Route::middleware(CheckAuthorization::class.':view member tracking,director')
-            ->get('/members/{corporation_id}', [MemberTrackingController::class, 'getMemberTracking'])
-            ->name('get.corporation.member_tracking');
     });

--- a/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
+++ b/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
@@ -26,8 +26,8 @@
 
 namespace Seatplus\Web\Http\Controllers\Corporation\MemberTracking;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
@@ -45,19 +45,37 @@ class MemberTrackingController extends Controller
             ->setIsCharacter(false)
             ->create(CorporationMemberTracking::class);
 
+        $corporations = $this->getAffiliatedCorporations($dispatchTransferObject);
+
+        // One InfiniteScroll prop per corporation (mirrors the wallet/contracts migration),
+        // replacing the axios/Ziggy useInfinityScrolling loader. Each paginator carries the
+        // MemberTrackingResource shape and its own pageName so the per-corporation scroll
+        // state never collides.
+        $members = $corporations->mapWithKeys(fn (CorporationInfo $corporation): array => [
+            "members_{$corporation->corporation_id}" => Inertia::scroll(
+                fn () => $this->memberQuery($corporation->corporation_id)
+                    ->paginate(pageName: "members_{$corporation->corporation_id}")
+                    ->through(fn (CorporationMemberTracking $member) => (new MemberTrackingResource($member))->resolve()),
+            ),
+        ])->all();
+
         return Inertia::render('Corporation/MemberTracking/MemberTracking', [
             'dispatchTransferObject' => $dispatchTransferObject,
-            'corporations' => $this->getAffiliatedCorporations($dispatchTransferObject),
+            'corporations' => $corporations,
+            ...$members,
         ]);
     }
 
-    public function getMemberTracking(int $corporation_id): AnonymousResourceCollection
+    /**
+     * Base query for a corporation's ESI member tracking with everything the row cells render.
+     * Pure ESI member tracking — SSO-scope compliance lives in Personnel → Observation.
+     *
+     * @return Builder<CorporationMemberTracking>
+     */
+    private function memberQuery(int $corporation_id): Builder
     {
-        // Pure ESI member tracking — SSO-scope compliance lives in Personnel → Observation.
-        $query = CorporationMemberTracking::where('corporation_id', $corporation_id)
+        return CorporationMemberTracking::where('corporation_id', $corporation_id)
             ->with('character', 'location.locatable', 'ship');
-
-        return MemberTrackingResource::collection($query->paginate());
     }
 
     private function getAffiliatedCorporations(DispatchTransferObject $dispatchTransferObject): Collection

--- a/tests/Browser/MemberTrackingTest.php
+++ b/tests/Browser/MemberTrackingTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Enums\Device;
+use Pest\Browser\Playwright\Playwright;
+use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
+
+if (! function_exists('deviceVisit')) {
+    /**
+     * Visit $url on the given viewport ("desktop" or "iphone"). Browser tests run in the core app,
+     * whose tests/Pest.php is not overlaid, so this helper is defined here (guarded) alongside the
+     * suite's other function_exists helpers rather than in tests/Pest.php.
+     */
+    function deviceVisit(string $device, string $url, array $options = []): mixed
+    {
+        // iPhone: build a persistent page at the mobile viewport the same way visit() builds the
+        // desktop one, so the page loads mobile from the start (no desktop-load-then-resize reflow,
+        // no per-call re-navigation like ->on()->iPhone15()).
+        if ($device === 'iphone') {
+            return new PendingAwaitablePage(
+                Playwright::defaultBrowserType(),
+                Device::IPHONE_15,
+                $url,
+                $options,
+            );
+        }
+
+        return visit($url, $options);
+    }
+}
+
+if (! function_exists('snap')) {
+    /**
+     * Settle before screenshotting: flip lazy EVE-image portraits/logos to eager so off-screen
+     * (full-page) images fetch, wait for the network to go idle, then capture — so screenshots show
+     * resolved images instead of loading placeholders. Best-effort: a slow/absent image won't fail.
+     */
+    function snap($page, string $name): void
+    {
+        $page->script("document.querySelectorAll('img').forEach((i) => { i.loading = 'eager'; });");
+        $page->waitForEvent('networkidle');
+        $page->screenshot(true, $name);
+    }
+}
+
+/*
+ * Corporation member tracking browser test.
+ *
+ * The page renders one card per affiliated corporation, each backed by a
+ * members_<corporation> infinite-scroll prop (Inertia <InfiniteScroll> over a page
+ * scroll prop) — the migration off the legacy axios/Ziggy useInfinityScrolling loader.
+ * Access is granted by the in-game Director corp role (giveCorporationRole) — not
+ * superuser — which CanUserService accepts, mirroring a real director viewing their
+ * corp. Provisioning helpers live in core's browser context (actingAsCharacter /
+ * giveCorporationRole).
+ */
+
+uses(RefreshDatabase::class);
+
+it('merges the next member page in on scroll', function (string $device) {
+    $character = actingAsCharacter();
+    $corporationId = $character->corporation->corporation_id;
+
+    // Director corp role → grants member-tracking access (no superuser / Spatie permission).
+    giveCorporationRole($character);
+
+    // 40 tracked members (default page size 15 → several pages) so scrolling the card's
+    // own container triggers InfiniteScroll to merge the next page. Distinct characters
+    // satisfy the (corporation_id, character_id) unique key.
+    CorporationMemberTracking::factory()
+        ->count(40)
+        ->sequence(fn ($sequence) => [
+            'start_date' => now()->subDays($sequence->index),
+            'logon_date' => now()->subHours($sequence->index),
+        ])
+        ->create(['corporation_id' => $corporationId]);
+
+    $page = deviceVisit($device, '/corporation/tracking');
+    $page->assertNoSmoke();
+    $page->assertSee('Member Tracking');
+    $page->waitForText('Member Tracking');
+
+    // Scroll the card's own container to the bottom → InfiniteScroll's end trigger fires
+    // and merges the next page. assertScript auto-polls until the row count grows.
+    $bodyId = "members-body-{$corporationId}";
+    $rows = "#{$bodyId} > li";
+    $before = (int) $page->script("document.querySelectorAll('{$rows}').length");
+    expect($before)->toBeGreaterThan(0);
+
+    // Re-scroll to the bottom on every poll (comma expression) so the observer reliably
+    // fires even if layout hadn't settled on the first attempt; passes once the next page
+    // has merged in.
+    $page->assertScript("(document.getElementById('{$bodyId}').closest('.overflow-y-auto').scrollTo(0, 1e6), document.querySelectorAll('{$rows}').length > {$before})");
+
+    snap($page, "corporation-member-tracking-infinite-scroll-{$device}");
+})->with(['desktop', 'iphone']);

--- a/tests/Feature/CorporationMemberTrackingTest.php
+++ b/tests/Feature/CorporationMemberTrackingTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Inertia\Testing\AssertableInertia as Assert;
+use Seatplus\Eveapi\Models\Character\CharacterRole;
+use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
 
 beforeEach(function () {
     test()->test_character->roles()->update(['roles' => ['']]);
@@ -20,4 +22,27 @@ test('has dispatchable job', function () {
         ->assertOk();
 
     $response->assertInertia(fn (Assert $page) => $page->has('dispatchTransferObject'));
+});
+
+test('exposes a per-corporation member scroll prop', function () {
+    $corporationId = test()->test_character->corporation->corporation_id;
+
+    // Director corp role grants member-tracking access and includes the corp in the
+    // affiliated ids (mirrors how a real director views their corp).
+    CharacterRole::updateOrCreate(
+        ['character_id' => test()->test_character->character_id],
+        ['roles' => ['Director']],
+    );
+
+    CorporationMemberTracking::factory()
+        ->count(3)
+        ->create(['corporation_id' => $corporationId]);
+
+    test()->actingAs(test()->test_user)
+        ->get(route('corporation.member_tracking'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Corporation/MemberTracking/MemberTracking')
+            ->has('corporations', 1)
+            ->has("members_{$corporationId}.data", 3)
+        );
 });


### PR DESCRIPTION
## What

Migrates the corporation **Member Tracking** list (last login / location / ship per member) off the legacy axios + Ziggy `useInfinityScrolling` loader onto native Inertia v3 `<InfiniteScroll>`, following the merged wallet/contracts migrations.

## Changes

- **Controller** (`MemberTrackingController::index`) now renders one page-level `members_<corporation>` scroll prop per affiliated corporation — `Inertia::scroll(fn () => …->paginate(pageName:))` with `->through()` carrying the `MemberTrackingResource` shape. Replaces the separate `get.corporation.member_tracking` JSON endpoint.
- **Route**: dropped the now-dead `/members/{corporation_id}` route + `getMemberTracking` action.
- **`MemberTrackingComponent.vue`**: consumes the prop via `<InfiniteScroll :data="scrollKey" :items-element>` inside a `scroll-region` container, with a `#loading` skeleton and empty-safe `members` computed. Keeps the desktop (`MemberTrackingListElement`) / mobile (`…ForSmallDevices`) row split unchanged.
- The shared `useInfinityScrolling.js` / `InfiniteLoadingHelper.vue` are left in place (still used by other pages — later teardown).

## Tests

- **Feature**: `CorporationMemberTrackingTest` now asserts the per-corporation `members_<id>` scroll prop is populated (Director-role access path).
- **Browser**: new `MemberTrackingTest` (desktop + iPhone) seeds 40 tracked members and verifies the next page merges in on scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)