### PR TITLE
refactor(settings): share settings navigation as a prop (drop axios)

### DIFF
--- a/resources/js/Pages/Configuration/Settings.vue
+++ b/resources/js/Pages/Configuration/Settings.vue
@@ -74,16 +74,16 @@ export default {
         return {
             pageTitle: 'Server Settings',
             currentRoute: '',
-            navTabs: []
+        }
+    },
+    computed: {
+        // Nav tabs are static config, shared eagerly by HandleInertiaRequests as page chrome —
+        // read them off the page props rather than fetching them after mount.
+        navTabs() {
+            return this.$page.props.settingsNavigation ?? []
         }
     },
     watch: {
-        navTabs(Tabs) {
-            _.each(Tabs, navTab => {
-                if(this.isActive(navTab.route))
-                    this.currentRoute = navTab.route
-            })
-        },
         currentRoute(currentRoute) {
             if(this.isActive(currentRoute))
                 return
@@ -92,11 +92,9 @@ export default {
         }
     },
     mounted() {
-        this.$nextTick(function () {
-            axios.get(route('settings.navigation')).then(result => {
-                this.navTabs = result.data
-            })
-        })
+        const active = this.navTabs.find(navTab => this.isActive(navTab.route))
+        if (active)
+            this.currentRoute = active.route
     },
     methods: {
         isActive(string) {

--- a/routes/Routes/Configuration/Configuration.php
+++ b/routes/Routes/Configuration/Configuration.php
@@ -38,9 +38,6 @@ Route::middleware([CheckAuthorization::class.':superuser'])->group(function () {
 
     Route::get('/start/impersonate/{user_id}', [SeatPlusController::class, 'impersonate'])->name('impersonate.start');
 
-    // TODO: create own controller for server
-    Route::get('/settings/navigation', [SeatPlusController::class, 'navigation'])->name('settings.navigation');
-
     Route::get('/settings/scopes/overview', OverviewController::class)->name('settings.scopes');
 
     Route::get('/settings/scopes/view/{entity_id}', [SsoSettingsController::class, 'index'])->name('view.scopes.settings');

--- a/src/Http/Controllers/Configuration/SeatPlusController.php
+++ b/src/Http/Controllers/Configuration/SeatPlusController.php
@@ -37,15 +37,6 @@ use Seatplus\Web\Services\ImpersonateService;
 
 class SeatPlusController extends Controller
 {
-    public function navigation(): string
-    {
-        $navigation_tabs = config('web.settings');
-
-        return collect($navigation_tabs)
-            ->map(fn (array $tab) => array_merge($tab, ['uri' => route($tab['route'])]))
-            ->toJson();
-    }
-
     public function settings(): Response
     {
         $validatedData = request()->validate([

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -97,6 +97,10 @@ class HandleInertiaRequests extends Middleware
                 'logo' => asset(config('web.images.logo')),
                 'icon' => asset(config('web.images.icon')),
             ],
+            // Server-settings navigation tabs. Static config (name/logo/route per tab), so it is
+            // shared eagerly as page chrome rather than fetched post-mount by Settings.vue — which
+            // removes an axios + Ziggy round-trip and the flash of empty tabs.
+            'settingsNavigation' => fn () => config('web.settings'),
             // The entity-picker slide-over's affiliated character/corporation list. Declared
             // `optional` so it is NOT resolved on ordinary page loads (no DB query, no cost) —
             // only when the picker's <WhenVisible data="affiliatedEntities"> scrolls into view and

--- a/tests/Browser/SettingsNavigationTest.php
+++ b/tests/Browser/SettingsNavigationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seatplus\Auth\Models\Permissions\Permission;
+
+require_once __DIR__.'/helpers.php';
+
+/*
+ * Server-settings navigation browser test.
+ *
+ * The settings tab bar is static config (name/logo/route per tab) shared eagerly by
+ * HandleInertiaRequests as `settingsNavigation` and read straight off the page props — there is
+ * no post-mount axios/Ziggy fetch anymore. This proves the tabs render on first paint for a
+ * superuser. The labels live in a desktop <nav> of <div>s AND a mobile <select> of <option>s, so
+ * the nav is asserted via innerHTML (present on both viewports) rather than a visibility-sensitive
+ * waitForText.
+ */
+
+uses(RefreshDatabase::class);
+
+it('renders the server-settings navigation from a shared prop', function (string $device) {
+    $character = actingAsCharacter();
+    userOfCharacter($character->character_id)->givePermissionTo(Permission::findOrCreate('superuser'));
+    cache()->flush();
+
+    $page = deviceVisit($device, route('server.settings', absolute: false));
+    // No assertNoSmoke here: the settings page's HorizonStats widget polls /queue/status on mount,
+    // which 500s under the test's Queue::fake (Horizon's WaitTimeCalculator calls QueueFake::readyNow).
+    // That console error is unrelated to the navigation this test covers.
+    $page->waitForText('Available Settings');
+
+    // Every configured tab rendered from the shared prop — no fetch required.
+    $page->assertScript("document.body.innerHTML.includes('User List') && document.body.innerHTML.includes('SSO Setting') && document.body.innerHTML.includes('Schedules')");
+
+    snap($page, "settings-navigation-{$device}");
+})->with(['desktop', 'iphone']);

--- a/tests/Feature/ServerSettingsTest.php
+++ b/tests/Feature/ServerSettingsTest.php
@@ -25,6 +25,16 @@ it('has users list', function () {
     $response->assertInertia(fn (Assert $page) => $page->component('Configuration/UserList'));
 });
 
+it('shares the settings navigation as a prop', function () {
+    $response = test()->actingAs(test()->test_user)
+        ->get(route('server.settings'));
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->has('settingsNavigation', count(config('web.settings')))
+        ->where('settingsNavigation.0.route', 'server.settings')
+    );
+});
+
 it('has server scopes', function () {
     $response = test()->actingAs(test()->test_user)
         ->get(route('settings.scopes'));


### PR DESCRIPTION
## What

`Settings.vue` fetched the settings tab bar post-mount via `axios.get(route('settings.navigation'))` — an extra round-trip (plus axios + Ziggy) for three **static config** items, with a flash of empty tabs.

Now `config('web.settings')` is shared eagerly by `HandleInertiaRequests` as **`settingsNavigation`** (like the `sidebar`/`user` chrome), and `Settings.vue` reads it off the page props.

- Removed: the `mounted()` axios call, `SeatPlusController::navigation()`, and the `settings.navigation` route (the client never used the server-computed `uri`, so it's dropped).

## Tests

- **Browser** `tests/Browser/SettingsNavigationTest.php` (desktop + iphone): superuser visits `/settings`; the nav renders from the shared prop with no fetch (asserted via `innerHTML`, viewport-agnostic — the labels live in a desktop `<nav>` and a mobile `<select>`).
- **Feature** `ServerSettingsTest`: `settingsNavigation` present with the configured tab count.
- Local gates: Pint ✅, PHPStan ✅, type-coverage 100% ✅, feature suite ✅. ESLint via CI.

First PR of the JSON-endpoint → Inertia defer/scroll sweep. Base `5.x` (browser-helpers extraction #1606 already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)