### PR TITLE
refactor(i18n): drop I18nPlugin, consolidate on useTranslations()

### DIFF
--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -12,7 +12,7 @@
           SeAT plus
         </h2>
         <p class="mt-2 text-center text-sm leading-5 text-gray-600 max-w">
-          {{ $trans('web::auth.login_welcome') }}
+          {{ trans('web::auth.login_welcome') }}
         </p>
       </div>
 
@@ -65,11 +65,17 @@ import { router } from "@inertiajs/vue3";
 import { localeName } from "@/i18n/localeName";
 import { update as postLocale } from "@/actions/Seatplus/Web/Http/Controllers/LocaleController";
 import RedirectSSOController from "@/actions/Seatplus/Auth/Http/Controllers/Auth/RedirectSSOController";
+import { useTranslations } from "@/composables/useTranslations";
 
 export default {
     name: "Login",
     components: {AppHead},
     layout: (h, page) => h(EmptyLayout, () => page),
+    setup() {
+        const { trans } = useTranslations();
+
+        return { trans };
+    },
     data() {
         return {
             selectedLocale: this.$page.props.locale,

--- a/resources/js/Pages/Auth/MissingRequiredScopes.vue
+++ b/resources/js/Pages/Auth/MissingRequiredScopes.vue
@@ -3,10 +3,10 @@
     <AppHead app-title="Missing Characters Esi Scopes" />
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
       <h2 class="mt-6 text-center text-3xl leading-9 font-extrabold text-gray-900">
-        {{ $trans('web::missing_required_scopes.title') }}
+        {{ trans('web::missing_required_scopes.title') }}
       </h2>
       <p class="mt-2 text-center text-sm leading-5 text-gray-600 max-w">
-        {{ $trans('web::missing_required_scopes.description') }}
+        {{ trans('web::missing_required_scopes.description') }}
       </p>
     </div>
 
@@ -85,6 +85,7 @@
     import ImpersonatingBanner from "@/Shared/SidebarLayout/ImpersonatingBanner.vue";
     import EmptyLayout from "@/Shared/Layout/AuthLayout/EmptyLayout.vue";
     import AppHead from "@/Shared/AppHead.vue";
+    import { useTranslations } from "@/composables/useTranslations";
     export default {
         name: "MissingRequiredScopes",
         components: {AppHead, ImpersonatingBanner, EveImage},
@@ -93,6 +94,11 @@
             characters: {
                 required: true
             }
+        },
+        setup() {
+            const { trans } = useTranslations();
+
+            return { trans };
         }
     }
 </script>

--- a/resources/js/Shared/Toasts/Toast.vue
+++ b/resources/js/Shared/Toasts/Toast.vue
@@ -3,6 +3,9 @@ import { CheckCircleIcon, InformationCircleIcon, ExclamationCircleIcon, XCircleI
 import { XMarkIcon } from '@heroicons/vue/20/solid'
 import {ref} from "vue";
 import {useToasts} from "@/Functions/useToasts.js";
+import { useTranslations } from "@/composables/useTranslations";
+
+const { trans } = useTranslations();
 
 const props = defineProps({
     toast: {
@@ -38,7 +41,7 @@ const isError = ref(props.toast.appearance === 'error')
           <XCircleIcon v-if="isError" class="h-6 w-6 text-red-400" aria-hidden="true" />
         </div>
         <div class="ml-3 w-0 flex-1 pt-0.5">
-          <p class="text-sm font-medium text-gray-900">{{ $trans(`web::notifications.${toast.appearance}`) }}</p>
+          <p class="text-sm font-medium text-gray-900">{{ trans(`web::notifications.${toast.appearance}`) }}</p>
           <p class="mt-1 text-sm text-gray-500">{{ toast.message }}</p>
         </div>
         <div class="ml-4 flex shrink-0">

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,20 +5,6 @@ import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3'
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import SingleColumnLayout from "@/Shared/SidebarLayout/SingleColumnLayout.vue";
-import I18n from '@/i18n/I18n';
-
-const I18nPlugin = {
-    install(app) {
-        // Options-API global: translate against the current page's reactive `translations`
-        // prop. (`<script setup>` pages use the useTranslations() composable instead.)
-        app.config.globalProperties.$trans = function (key, replace = {}) {
-            return I18n.trans(I18n.merge(this.$page?.props?.translations, this.$page?.props?.pageTranslations), key, replace);
-        };
-        app.config.globalProperties.$trans_choice = function (key, count = 1, replace = {}) {
-            return I18n.trans_choice(I18n.merge(this.$page?.props?.translations, this.$page?.props?.pageTranslations), key, count, replace);
-        };
-    }
-}
 
 createInertiaApp({
     resolve: async (name) => {
@@ -37,7 +23,6 @@ createInertiaApp({
     setup({ el, App, props, plugin }) {
         return createApp({ render: () => h(App, props) })
             .use(plugin)
-            .use(I18nPlugin)
             .mount(el);
     },
     progress: {


### PR DESCRIPTION
## What

Removes the `I18nPlugin` (the global Options-API `\$trans` / `\$trans_choice` helpers in `resources/js/app.js`) and consolidates the web package on the single `useTranslations()` composable path.

## Why

`packages/web` had **two** i18n code paths doing the same lookup:

1. `I18nPlugin` — global `\$trans` / `\$trans_choice` for Options-API components.
2. `useTranslations()` — the `<script setup>` / Composition-API path (15 components).

Audit found `\$trans_choice` had **zero** consumers and `\$trans` only **four**, so the plugin is redundant once those four move to the composable.

## Changes

- **`Toast.vue`** (`<script setup>`) — `useTranslations()` → `trans`, template swap.
- **`WalletJournalRowComponent.vue`**, **`Login.vue`**, **`MissingRequiredScopes.vue`** (Options API) — added a minimal `setup()` returning `{ trans }` (keeps their `layout`/`data`/`computed`/`methods` intact); `\$trans`/`this.\$trans` → `trans`/`this.trans`.
- **`app.js`** — deleted the `I18nPlugin` block, its `.use(I18nPlugin)`, and the now-orphaned `import I18n` (referenced only by the plugin).

The `@/i18n/I18n` class stays — still used by the composable.

## Verification

- `grep -rn '\$trans' resources/js` → clean; `grep -rn 'I18nPlugin' resources/js` → clean.
- `eslint resources/js` on the touched files → **0 errors** (only 2 pre-existing `require-prop-types` warnings on untyped props I didn't touch).
- No route changes → no Wayfinder regen.
- ⚠️ **Browser tests run only in "Browser (vs core)" CI / on host**, not the dev container. Pages to eyeball: **Login** (`web::auth.login_welcome`), **MissingRequiredScopes** (title/description), **Toasts** (notification label), a **wallet journal** row — and confirm Login's locale switch still re-renders text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)