### PR TITLE
refactor(js): migrate 31 Shared components to <script setup> (phase 1)

### DIFF
--- a/resources/js/Shared/Components/Assets/AssetContentsLink.vue
+++ b/resources/js/Shared/Components/Assets/AssetContentsLink.vue
@@ -41,7 +41,7 @@
   </teleport>
 </template>
 
-<script>
+<script setup>
 import { ref } from "vue";
 import { DialogTitle } from "@headlessui/vue";
 import WithDismissButtonModal from "@/Shared/Modals/WithDismissButtonModal.vue";
@@ -49,38 +49,32 @@ import ItemList from "./ItemList.vue";
 import { getJson } from "@/Functions/http";
 import { item as itemAction } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
 
-export default {
-    name: "AssetContentsLink",
-    components: { WithDismissButtonModal, DialogTitle, ItemList },
-    // Renders <a> + <teleport> (two roots), so it can't auto-inherit fallthrough attrs.
-    inheritAttrs: false,
-    props: {
-        characterId: {
-            type: Number,
-            required: true,
-        },
-        itemId: {
-            type: Number,
-            required: true,
-        },
+// Renders <a> + <teleport> (two roots), so it can't auto-inherit fallthrough attrs.
+defineOptions({ inheritAttrs: false });
+
+const props = defineProps({
+    characterId: {
+        type: Number,
+        required: true,
     },
-    setup(props) {
-        const openModal = ref(false)
-        const contents = ref([])
+    itemId: {
+        type: Number,
+        required: true,
+    },
+});
 
-        const itemUrl = itemAction.url({ character_id: props.characterId, item_id: props.itemId })
+const openModal = ref(false)
+const contents = ref([])
 
-        const open = async () => {
-            if (! contents.value.length) {
-                // X-Modal returns [the container]; its `content` is the one level of contents.
-                const data = await getJson(itemUrl, { 'X-Modal': true })
-                contents.value = data[0]?.content ?? []
-            }
+const itemUrl = itemAction.url({ character_id: props.characterId, item_id: props.itemId })
 
-            openModal.value = true
-        }
-
-        return { openModal, contents, itemUrl, open }
+const open = async () => {
+    if (! contents.value.length) {
+        // X-Modal returns [the container]; its `content` is the one level of contents.
+        const data = await getJson(itemUrl, { 'X-Modal': true })
+        contents.value = data[0]?.content ?? []
     }
+
+    openModal.value = true
 }
 </script>

--- a/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListElement.vue
@@ -5,21 +5,17 @@
   />
 </template>
 
-<script>
+<script setup>
 import CompactAssetListTemplate from "./CompactAssetListTemplate.vue";
 
-export default {
-    name: "CompactAssetListElement",
-    components: { CompactAssetListTemplate },
-    props: {
-        entry: {
-            required: true,
-            type: Object
-        },
-        even: {
-            required: true,
-            type: Number
-        }
+defineProps({
+    entry: {
+        required: true,
+        type: Object
+    },
+    even: {
+        required: true,
+        type: Number
     }
-}
+});
 </script>

--- a/resources/js/Shared/Components/CharacterInspection/Tabs/ContractTab.vue
+++ b/resources/js/Shared/Components/CharacterInspection/Tabs/ContractTab.vue
@@ -12,43 +12,30 @@
   />
 </template>
 
-<script>
+<script setup>
 import BarWithUnderline from "@/Shared/Layout/Tabs/BarWithUnderline.vue";
 import {computed, ref} from "vue";
 import ContractComponent from "@/Shared/Components/Contracts/ContractComponent.vue";
 
-let raw_tabs = [
+const props = defineProps({
+    characterIds: {
+        required: true,
+        type: Array
+    },
+    watchlist: {
+        required: true,
+        type: Object
+    }
+});
+
+const tabs = [
     {id: 1, name: 'Watchlisted Contracts'},
     {id: 2, name: 'All Contracts'},
 ]
 
-export default {
-    name: "ContractTab",
-    components: {ContractComponent, BarWithUnderline},
-    props: {
-        characterIds: {
-            required: true,
-            type: Array
-        },
-        watchlist: {
-            required: true,
-            type: Object
-        }
-    },
-    setup(props) {
+const changeActiveTab = (tab) => activeTabId.value = tab.id;
 
-        const changeActiveTab = (tab) => activeTabId.value = tab.id;
+const hasWatchlist = computed(() => _.flattenDeep(Object.values(props.watchlist)).length > 0)
 
-        const hasWatchlist = computed(() => _.flattenDeep(Object.values(props.watchlist)).length > 0)
-
-        const activeTabId = ref(hasWatchlist.value ? 1 : 2)
-
-        return {
-            tabs: raw_tabs,
-            changeActiveTab,
-            hasWatchlist,
-            activeTabId
-        }
-    }
-}
+const activeTabId = ref(hasWatchlist.value ? 1 : 2)
   </script>

--- a/resources/js/Shared/Components/CharacterInspection/Tabs/LogTab.vue
+++ b/resources/js/Shared/Components/CharacterInspection/Tabs/LogTab.vue
@@ -147,7 +147,7 @@
   </section>
 </template>
 
-<script>
+<script setup>
 import { ChatBubbleBottomCenterTextIcon } from '@heroicons/vue/20/solid'
 import { computed } from "vue";
 import EveImage from "@/Shared/EveImage.vue";
@@ -155,74 +155,61 @@ import Time from "@/Shared/Time.vue";
 import { useForm, usePage } from "@inertiajs/vue3";
 import { addComment } from "@/actions/Seatplus/Web/Http/Controllers/Recruitment/ApplicationsController";
 
-export default {
-    name: "LogTab",
-    components: {Time, EveImage, ChatBubbleBottomCenterTextIcon },
-    props: {
-        application: {
-            required: true,
-            type: Object
-        },
-        withHeader: {
-            required: false,
-            type: Boolean,
-            default: true
-        }
+const props = defineProps({
+    application: {
+        required: true,
+        type: Object
     },
-    setup(props) {
-
-        const form = useForm({
-            comment: null
-        })
-
-        const isFinalDecision = (index) => {
-            return  _.filter(props.application.log_entries, {type: 'decision'}).length === (index+1)
-        }
-
-        const activity = computed(() => {
-
-            let activity = [
-                {
-                    type: 'decision',
-                    character: _.has(props.application, 'applicationable.main_character') ? _.get(props.application, 'applicationable.main_character') : _.get(props.application, 'applicationable'),
-                    comment: 'has applied',
-                    created_at: props.application.created_at
-                }
-            ]
-
-            _.each(props.application.log_entries, (entry, entryIdx) => {
-                activity.push({
-                    type: 'comment',
-                    character: entry.causer.main_character,
-                    comment: entry.comment,
-                    created_at: entry.created_at
-                })
-
-                if(entry.type === 'decision') {
-                    activity.push({
-                        type: 'decision',
-                        character: entry.causer.main_character,
-                        comment: isFinalDecision(entryIdx) ? `${props.application.status} the application` :  'approved step',
-                        created_at: entry.created_at
-                    })
-                }
-
-            })
-
-            return activity
-        })
-        const user = usePage().props.user.data
-
-        const commentUrl = addComment.url(props.application.id)
-
-        return {
-            activity,
-            user,
-            form,
-            commentUrl
-        }
+    withHeader: {
+        required: false,
+        type: Boolean,
+        default: true
     }
+});
+
+const form = useForm({
+    comment: null
+})
+
+const isFinalDecision = (index) => {
+    return  _.filter(props.application.log_entries, {type: 'decision'}).length === (index+1)
 }
+
+const activity = computed(() => {
+
+    let activity = [
+        {
+            type: 'decision',
+            character: _.has(props.application, 'applicationable.main_character') ? _.get(props.application, 'applicationable.main_character') : _.get(props.application, 'applicationable'),
+            comment: 'has applied',
+            created_at: props.application.created_at
+        }
+    ]
+
+    _.each(props.application.log_entries, (entry, entryIdx) => {
+        activity.push({
+            type: 'comment',
+            character: entry.causer.main_character,
+            comment: entry.comment,
+            created_at: entry.created_at
+        })
+
+        if(entry.type === 'decision') {
+            activity.push({
+                type: 'decision',
+                character: entry.causer.main_character,
+                comment: isFinalDecision(entryIdx) ? `${props.application.status} the application` :  'approved step',
+                created_at: entry.created_at
+            })
+        }
+
+    })
+
+    return activity
+})
+const user = usePage().props.user.data
+
+const commentUrl = addComment.url(props.application.id)
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/CharacterInspection/UpdateCharacterComponent.vue
+++ b/resources/js/Shared/Components/CharacterInspection/UpdateCharacterComponent.vue
@@ -50,7 +50,7 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import LeftAlignedData from "@/Shared/Layout/DataDisplay/LeftAlignedData.vue";
 import Button from "@/Shared/Layout/Button.vue";
 import {computed, ref, watch} from "vue";
@@ -59,50 +59,37 @@ import Time from "@/Shared/Time.vue";
 import { getJson, post } from "@/Functions/http";
 import { getBatchUpdate, dispatchBatchUpdate } from "@/actions/Seatplus/Web/Http/Controllers/Recruitment/ApplicationsController";
 
-export default {
-    name: "UpdateCharacterComponent",
-    components: {Time, Button, LeftAlignedData},
-    props: {
-        character: {
-            type: Object,
-            required:true
-        }
-    },
-    setup(props) {
-
-        const batchUpdate = ref(props.character.batch_update != null ? props.character.batch_update : {finished_at: null})
-        const isUpdating = ref(false)
-        const interval = ref()
-
-        const canUpdate = computed(() => _.isNil(batchUpdate.value.finished_at) || dayjs(batchUpdate.value.finished_at).isBefore(dayjs().subtract(1,'hour')))
-
-        const getUpdate = async () => getJson(getBatchUpdate.url(props.character.character_id))
-            .then((data) => {
-                batchUpdate.value = data
-
-                if (data?.finished_at) {
-                    isUpdating.value = false
-                }
-            })
-
-        const updateCharacter = function () {
-            isUpdating.value = true;
-
-            post(dispatchBatchUpdate.url(props.character.character_id))
-        }
-
-        watch(isUpdating,(newValue) => {
-            newValue ? interval.value = setInterval(getUpdate,15000) : clearInterval(interval.value)
-        })
-
-        return {
-            batchUpdate,
-            canUpdate,
-            isUpdating,
-            updateCharacter
-        }
+const props = defineProps({
+    character: {
+        type: Object,
+        required:true
     }
+});
+
+const batchUpdate = ref(props.character.batch_update != null ? props.character.batch_update : {finished_at: null})
+const isUpdating = ref(false)
+const interval = ref()
+
+const canUpdate = computed(() => _.isNil(batchUpdate.value.finished_at) || dayjs(batchUpdate.value.finished_at).isBefore(dayjs().subtract(1,'hour')))
+
+const getUpdate = async () => getJson(getBatchUpdate.url(props.character.character_id))
+    .then((data) => {
+        batchUpdate.value = data
+
+        if (data?.finished_at) {
+            isUpdating.value = false
+        }
+    })
+
+const updateCharacter = function () {
+    isUpdating.value = true;
+
+    post(dispatchBatchUpdate.url(props.character.character_id))
 }
+
+watch(isUpdating,(newValue) => {
+    newValue ? interval.value = setInterval(getUpdate,15000) : clearInterval(interval.value)
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Contacts/CharacterContactsComponent.vue
+++ b/resources/js/Shared/Components/Contacts/CharacterContactsComponent.vue
@@ -45,8 +45,7 @@
   </CardWithHeader>
 </template>
 
-<script>
-
+<script setup>
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import CharacterContactsRowComponent from "./CharacterContactsRowComponent.vue";
@@ -54,85 +53,66 @@ import StickyHeaderTable from "@/Shared/Layout/Table/StickyHeaderTable.vue";
 import SimpleInlineList from "../../Layout/SimpleInlineList.vue";
 import { computed, ref } from "vue";
 
-export default {
-    name: "CharacterContactsComponent",
-    components: {
-        SimpleInlineList,
-        CharacterContactsRowComponent,
-        StickyHeaderTable,
-        CardWithHeader,
-        EntityBlock,
+const props = defineProps({
+    character: {
+        required: true,
+        type: Object
     },
-    props: {
-        character: {
-            required: true,
-            type: Object
-        },
-        contacts: {
-            type: Array,
-            default: () => []
-        },
+    contacts: {
+        type: Array,
+        default: () => []
     },
-    setup(props) {
+});
 
-        const selected_filter = ref('')
-        const options = [
-            {id: 'all', title: 'All contacts'},
-            {id: 'standing', title: 'Only With Standing Offset'},
-        ]
+const selected_filter = ref('')
+const options = [
+    {id: 'all', title: 'All contacts'},
+    {id: 'standing', title: 'Only With Standing Offset'},
+]
 
-        const headerTitles = [
-            {title: 'Contact', columnSpan: 2},
-            {title: 'Labels', columnSpan: 1},
-            {title: 'Standing', columnSpan: 1},
-            {title: 'Corporation standing', columnSpan: 1},
-            {title: 'Alliance standing', columnSpan: 1},
-        ]
+const headerTitles = [
+    {title: 'Contact', columnSpan: 2},
+    {title: 'Labels', columnSpan: 1},
+    {title: 'Standing', columnSpan: 1},
+    {title: 'Corporation standing', columnSpan: 1},
+    {title: 'Alliance standing', columnSpan: 1},
+]
 
-        const diff = (a,b) => a > b ? a - b : b - a
+const diff = (a,b) => a > b ? a - b : b - a
 
-        const filteredContacts = computed(() => {
+const filteredContacts = computed(() => {
 
-            let unsortedContacts = props.contacts
+    let unsortedContacts = props.contacts
 
-            if(selected_filter.value === 'wofaction') {
-                unsortedContacts = _.filter(props.contacts, {contact_type: 'faction'})
-            }
-
-            if(selected_filter.value === 'standing') {
-                unsortedContacts =  _.filter(props.contacts, (contact) => {
-                    if(_.isNil(contact.corporation_standing) && _.isNil(contact.alliance_standing)) {
-                        return false
-                    }
-
-                    let standing = contact.standing
-
-                    if(standing === 0) {
-                        return false
-                    }
-
-                    let corp_standing = contact.corporation_standing != null ? contact.corporation_standing : 0
-                    let alliance_standing = contact.alliance_standing != null ? contact.alliance_standing : 0
-
-                    return !((diff(corp_standing,standing) === 0) || (diff(alliance_standing,standing) === 0));
-
-                })
-            }
-
-            return _.chain(unsortedContacts)
-                .sortBy(['standing', 'corporation_standing', 'alliance_standing'])
-                .reverse()
-                .value()
-        })
-
-        return {
-            filteredContacts,
-            options,
-            selected_filter,
-            headerTitles,
-        }
+    if(selected_filter.value === 'wofaction') {
+        unsortedContacts = _.filter(props.contacts, {contact_type: 'faction'})
     }
-}
+
+    if(selected_filter.value === 'standing') {
+        unsortedContacts =  _.filter(props.contacts, (contact) => {
+            if(_.isNil(contact.corporation_standing) && _.isNil(contact.alliance_standing)) {
+                return false
+            }
+
+            let standing = contact.standing
+
+            if(standing === 0) {
+                return false
+            }
+
+            let corp_standing = contact.corporation_standing != null ? contact.corporation_standing : 0
+            let alliance_standing = contact.alliance_standing != null ? contact.alliance_standing : 0
+
+            return !((diff(corp_standing,standing) === 0) || (diff(alliance_standing,standing) === 0));
+
+        })
+    }
+
+    return _.chain(unsortedContacts)
+        .sortBy(['standing', 'corporation_standing', 'alliance_standing'])
+        .reverse()
+        .value()
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Contacts/CharacterContactsRowComponent.vue
+++ b/resources/js/Shared/Components/Contacts/CharacterContactsRowComponent.vue
@@ -45,29 +45,25 @@
   </StickyHeaderTableRow>
 </template>
 
-<script>
+<script setup>
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import StickyHeaderTableRow from "@/Shared/Layout/Table/StickyHeaderTableRow.vue";
 import StickyHeaderCell from "@/Shared/Layout/Table/StickyHeaderCell.vue";
 
-export default {
-    name: "CharacterContactsRowComponent",
-    components: { EntityByIdBlock, StickyHeaderTableRow, StickyHeaderCell },
-    props: {
-        entry: {
-            required: true,
-            type: Object,
-        },
-        columns: {
-            required: true,
-            type: Array,
-        },
-        numberColumns: {
-            required: true,
-            type: Number,
-        },
+defineProps({
+    entry: {
+        required: true,
+        type: Object,
     },
-}
+    columns: {
+        required: true,
+        type: Array,
+    },
+    numberColumns: {
+        required: true,
+        type: Number,
+    },
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Contracts/Cells/AssigneeComponent.vue
+++ b/resources/js/Shared/Components/Contracts/Cells/AssigneeComponent.vue
@@ -14,16 +14,13 @@
   />
 </template>
 
-<script>
+<script setup>
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
-export default {
-    name: "AssigneeComponent",
-    components: {EntityByIdBlock},
-    props: {
-        contract: {
-            required: true,
-            type: Object
-        }
+
+defineProps({
+    contract: {
+        required: true,
+        type: Object
     }
-}
+});
 </script>

--- a/resources/js/Shared/Components/Contracts/Cells/ContractTypeComponent.vue
+++ b/resources/js/Shared/Components/Contracts/Cells/ContractTypeComponent.vue
@@ -26,29 +26,17 @@
   </p>
 </template>
 
-<script>
+<script setup>
 import { MapPinIcon } from "@heroicons/vue/20/solid";
 
-export default {
-    name: "ContractTypeComponent",
-    components: {MapPinIcon},
-    props: {
-        contract: {
-            required: true,
-            type: Object
-        }
-    },
-    setup() {
+defineProps({
+    contract: {
+        required: true,
+        type: Object
+    }
+});
 
-        const getStartLocation = (contract) => _.get(contract, 'start_location.name', _.get(contract, 'start_location.locatable.name', 'unknown'))
-        const getEndLocation = (contract) => _.get(contract, 'end_location.name', _.get(contract, 'end_location.locatable.name', 'unknown'))
-
-        return {
-            getStartLocation,
-            getEndLocation
-        }
-
-    },
-}
+const getStartLocation = (contract) => _.get(contract, 'start_location.name', _.get(contract, 'start_location.locatable.name', 'unknown'))
+const getEndLocation = (contract) => _.get(contract, 'end_location.name', _.get(contract, 'end_location.locatable.name', 'unknown'))
 </script>
 

--- a/resources/js/Shared/Components/Contracts/Cells/DetailsComponent.vue
+++ b/resources/js/Shared/Components/Contracts/Cells/DetailsComponent.vue
@@ -40,28 +40,20 @@
   </p>
 </template>
 
-<script>
+<script setup>
 import {
     TagIcon,
     SignalIcon,
     BanknotesIcon,
     ArchiveBoxIcon,
 } from "@heroicons/vue/20/solid";
-export default {
-    name: "DetailsComponent",
-    components: {
-        TagIcon,
-        SignalIcon,
-        BanknotesIcon,
-        ArchiveBoxIcon
-    },
-    props: {
-        contract: {
-            required: true,
-            type: Object
-        }
+
+defineProps({
+    contract: {
+        required: true,
+        type: Object
     }
-}
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Contracts/Cells/IssuerComponent.vue
+++ b/resources/js/Shared/Components/Contracts/Cells/IssuerComponent.vue
@@ -17,17 +17,13 @@
   />
 </template>
 
-<script>
+<script setup>
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 
-export default {
-    name: "IssuerComponent",
-    components: {EntityByIdBlock},
-    props: {
-        contract: {
-            required: true,
-            type: Object
-        }
+defineProps({
+    contract: {
+        required: true,
+        type: Object
     }
-}
+});
 </script>

--- a/resources/js/Shared/Components/Contracts/ContractDetailsComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ContractDetailsComponent.vue
@@ -198,58 +198,50 @@
 </template>
 
 <script>
-import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
-import {prefix} from "metric-prefix";
-import WideListElement from "../../WideListElement.vue";
-import EveImage from "@/Shared/EveImage.vue"
-import WideLists from "../../WideLists.vue";
-import AssigneeComponent from "./Cells/AssigneeComponent.vue";
 import {useValidateObject} from "@/Functions/useValidateObject";
-import IssuerComponent from "./Cells/IssuerComponent.vue";
-import ContractTypeComponent from "./Cells/ContractTypeComponent.vue";
-import DetailsComponent from "./Cells/DetailsComponent.vue";
-import Card from "../../Layout/Cards/Card.vue";
 
 const schema = {
     items: value => _.isArray(value),
 }
 
 schema.items.required = true
+</script>
 
-export default {
-    name: "ContractDetailsComponent",
-    components: {
-        Card,
-        DetailsComponent,
-        ContractTypeComponent,
-        IssuerComponent, AssigneeComponent, WideLists, EveImage, WideListElement, CardWithHeader},
-    props: {
-        contract: {
-            required: true,
-            type: Object,
-            validator: value => useValidateObject(value, schema)
-        }
-    },
-    computed: {
-        requested_items() {
-            return _.filter(this.contract.items, 'is_included')
-        },
-        included_items() {
-            return _.filter(this.contract.items, !'is_included')
-        }
-    },
-    methods: {
-        getMetricPrefix(numeric_value) {
+<script setup>
+import { computed } from "vue";
+import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
+import {prefix} from "metric-prefix";
+import WideListElement from "../../WideListElement.vue";
+import EveImage from "@/Shared/EveImage.vue"
+import WideLists from "../../WideLists.vue";
+import AssigneeComponent from "./Cells/AssigneeComponent.vue";
+import IssuerComponent from "./Cells/IssuerComponent.vue";
+import ContractTypeComponent from "./Cells/ContractTypeComponent.vue";
+import DetailsComponent from "./Cells/DetailsComponent.vue";
+import Card from "../../Layout/Cards/Card.vue";
 
-            return prefix(numeric_value, {precision: 3, unit: 'm³'})
-        },
-        isBlueprint(item) {
-            return _.get(item, 'type.category.name') === 'Blueprint'
-        },
-        isBPO(item) {
-            return this.isBlueprint(item) && item.raw_quantity === -1
-        }
+const props = defineProps({
+    contract: {
+        required: true,
+        type: Object,
+        validator: value => useValidateObject(value, schema)
     }
+});
+
+const requested_items = computed(() => _.filter(props.contract.items, 'is_included'))
+
+const included_items = computed(() => _.filter(props.contract.items, !'is_included'))
+
+function getMetricPrefix(numeric_value) {
+    return prefix(numeric_value, {precision: 3, unit: 'm³'})
+}
+
+function isBlueprint(item) {
+    return _.get(item, 'type.category.name') === 'Blueprint'
+}
+
+function isBPO(item) {
+    return isBlueprint(item) && item.raw_quantity === -1
 }
 </script>
 

--- a/resources/js/Shared/Components/Contracts/ContractRowComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ContractRowComponent.vue
@@ -40,7 +40,7 @@
   </StickyHeaderTableRow>
 </template>
 
-<script>
+<script setup>
 import StickyHeaderTableRow from "@/Shared/Layout/Table/StickyHeaderTableRow.vue";
 import StickyHeaderCell from "@/Shared/Layout/Table/StickyHeaderCell.vue";
 import ExpandContractComponent from "./ExpandContractComponent.vue";
@@ -49,36 +49,24 @@ import AssigneeComponent from "./Cells/AssigneeComponent.vue";
 import ContractTypeComponent from "./Cells/ContractTypeComponent.vue";
 import DetailsComponent from "./Cells/DetailsComponent.vue";
 
-export default {
-    name: "ContractRowComponent",
-    components: {
-        StickyHeaderTableRow,
-        StickyHeaderCell,
-        ExpandContractComponent,
-        IssuerComponent,
-        AssigneeComponent,
-        ContractTypeComponent,
-        DetailsComponent,
+defineProps({
+    contract: {
+        required: true,
+        type: Object,
     },
-    props: {
-        contract: {
-            required: true,
-            type: Object,
-        },
-        // The StickyHeaderTable slot's column definitions + count, threaded through so
-        // the cells lay out identically whether fed by InfiniteScroll or the helper.
-        columns: {
-            required: true,
-            type: Array,
-        },
-        countColumns: {
-            required: true,
-            type: Number,
-        },
-        characterId: {
-            required: true,
-            type: Number,
-        },
+    // The StickyHeaderTable slot's column definitions + count, threaded through so
+    // the cells lay out identically whether fed by InfiniteScroll or the helper.
+    columns: {
+        required: true,
+        type: Array,
     },
-}
+    countColumns: {
+        required: true,
+        type: Number,
+    },
+    characterId: {
+        required: true,
+        type: Number,
+    },
+});
 </script>

--- a/resources/js/Shared/Components/Contracts/ExpandContractComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ExpandContractComponent.vue
@@ -27,7 +27,7 @@
     </WithDismissButtonModal>
   </teleport>
 </template>
-<script>
+<script setup>
 import {ArrowsPointingOutIcon} from "@heroicons/vue/20/solid";
 import {ref} from "vue";
 import WithDismissButtonModal from "@/Shared/Modals/WithDismissButtonModal.vue";
@@ -36,46 +36,32 @@ import ContractDetailsComponent from "./ContractDetailsComponent.vue";
 import { getJson } from "@/Functions/http";
 import { getContractDetails } from "@/actions/Seatplus/Web/Http/Controllers/Character/ContractsController";
 
-export default {
-    name: "ExpandContractComponent",
-    components: {
-        ContractDetailsComponent,
-        WithDismissButtonModal, ArrowsPointingOutIcon, DialogTitle},
-    props: {
-        contract: {
-            required: true,
-            type: Object
-        },
-        characterId: {
-            required: true,
-            type: Number
-        }
+const props = defineProps({
+    contract: {
+        required: true,
+        type: Object
     },
-    setup(props) {
-        const openModal = ref(false)
-        const contractDetails = ref()
-
-        const url = getContractDetails.url({character_id: props.characterId, contract_id: props.contract.contract_id})
-
-        const fetchDetails = async () => {
-            const details = await getJson(url, {'X-Modal': true})
-            contractDetails.value = details[0]
-        }
-
-        const open = () => {
-            if(!contractDetails.value) {
-                fetchDetails()
-            }
-            openModal.value = true
-        }
-
-        return {
-            openModal,
-            open,
-            contractDetails,
-            url
-        }
+    characterId: {
+        required: true,
+        type: Number
     }
+});
+
+const openModal = ref(false)
+const contractDetails = ref()
+
+const url = getContractDetails.url({character_id: props.characterId, contract_id: props.contract.contract_id})
+
+const fetchDetails = async () => {
+    const details = await getJson(url, {'X-Modal': true})
+    contractDetails.value = details[0]
+}
+
+const open = () => {
+    if(!contractDetails.value) {
+        fetchDetails()
+    }
+    openModal.value = true
 }
 </script>
 

--- a/resources/js/Shared/Components/LocationSlot.vue
+++ b/resources/js/Shared/Components/LocationSlot.vue
@@ -90,7 +90,8 @@
   </CardWithHeader>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import WideLists from "../WideLists.vue";
 import WideListElement from "../WideListElement.vue";
 import EveImage from "../EveImage.vue"
@@ -98,44 +99,35 @@ import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import { prefix } from "metric-prefix";
 import { item as itemRoute } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
 
-export default {
-    name: "LocationSlot",
-    components: {CardWithHeader, WideListElement, WideLists, EveImage},
-    props: {
-        name: {
-            type: String,
-            required: true
-        },
-        items: {
-            type: Array,
-            required: true
-        },
-        slots: {
-            type: Array,
-            required: true
-        }
+const props = defineProps({
+    name: {
+        type: String,
+        required: true
     },
-    computed: {
-        filtered_items() {
-            return _.sortBy(_.each(_.filter(this.items, (item) => this.slots.includes(item.location_flag)), (item) => item.index = this.slots.indexOf(item.location_flag)), 'index')
-        },
-        isShown() {
-            return !_.isEmpty(this.filtered_items)
-        }
+    items: {
+        type: Array,
+        required: true
     },
-    methods: {
-        getMetricPrefix(numeric_value) {
-
-            return prefix(numeric_value, {precision: 3, unit: 'm³'})
-        },
-        url(asset) {
-
-            return _.isEmpty(asset.content) ? '' : itemRoute.url({character_id: asset.owner_id, item_id: asset.item_id})
-        },
-        hasContent(content) {
-            return !_.isEmpty(content)
-        }
+    slots: {
+        type: Array,
+        required: true
     }
+});
+
+const filtered_items = computed(() => _.sortBy(_.each(_.filter(props.items, (item) => props.slots.includes(item.location_flag)), (item) => item.index = props.slots.indexOf(item.location_flag)), 'index'))
+
+const isShown = computed(() => !_.isEmpty(filtered_items.value))
+
+function getMetricPrefix(numeric_value) {
+    return prefix(numeric_value, {precision: 3, unit: 'm³'})
+}
+
+function url(asset) {
+    return _.isEmpty(asset.content) ? '' : itemRoute.url({character_id: asset.owner_id, item_id: asset.item_id})
+}
+
+function hasContent(content) {
+    return !_.isEmpty(content)
 }
 </script>
 

--- a/resources/js/Shared/Components/Mails/MailRepresentation.vue
+++ b/resources/js/Shared/Components/Mails/MailRepresentation.vue
@@ -61,45 +61,36 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import {onBeforeMount, ref} from "vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import Time from "@/Shared/Time.vue";
 
-export default {
-    name: "MailRepresentation",
-    components: {Time, EntityByIdBlock},
-    props: {
-        mailId: {
-            type: Number,
-            required: true
-        }
-    },
-    setup(props) {
-        const messages = ref([])
-
-        const fetchMails = async () => {
-
-            // Plain same-origin fetch — no axios, no Ziggy route(). (Wayfinder would be
-            // the typed alternative, but its generated routes aren't built in CI yet — B3.)
-            const response = await fetch(`/character/mails/content/${props.mailId}`, {
-                headers: { Accept: 'application/json' },
-            })
-
-            if (! response.ok) {
-                return
-            }
-
-            messages.value.push(...await response.json())
-        }
-
-        onBeforeMount(() => fetchMails())
-
-        return {
-            messages
-        }
+const props = defineProps({
+    mailId: {
+        type: Number,
+        required: true
     }
+});
+
+const messages = ref([])
+
+const fetchMails = async () => {
+
+    // Plain same-origin fetch — no axios, no Ziggy route(). (Wayfinder would be
+    // the typed alternative, but its generated routes aren't built in CI yet — B3.)
+    const response = await fetch(`/character/mails/content/${props.mailId}`, {
+        headers: { Accept: 'application/json' },
+    })
+
+    if (! response.ok) {
+        return
+    }
+
+    messages.value.push(...await response.json())
 }
+
+onBeforeMount(() => fetchMails())
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Skills/SkillsComponent.vue
+++ b/resources/js/Shared/Components/Skills/SkillsComponent.vue
@@ -14,28 +14,25 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import Skills from "./Skills.vue";
 import SkillQueue from "./SkillQueue.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
-export default {
-    name: "SkillsComponent",
-    components: {EntityByIdBlock, SkillQueue, Skills},
-    props: {
-        characterId: {
-            type: Number,
-            required: true
-        },
-        skills: {
-            type: Array,
-            default: () => []
-        },
-        skillQueue: {
-            type: Array,
-            default: () => []
-        }
+
+defineProps({
+    characterId: {
+        type: Number,
+        required: true
+    },
+    skills: {
+        type: Array,
+        default: () => []
+    },
+    skillQueue: {
+        type: Array,
+        default: () => []
     }
-}
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Wallet/WalletComponent.vue
+++ b/resources/js/Shared/Components/Wallet/WalletComponent.vue
@@ -26,29 +26,26 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import WalletJournalComponent from "./Journal/WalletJournalComponent.vue";
 import WalletTransactionComponent from "./Transaction/WalletTransactionComponent.vue";
 import WalletJournalBalanceChart from "./Journal/WalletJournalBalanceChart.vue";
-export default {
-    name: "WalletComponent",
-    components: {WalletJournalBalanceChart, WalletTransactionComponent, WalletJournalComponent},
-    props: {
-        id: {
-            required: true,
-            type: Number
-        },
-        division: {
-            required: false,
-            type: Object
-        },
-        filters: {
-            required: false,
-            type: Object,
-            default: () => new Object()
-        }
+
+defineProps({
+    id: {
+        required: true,
+        type: Number
+    },
+    division: {
+        required: false,
+        type: Object
+    },
+    filters: {
+        required: false,
+        type: Object,
+        default: () => new Object()
     }
-}
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/EveImage.vue
+++ b/resources/js/Shared/EveImage.vue
@@ -24,102 +24,92 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import { computed } from "vue";
 
-    export default {
-        name: "EveImage",
-        props: {
-            object: {
-                type: Object,
-                required: true
-            },
-            size: {
-                type: Number,
-                default: 32
-            },
-            tailwind_class: {
-                required: false,
-                default: "h-12 w-12 rounded-full"
-            },
-            showName: {
-                type: Boolean,
-                required: false,
-                default: false
-            },
-            bpo: {
-                type: Boolean,
-                required: false,
-                default: false
-            }
-        },
-        setup(props) {
-            const resourceId = computed(() => {
-                return _.chain(['type_id', 'character_id', 'corporation_id', 'alliance_id'])
-                    .map(resource => _.get(props.object, resource))
-                    .filter()
-                    .head()
-                    .value()
-            })
-
-            const resourceType = computed(() => {
-                let array = {
-                    'character_id': 'characters',
-                    'corporation_id': 'corporations',
-                    'alliance_id': 'alliances',
-                    'type_id': 'types',
-                }
-
-                return _.chain(array)
-                    .filter( (type, id) => id in props.object )
-                    .map((type) => type)
-                    .head()
-                    .value();
-            })
-
-            // Resolved synchronously — no per-image HTTP roundtrip. characters/corps/alliances are
-            // deterministic; types carry their variation (render/bp/icon) from the backend
-            // (TypeResource.image_variant, derived from the inventory category), defaulting to icon.
-            const resourceVariant = computed(() => {
-                if (!props.object || typeof props.object !== 'object')
-                    return null
-
-                if ('character_id' in props.object)
-                    return 'portrait'
-
-                if ('corporation_id' in props.object || 'alliance_id' in props.object)
-                    return 'logo'
-
-                if (resourceType.value !== 'types')
-                    return null
-
-                return props.bpo ? 'bp' : (props.object.image_variant ?? 'icon')
-            })
-
-            const resourceSize = computed(() => {
-
-                function isRetina() {
-                    return (window.devicePixelRatio > 1 ||	(window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches));
-                }
-
-                let size = props.size < 32 ? 32 : props.size
-
-                return isRetina() ? size*2 : size;
-            })
-
-            const imageUrl = computed(() => {
-                return `https://images.evetech.net/${resourceType.value}/${resourceId.value}/${resourceVariant.value}?size=${resourceSize.value}&tenant=tranquility`
-            })
-
-            const isReady = computed(() => Boolean(resourceType.value && resourceId.value && resourceVariant.value))
-
-            return {
-                imageUrl,
-                isReady,
-            }
-
-        },
+const props = defineProps({
+    object: {
+        type: Object,
+        required: true
+    },
+    size: {
+        type: Number,
+        default: 32
+    },
+    tailwind_class: {
+        required: false,
+        default: "h-12 w-12 rounded-full"
+    },
+    showName: {
+        type: Boolean,
+        required: false,
+        default: false
+    },
+    bpo: {
+        type: Boolean,
+        required: false,
+        default: false
     }
+});
+
+const resourceId = computed(() => {
+    return _.chain(['type_id', 'character_id', 'corporation_id', 'alliance_id'])
+        .map(resource => _.get(props.object, resource))
+        .filter()
+        .head()
+        .value()
+})
+
+const resourceType = computed(() => {
+    let array = {
+        'character_id': 'characters',
+        'corporation_id': 'corporations',
+        'alliance_id': 'alliances',
+        'type_id': 'types',
+    }
+
+    return _.chain(array)
+        .filter( (type, id) => id in props.object )
+        .map((type) => type)
+        .head()
+        .value();
+})
+
+// Resolved synchronously — no per-image HTTP roundtrip. characters/corps/alliances are
+// deterministic; types carry their variation (render/bp/icon) from the backend
+// (TypeResource.image_variant, derived from the inventory category), defaulting to icon.
+const resourceVariant = computed(() => {
+    if (!props.object || typeof props.object !== 'object')
+        return null
+
+    if ('character_id' in props.object)
+        return 'portrait'
+
+    if ('corporation_id' in props.object || 'alliance_id' in props.object)
+        return 'logo'
+
+    if (resourceType.value !== 'types')
+        return null
+
+    return props.bpo ? 'bp' : (props.object.image_variant ?? 'icon')
+})
+
+const resourceSize = computed(() => {
+
+    function isRetina() {
+        return (window.devicePixelRatio > 1 ||	(window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches));
+    }
+
+    let size = props.size < 32 ? 32 : props.size
+
+    return isRetina() ? size*2 : size;
+})
+
+const imageUrl = computed(() => {
+    return `https://images.evetech.net/${resourceType.value}/${resourceId.value}/${resourceVariant.value}?size=${resourceSize.value}&tenant=tranquility`
+})
+
+const isReady = computed(() => Boolean(resourceType.value && resourceId.value && resourceVariant.value))
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/AuthLayout/EmptyLayout.vue
+++ b/resources/js/Shared/Layout/AuthLayout/EmptyLayout.vue
@@ -7,13 +7,8 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import Toasts from "@/Shared/Toasts/Toasts.vue";
-
-export default {
-    name: "EmptyLayout",
-    components: {Toasts}
-}
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/Cards/Card.vue
+++ b/resources/js/Shared/Layout/Cards/Card.vue
@@ -7,9 +7,3 @@
     </div>
   </div>
 </template>
-
-<script>
-export default {
-    name: "Card"
-}
-</script>

--- a/resources/js/Shared/Layout/Cards/CardWithHeader.vue
+++ b/resources/js/Shared/Layout/Cards/CardWithHeader.vue
@@ -14,12 +14,6 @@
   </div>
 </template>
 
-<script>
-export default {
-    name: "CardWithHeader"
-}
-</script>
-
 <style scoped>
 
 </style>

--- a/resources/js/Shared/Layout/DataDisplay/LeftAligned.vue
+++ b/resources/js/Shared/Layout/DataDisplay/LeftAligned.vue
@@ -63,12 +63,6 @@
   </div>
 </template>
 
-<script>
-export default {
-    name: "LeftAligned"
-}
-</script>
-
 <style scoped>
 
 </style>

--- a/resources/js/Shared/Layout/DataDisplay/LeftAlignedData.vue
+++ b/resources/js/Shared/Layout/DataDisplay/LeftAlignedData.vue
@@ -12,11 +12,6 @@
     </dd>
   </div>
 </template>
-<script>
-export default {
-    name: "LeftAlignedData"
-}
-</script>
 
 <style scoped>
 

--- a/resources/js/Shared/Layout/Eve/EntityBlock.vue
+++ b/resources/js/Shared/Layout/Eve/EntityBlock.vue
@@ -21,60 +21,48 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue"
 import EveImage from "@/Shared/EveImage.vue"
-export default {
-    name: "EntityBlock",
-    components: {EveImage},
-    props: {
-        entity: {
-            required: true,
-            type: Object
-        },
-        imageSize: {
-            required: false,
-            default: 12,
-            type: Number
-        },
-        nameFontSize: {
-            required: false,
-            default: 'lg',
-            type: String
-        },
-        nameClass: {
-            required: false,
-            type: String,
-            default: ''
-        }
+
+const props = defineProps({
+    entity: {
+        required: true,
+        type: Object
     },
-    computed: {
-        name() {
-            return _.get(this.entity, 'name', 'missing name')
-        },
-        image_class() {
-            return `h-${this.imageSize} w-${this.imageSize} rounded-full`
-        },
-        name_class() {
-            return this.nameClass ? this.nameClass : `text-${this.nameFontSize} leading-6 font-medium text-gray-900`
-        },
-        subText() {
-
-            let alliance = _.get(this.entity, 'alliance', null)
-
-            let names = _.compact([
-                _.get(this.entity, 'corporation.name'),
-                _.isString(alliance) ? alliance : _.get(alliance, 'name', null),
-            ])
-
-            return _.join(names, ' | ')
-        }
+    imageSize: {
+        required: false,
+        default: 12,
+        type: Number
     },
-    methods: {
-        hasAlliance() {
-            return _.has(this.entity, 'alliance.name')
-        }
+    nameFontSize: {
+        required: false,
+        default: 'lg',
+        type: String
+    },
+    nameClass: {
+        required: false,
+        type: String,
+        default: ''
     }
-}
+});
+
+const name = computed(() => _.get(props.entity, 'name', 'missing name'))
+
+const image_class = computed(() => `h-${props.imageSize} w-${props.imageSize} rounded-full`)
+
+const name_class = computed(() => props.nameClass ? props.nameClass : `text-${props.nameFontSize} leading-6 font-medium text-gray-900`)
+
+const subText = computed(() => {
+    let alliance = _.get(props.entity, 'alliance', null)
+
+    let names = _.compact([
+        _.get(props.entity, 'corporation.name'),
+        _.isString(alliance) ? alliance : _.get(alliance, 'name', null),
+    ])
+
+    return _.join(names, ' | ')
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/HeaderButton.vue
+++ b/resources/js/Shared/Layout/HeaderButton.vue
@@ -9,15 +9,12 @@
   </span>
 </template>
 
-<script>
-  export default {
-      name: "HeaderButton",
-      props: {
-          secondary: {
-              default: false
-          }
-      },
-  }
+<script setup>
+defineProps({
+    secondary: {
+        default: false,
+    },
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/Table/StickyHeaderCell.vue
+++ b/resources/js/Shared/Layout/Table/StickyHeaderCell.vue
@@ -12,7 +12,6 @@
 
 <script>
 import {useValidateObject} from "@/Functions/useValidateObject";
-import {computed} from "vue";
 
 var schema = {
     label: value => _.isString(value),
@@ -22,35 +21,31 @@ var schema = {
 
 schema.label.required = true
 schema.columnSpan.required = true
+</script>
 
-export default {
-    name: "StickyHeaderCell",
-    props: {
-        cell: {
-            required: true,
-            type: [String, Object],
-            validator: cell => _.isObject(cell) ? useValidateObject(cell, schema) : _.isString(cell)
-        },
-        mobileColumnSpan: {
-            required: false,
-            type: Number,
-            default: 1
-        }
+<script setup>
+import {computed} from "vue";
+
+const props = defineProps({
+    cell: {
+        required: true,
+        type: [String, Object],
+        validator: cell => _.isObject(cell) ? useValidateObject(cell, schema) : _.isString(cell)
     },
-    setup(props) {
-        const enrichedCell = computed(() => {
-            return {
-                label: _.isString(props.cell) ? props.cell : props.cell.label,
-                columnSpan: _.isString(props.cell) ? 1 : props.cell.columnSpan,
-                mobileColumnSpan: _.isString(props.cell) ? 1 : _.get(props.cell, 'mobileColumnSpan', props.mobileColumnSpan),
-            }
-        })
-
-        return {
-            enrichedCell
-        }
+    mobileColumnSpan: {
+        required: false,
+        type: Number,
+        default: 1
     }
-}
+});
+
+const enrichedCell = computed(() => {
+    return {
+        label: _.isString(props.cell) ? props.cell : props.cell.label,
+        columnSpan: _.isString(props.cell) ? 1 : props.cell.columnSpan,
+        mobileColumnSpan: _.isString(props.cell) ? 1 : _.get(props.cell, 'mobileColumnSpan', props.mobileColumnSpan),
+    }
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/Table/StickyHeaderTable.vue
+++ b/resources/js/Shared/Layout/Table/StickyHeaderTable.vue
@@ -24,7 +24,6 @@
 </template>
 
 <script>
-import {computed} from "vue";
 import {useValidateObject} from "@/Functions/useValidateObject";
 
 var schema = {
@@ -36,48 +35,42 @@ var schema = {
 
 schema.title.required = true
 schema.columnSpan.required = true
+</script>
 
-export default {
-    name: "StickyHeaderTable",
-    props: {
-        headerTitles: {
-            required: true,
-            type: Array,
-            validator: titles => _.chain(titles)
-                .map(title => _.isObject(title) ? useValidateObject(title, schema) : _.isString(title))
-                .filter()
-                .value()
-                .length> 0
-        },
-        // Optional id for the row <ul> so an <InfiniteScroll items-element> can target it.
-        bodyId: {
-            required: false,
-            type: String,
-            default: null,
-        }
+<script setup>
+import {computed} from "vue";
+
+const props = defineProps({
+    headerTitles: {
+        required: true,
+        type: Array,
+        validator: titles => _.chain(titles)
+            .map(title => _.isObject(title) ? useValidateObject(title, schema) : _.isString(title))
+            .filter()
+            .value()
+            .length> 0
     },
-    setup(props) {
-
-        const countColumns = computed(() => {
-            return _.sumBy(props.headerTitles, (title) => {
-                return _.isString(title) ? 1 : title.columnSpan
-            })
-        })
-
-        const columns = computed(() => _.map(props.headerTitles, function (title) {
-            return {
-                columnSpan: _.get(title, 'columnSpan', 1),
-                mobileColumnSpan: _.get(title, 'singleRowElement', false) ? 2 : 1,
-                label: _.get(title, 'title', title),
-                srOnly: _.get(title, 'srOnly', false),
-            }
-        }))
-
-        return {
-            countColumns,
-            columns,
-        }
+    // Optional id for the row <ul> so an <InfiniteScroll items-element> can target it.
+    bodyId: {
+        required: false,
+        type: String,
+        default: null,
     }
-}
+});
+
+const countColumns = computed(() => {
+    return _.sumBy(props.headerTitles, (title) => {
+        return _.isString(title) ? 1 : title.columnSpan
+    })
+})
+
+const columns = computed(() => _.map(props.headerTitles, function (title) {
+    return {
+        columnSpan: _.get(title, 'columnSpan', 1),
+        mobileColumnSpan: _.get(title, 'singleRowElement', false) ? 2 : 1,
+        label: _.get(title, 'title', title),
+        srOnly: _.get(title, 'srOnly', false),
+    }
+}))
 </script>
 

--- a/resources/js/Shared/Layout/Table/StickyHeaderTableRow.vue
+++ b/resources/js/Shared/Layout/Table/StickyHeaderTableRow.vue
@@ -7,17 +7,14 @@
   </div>
 </template>
 
-<script>
-export default {
-    name: "StickyHeaderTableRow",
-    props: {
-        numberColumns: {
-            type: Number,
-            required: true,
-            default: 1
-        }
+<script setup>
+defineProps({
+    numberColumns: {
+        type: Number,
+        required: true,
+        default: 1
     }
-}
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/WideListElement.vue
+++ b/resources/js/Shared/WideListElement.vue
@@ -74,19 +74,16 @@
   </li>
 </template>
 
-<script>
+<script setup>
 import { Link } from '@inertiajs/vue3';
-export default {
-    name: "WideListElement",
-    components: {Link},
-    props: {
-        url: {
-            type: String,
-            required: false,
-            default: ''
-        },
-    }
-}
+
+defineProps({
+    url: {
+        type: String,
+        required: false,
+        default: '',
+    },
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/WideLists.vue
+++ b/resources/js/Shared/WideLists.vue
@@ -8,12 +8,6 @@
   </div>
 </template>
 
-<script>
-  export default {
-    name: "WideLists"
-  }
-</script>
-
 <style scoped>
 
 </style>


### PR DESCRIPTION
## What

Phase 1 of migrating the web package's remaining **Options API** Vue SFCs (the old `export default { data, computed, methods, ... }` style) to **`<script setup>`**, matching the newer pages and the house style in `Shared/Components/AccessControl/UserPicker.vue`.

This PR converts **31 low-risk `Shared/` files** — presentational/leaf layout components (Cards, DataDisplay, Tables, EveImage, EntityBlock, WideList*) and the `Shared/Components/*` set (contract cells/rows, contacts, mails, assets, skills, wallet, character-inspection tabs).

## Why

On `5.x`, 108 of 169 `.vue` files were still Options API. This is the first slice; **77 remain** for follow-up phases (Pages/*, Modals, SlideOver, Sidebar).

## Scope / guarantees

- **Pure style/API migration** — no `<template>`, `<style>`, `route()`, or HTTP changes.
- **ESLint: 0 new errors or warnings** vs. the original files (the handful of remaining warnings — untyped/snake_case props, template indentation, `v-html` — all pre-existed and are left untouched to avoid API/behaviour changes).

## Conversion notes

- Name-only presentational wrappers (Card, CardWithHeader, LeftAligned*, WideLists) **drop their `<script>` block** entirely.
- Module-scoped code referenced by a `defineProps` validator (`StickyHeaderCell`, `StickyHeaderTable`, `ContractDetailsComponent`) moves to a **companion plain `<script>` block** — `defineProps` is a compile macro and can't reference `<script setup>`-scoped variables.
- `EntityBlock.vue` drops a dead, unreferenced `hasAlliance()` method (would otherwise trip `no-unused-vars` in `<script setup>`).
- lodash `_` stays a **global** (never imported), matching project convention.

## Verification

- [x] `npm run lint` (ESLint) — 0 errors, no new warnings.
- [ ] Browser tests (`tests/Browser/`) — run in the "Browser (vs core)" job / on host. Surfaces touched: character contracts/contacts/mail/skill/assets, wallet, character-inspection tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)