### PR TITLE
refactor(recruitment): UpdateCharacterComponent axios → fetch + Wayfinder

### DIFF
--- a/resources/js/Pages/Corporation/Recruitment/UpdateCharacterComponent.vue
+++ b/resources/js/Pages/Corporation/Recruitment/UpdateCharacterComponent.vue
@@ -56,6 +56,8 @@ import Button from "@/Shared/Layout/Button.vue";
 import {computed, ref, watch} from "vue";
 import dayjs from "dayjs";
 import Time from "@/Shared/Time.vue";
+import { getJson, post } from "@/Functions/http";
+import { getBatchUpdate, dispatchBatchUpdate } from "@/actions/Seatplus/Web/Http/Controllers/Corporation/Recruitment/ApplicationsController";
 
 export default {
     name: "UpdateCharacterComponent",
@@ -74,11 +76,11 @@ export default {
 
         const canUpdate = computed(() => _.isNil(batchUpdate.value.finished_at) || dayjs(batchUpdate.value.finished_at).isBefore(dayjs().subtract(1,'hour')))
 
-        const getUpdate = async () => axios.get(route('get.batch_update', props.character.character_id))
-            .then((response) => {
-                batchUpdate.value = response.data
+        const getUpdate = async () => getJson(getBatchUpdate.url(props.character.character_id))
+            .then((data) => {
+                batchUpdate.value = data
 
-                if(response.data.finished_at) {
+                if (data?.finished_at) {
                     isUpdating.value = false
                 }
             })
@@ -86,7 +88,7 @@ export default {
         const updateCharacter = function () {
             isUpdating.value = true;
 
-            axios.post(route('dispatch.batch_update', props.character.character_id))
+            post(dispatchBatchUpdate.url(props.character.character_id))
         }
 
         watch(isUpdating,(newValue) => {

--- a/tests/Browser/RecruitmentLifecycleTest.php
+++ b/tests/Browser/RecruitmentLifecycleTest.php
@@ -268,3 +268,28 @@ it('reviews — the inspection tabs render the applicant\'s data', function (str
     $page->assertScript("document.querySelectorAll('#contracts-body-{$applicantCharacter->character_id} > *').length >= 1");
     snap($page, "recruitment-review-tab-contracts-{$device}");
 })->with(['desktop', 'iphone']);
+
+it('reviews — a reviewer dispatches an on-demand character update (fetch, no axios)', function () {
+    $character = actingAsCharacter();
+    makeRecruiterOfCorporation($character, 'can accept or deny applications');
+
+    openPostingWithStages($character->corporation_id, [['label' => 'Open', 'role' => null]]);
+    $application = seedApplicantAtStage($character->corporation_id, 'Jane Applicant', stage: 0);
+    cache()->flush();
+
+    // Desktop-only, like the tab test above. The applicant header renders an Update control per
+    // covered character; the migrated UpdateCharacterComponent dispatches the batch update via the
+    // native fetch (http.js + Wayfinder), not axios.
+    $page = visit("/corporation/recruitment/application/{$application->id}");
+    $page->assertNoSmoke();
+    $page->waitForText('Jane Applicant');
+
+    // Clicking Update flips the control to its "updating" state; assertNoSmoke afterwards proves the
+    // POST to dispatch.batch_update fired cleanly through the fetch wrapper (a broken Wayfinder URL
+    // or fetch would surface as a console error here).
+    $page->click('Update');
+    $page->waitForText('updating');
+    $page->assertNoSmoke();
+
+    snap($page, 'recruitment-review-update-character-desktop');
+});


### PR DESCRIPTION
## What

`UpdateCharacterComponent` (the recruitment review's on-demand character-update control) was the **last file using axios** — `axios.get/post` on the `get.batch_update` / `dispatch.batch_update` Ziggy routes.

Swap it for the native-fetch wrapper (`getJson` / `post` from `Functions/http.js`) with URLs built from the Wayfinder `ApplicationsController` actions (`getBatchUpdate` / `dispatchBatchUpdate`). `getJson` returns the parsed body directly (was `response.data`).

**No backend change** — the endpoints stay JSON (an on-demand dispatch + poll, not page-load data, so `defer`/`optional` don't apply — this one correctly stays a fetch).

## Tests

- **Browser** (`RecruitmentLifecycleTest`, desktop): a new test opens the review detail, clicks **Update**, asserts the control flips to its "updating" state, and `assertNoSmoke` — proving the POST fired cleanly through the fetch wrapper (a broken Wayfinder URL would surface here). Building the assembled app in the Browser job also validates the Wayfinder import resolves.
- The batch endpoints are already covered by the `junior hr can dispatch update batch and get status` feature test.
- Local: Pint ✅, `php -l` ✅. ESLint via CI.

PR 7 (final) of the JSON-endpoint / axios-Ziggy sweep. Base `5.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)