### PR TITLE
refactor(js): migrate 26 Shared/Components to <script setup> (phase 2)

### DIFF
--- a/resources/js/Shared/Components/Assets/AddManualLocationModal.vue
+++ b/resources/js/Shared/Components/Assets/AddManualLocationModal.vue
@@ -104,66 +104,53 @@
   </ModalWithFooter>
 </template>
 
-<script>
+<script setup>
+import { ref, watch } from "vue";
 import ModalWithFooter from "@/Shared/Modals/ModalWithFooter.vue";
 import EsiAutosuggest from "@/Shared/Components/EsiAutosuggest.vue";
 import {useForm} from "@inertiajs/vue3";
 import { create as createManualLocation } from "@/actions/Seatplus/Web/Http/Controllers/Shared/ManualLocationController";
 
-export default {
-    name: "AddManualLocationModal",
-    components: {EsiAutosuggest, ModalWithFooter,},
-    props: {
-      modelValue: {
+const props = defineProps({
+    modelValue: {
         required: true
-      },
-        location_id: {
-            required: true,
-            type: Number
-        }
     },
-emits: ['update:modelValue'],
-    data() {
-        return {
-          open: this.modelValue,
-            search_result: [],
-            query: '',
-            suggestions: [],
-            showSuggestions: false,
-            form: useForm({
-                name: '',
-                solar_system_id: null,
-            })
-        }
-    },
-    watch: {
-      modelValue(newVal) {
-        this.open = newVal
-      },
-      open(newVal) {
-        this.$emit('update:modelValue', newVal)
-      }
-    },
-    methods: {
-        submit() {
-            let self = this;
-
-            this.form.transform((data) => ({
-                ...data,
-                location_id: this.location_id
-            })).post(createManualLocation.url(), {
-                onSuccess: () => {
-                    self.form.reset()
-                    self.suggestions = []
-                    self.query = ''
-                    self.open = false
-                }
-            })
-
-
-
-        }
+    location_id: {
+        required: true,
+        type: Number
     }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const open = ref(props.modelValue)
+const query = ref('')
+const suggestions = ref([])
+const form = useForm({
+    name: '',
+    solar_system_id: null,
+})
+
+watch(() => props.modelValue, (newVal) => {
+    open.value = newVal
+})
+
+watch(open, (newVal) => {
+    emit('update:modelValue', newVal)
+})
+
+function submit() {
+    form.transform((data) => ({
+        ...data,
+        location_id: props.location_id
+    })).post(createManualLocation.url(), {
+        onSuccess: () => {
+            form.reset()
+            suggestions.value = []
+            query.value = ''
+            open.value = false
+        }
+    })
 }
 </script>
 

--- a/resources/js/Shared/Components/Assets/AssetsComponent.vue
+++ b/resources/js/Shared/Components/Assets/AssetsComponent.vue
@@ -86,43 +86,36 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
 import LocationComponent from "./LocationComponent.vue";
-import { InfiniteScroll } from "@inertiajs/vue3";
 
-export default {
-    name: "AssetsComponent",
-    components: {
-        InfiniteScroll,
-        LocationComponent,
+defineProps({
+    context: {
+        required: false,
+        type: String,
+        default: 'character'
     },
-    props: {
-        context: {
-            required: false,
-            type: String,
-            default: 'character'
-        },
-        compact: {
-            required: false,
-            default: false,
-            type: Boolean
-        },
-        loading: {
-            required: false,
-            default: false,
-            type: Boolean
-        },
-        // The applied asset filter, forwarded to each location's lazy per-location fetch.
-        filter: {
-            required: false,
-            type: Object,
-            default: () => ({})
-        }
+    compact: {
+        required: false,
+        default: false,
+        type: Boolean
     },
-    computed: {
-        locations() {
-            return this.$page.props.assets?.data ?? []
-        }
+    loading: {
+        required: false,
+        default: false,
+        type: Boolean
+    },
+    // The applied asset filter, forwarded to each location's lazy per-location fetch.
+    filter: {
+        required: false,
+        type: Object,
+        default: () => ({})
     }
-}
+});
+
+const page = usePage();
+
+const locations = computed(() => page.props.assets?.data ?? [])
 </script>

--- a/resources/js/Shared/Components/Assets/CompactAssetListComponent.vue
+++ b/resources/js/Shared/Components/Assets/CompactAssetListComponent.vue
@@ -24,28 +24,15 @@
   />
 </template>
 
-<script>
+<script setup>
 import CompactAssetListElement from "./CompactAssetListElement.vue";
 
-export default {
-    name: "CompactAssetListComponent",
-    components: {CompactAssetListElement,},
-    props: {
-        items: {
-            required: true,
-            type: Array
-        }
-    },
-    computed: {
-        uniqueItems() {
-            return _.uniqBy(this.items, 'item_id')
-        },
-        hasOwnerPicture() {
-            // Show the owner avatar when the user has more than one character.
-            return this.$page.props.user.data.characters.length > 1
-        }
+defineProps({
+    items: {
+        required: true,
+        type: Array
     }
-}
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Assets/LocationName.vue
+++ b/resources/js/Shared/Components/Assets/LocationName.vue
@@ -4,46 +4,38 @@
   </span>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from "vue";
 import { getJson } from "@/Functions/http";
 import { getLocation } from "@/actions/Seatplus/Web/Http/Controllers/Shared/ManualLocationController";
 
-export default {
-    name: "LocationName",
-    props: {
-        location: {
-            required: true,
-            type: Object
-        }
-    },
-    data() {
-        return {
-            result: {}
-        }
-    },
-    computed: {
-        name() {
-            // An already-resolved name (a location summary carries `name` directly) wins, so a
-            // known location renders immediately without an on-demand fetch.
-            if (this.location.name) {
-                return this.location.name
-            }
-
-            return this.location.location != null ? _.get(this.location, 'location.locatable.name') : _.get(this.result, 'name', 'loading ...')
-        },
-        system() {
-            return _.get(this.result, 'system.name',)
-        }
-    },
-    created() {
-        // Only resolve on-demand when there is no known name and no eager relation to read from.
-        if (! this.location.name && this.location.location == null) {
-            getJson(getLocation.url(this.location.location_id))
-                .then((data) => {
-                    this.result = data
-                })
-        }
+const props = defineProps({
+    location: {
+        required: true,
+        type: Object
     }
+});
+
+const result = ref({})
+
+const name = computed(() => {
+    // An already-resolved name (a location summary carries `name` directly) wins, so a
+    // known location renders immediately without an on-demand fetch.
+    if (props.location.name) {
+        return props.location.name
+    }
+
+    return props.location.location != null ? _.get(props.location, 'location.locatable.name') : _.get(result.value, 'name', 'loading ...')
+})
+
+const system = computed(() => _.get(result.value, 'system.name',))
+
+// Only resolve on-demand when there is no known name and no eager relation to read from.
+if (! props.location.name && props.location.location == null) {
+    getJson(getLocation.url(props.location.location_id))
+        .then((data) => {
+            result.value = data
+        })
 }
 </script>
 

--- a/resources/js/Shared/Components/Autosuggest.vue
+++ b/resources/js/Shared/Components/Autosuggest.vue
@@ -55,7 +55,8 @@
   </listbox>
 </template>
 
-<script>
+<script setup>
+import { computed, ref, watch } from "vue";
 import {CheckIcon} from "@heroicons/vue/20/solid";
 import {
     Listbox,
@@ -67,125 +68,71 @@ import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import { getJson } from "@/Functions/http";
 import { typesOrGroupsOrCategories } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
 
-export default {
-    name: "Autosuggest",
-    components: {EntityBlock, Listbox, ListboxOptions, ListboxOption, CheckIcon, ListboxLabel},
-    props: {
-        label: {
-            required: false,
-            type: String
-        },
-        placeholder: {
-            required: true,
-            type: String
-        }
+defineProps({
+    label: {
+        required: false,
+        type: String
     },
-    emits: ['selected', 'selectedObject'],
-    data() {
-        return {
-            search_result: [],
-            selected: null,
-            query: '',
-            suggestions: [],
-            open: false,
-        }
-    },
-    computed: {
-        options() {
-            return _.isArray(this.suggestions) ? this.suggestions : _.get(this.suggestions, 'data', [])
-        }
-    },
-    watch: {
-        query(query) {
+    placeholder: {
+        required: true,
+        type: String
+    }
+});
 
-            if (query === undefined) {
-                return;
-            }
+const emit = defineEmits(['selected', 'selectedObject']);
 
-            /*if (query === '')
-              this.$emit('selected', null)*/
+const selected = ref(null)
+const query = ref('')
+const suggestions = ref([])
+const open = ref(false)
 
-            // In case of a select, the query gets updated, we need to prevent the suggestions from showing again.
-            if (query === _.get(this.selected, 'name')) {
-                return;
-            }
+const options = computed(() => _.isArray(suggestions.value) ? suggestions.value : _.get(suggestions.value, 'data', []))
 
-            if (query.length <= 2)
-                return;
+function toggle() {
+    if (options.value.length > 0)
+        open.value = !open.value
+}
 
-            let self = this
+function handleBackspace() {
+    if (query.value.length > 2)
+        return;
 
-            return getJson(typesOrGroupsOrCategories.url({ query: { search: query } }))
-                .then((result) => {
-                    self.suggestions = result
+    open.value = false
+    suggestions.value = []
+    selected.value = null
+    emit('selected', null)
+}
 
-                    // if previously the suggestions were not shown toggle them
-                    if (!this.open)
-                        this.toggle()
-                })
-        },
-        selected(newValue) {
-            this.query = _.get(newValue, 'name')
-            this.open = false
-            this.$emit('selected', _.get(newValue, 'id'))
-            this.$emit('selectedObject', newValue)
-        }
-    },
-    methods: {
-        select(suggestion) {
-            //TODO: Delete
-            this.selected = suggestion
-            this.query = _.get(suggestion, 'name')
-            this.open = false
-            this.$emit('selected', suggestion.id)
-            this.$emit('selectedObject', suggestion)
-        },
-        toggle() {
+watch(query, (newQuery) => {
 
-            if (this.options.length > 0)
-                this.open = !this.open
-
-            /*if (this.open)
-                new createPopper(this.$refs.inputField, this.$refs.listboxCollabsible, {
-                    placement: 'bottom-start',
-                    modifiers: [
-                        {
-                            name: "sameWidth",
-                            enabled: true,
-                            phase: "beforeWrite",
-                            requires: ["computeStyles"],
-                            fn: ({state}) => {
-                                state.styles.popper.width = `${state.rects.reference.width}px`;
-                            },
-                            effect: ({state}) => {
-                                state.elements.popper.style.width = `${
-                                    state.elements.reference.offsetWidth
-                                }px`;
-                            },
-                        },
-                        {
-                            name: 'offset',
-                            options: {
-                                offset: [0, 8],
-                            },
-                        },
-                    ]
-                })*/
-
-        },
-        handleBackspace() {
-
-            if (this.query.length > 2)
-                return;
-
-            this.open = false
-            this.suggestions = []
-            this.selected = null
-            this.$emit('selected', null)
-        }
+    if (newQuery === undefined) {
+        return;
     }
 
-}
+    // In case of a select, the query gets updated, we need to prevent the suggestions from showing again.
+    if (newQuery === _.get(selected.value, 'name')) {
+        return;
+    }
+
+    if (newQuery.length <= 2)
+        return;
+
+    return getJson(typesOrGroupsOrCategories.url({ query: { search: newQuery } }))
+        .then((result) => {
+            suggestions.value = result
+
+            // if previously the suggestions were not shown toggle them
+            if (!open.value)
+                toggle()
+        })
+})
+
+watch(selected, (newValue) => {
+    query.value = _.get(newValue, 'name')
+    open.value = false
+    emit('selected', _.get(newValue, 'id'))
+    emit('selectedObject', newValue)
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Character/CorporationHistoryComponent.vue
+++ b/resources/js/Shared/Components/Character/CorporationHistoryComponent.vue
@@ -66,37 +66,31 @@
   </CardWithHeader>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
-import { InfiniteScroll } from "@inertiajs/vue3";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import ResolveIdToName from "../../ResolveIdToName.vue";
 
-export default {
-    name: "CorporationHistoryComponent",
-    components: {ResolveIdToName, Time, EveImage, InfiniteScroll, EntityBlock, CardWithHeader},
-    props: {
-        character: {
-            type: Object,
-            required: true
-        }
-    },
-    computed: {
-        // The hosting page (CharacterInspectionScrollProps) supplies one scroll prop per inspected
-        // character, so read this character's history straight off the page props.
-        scrollKey() {
-            return `corporation_history_${this.character.character_id}`
-        },
-        scrollBodyId() {
-            return `corporation-history-body-${this.character.character_id}`
-        },
-        events() {
-            return this.$page.props[this.scrollKey]?.data ?? []
-        }
+const props = defineProps({
+    character: {
+        type: Object,
+        required: true
     }
-}
+});
+
+const page = usePage();
+
+// The hosting page (CharacterInspectionScrollProps) supplies one scroll prop per inspected
+// character, so read this character's history straight off the page props.
+const scrollKey = computed(() => `corporation_history_${props.character.character_id}`)
+
+const scrollBodyId = computed(() => `corporation-history-body-${props.character.character_id}`)
+
+const events = computed(() => page.props[scrollKey.value]?.data ?? [])
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/CharacterInspection/TabComponent.vue
+++ b/resources/js/Shared/Components/CharacterInspection/TabComponent.vue
@@ -110,7 +110,9 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from "vue";
+import { usePage } from "@inertiajs/vue3";
 import CorporationHistoryComponent from "@/Shared/Components/Character/CorporationHistoryComponent.vue";
 import SkillsComponent from "@/Shared/Components/Skills/SkillsComponent.vue";
 import MobileMailList from "@/Shared/Components/Mails/MobileMailList.vue";
@@ -131,73 +133,47 @@ const tabs = [
     'Mails'
 ]
 
-export default {
-    name: "TabComponent",
-    components: {
-        WalletTab,
-        LogTab,
-        ContractTab,
-        AssetTab,
-        CharacterContactsComponent,
-        MobileMailList,
-        SkillsComponent,
-        CorporationHistoryComponent
-        },
-    props: {
-        recruit: {
-            type: Object,
-            required: true
-        },
-        watchlist: {
-            type: Object,
-            required: true
-        },
-        targetCorporation: {
-            type: Object,
-            required: false
-        },
-        application: {
-            type: Object,
-            required: false
-        }
+const props = defineProps({
+    recruit: {
+        type: Object,
+        required: true
     },
-    setup() {
-        return {
-            tabs
-        }
+    watchlist: {
+        type: Object,
+        required: true
     },
-    data() {
-        return {
-            active_element: 'Log',
-        }
+    targetCorporation: {
+        type: Object,
+        required: false
     },
-    computed: {
-        characterIds() {
-            return _.map(this.recruit.characters, character => character.character_id)
-        },
-        /*targetCorporation() {
-            return this.application.corporation
-        }*/
-    },
-    methods: {
-        isActive(entry) {
-            return _.isEqual(entry, this.active_element)
-        },
-        select(entry) {
-            this.active_element = entry
-        },
-        // Skills and contacts arrive as deferred page props keyed by character_id (built by
-        // CharacterInspectionScrollProps), so read them off the page rather than threading them through.
-        skillsFor(characterId) {
-            return _.get(this.$page.props, ['skills', characterId], [])
-        },
-        skillQueueFor(characterId) {
-            return _.get(this.$page.props, ['skillQueue', characterId], [])
-        },
-        contactsFor(characterId) {
-            return _.get(this.$page.props, ['contacts', characterId], [])
-        }
+    application: {
+        type: Object,
+        required: false
     }
+});
+
+const page = usePage();
+
+const active_element = ref('Log')
+
+const characterIds = computed(() => _.map(props.recruit.characters, character => character.character_id))
+
+function isActive(entry) {
+    return _.isEqual(entry, active_element.value)
+}
+
+// Skills and contacts arrive as deferred page props keyed by character_id (built by
+// CharacterInspectionScrollProps), so read them off the page rather than threading them through.
+function skillsFor(characterId) {
+    return _.get(page.props, ['skills', characterId], [])
+}
+
+function skillQueueFor(characterId) {
+    return _.get(page.props, ['skillQueue', characterId], [])
+}
+
+function contactsFor(characterId) {
+    return _.get(page.props, ['contacts', characterId], [])
 }
 </script>
 

--- a/resources/js/Shared/Components/CharacterInspection/Tabs/WalletTab.vue
+++ b/resources/js/Shared/Components/CharacterInspection/Tabs/WalletTab.vue
@@ -15,31 +15,23 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from "vue";
 import WalletJournalBalanceChart from "@/Shared/Components/Wallet/Journal/WalletJournalBalanceChart.vue";
 import WalletJournalComponent from "@/Shared/Components/Wallet/Journal/WalletJournalComponent.vue";
 import WalletTransactionComponent from "@/Shared/Components/Wallet/Transaction/WalletTransactionComponent.vue";
 import WalletFilter from "@/Shared/Components/Wallet/WalletFilter.vue";
-export default {
-    name: "WalletTab",
-    components: {WalletFilter, WalletTransactionComponent, WalletJournalComponent, WalletJournalBalanceChart},
-    props: {
-        characterIds: {
-            required: true,
-            type: Array
-        }
-    },
-    data() {
-        return {
-            filter: []
-        }
-    },
-    computed: {
-        ref_types() {
-            return _.map(this.filter, (ref_type) => ref_type.name)
-        }
+
+defineProps({
+    characterIds: {
+        required: true,
+        type: Array
     }
-}
+});
+
+const filter = ref([])
+
+const ref_types = computed(() => _.map(filter.value, (ref_type) => ref_type.name))
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Contracts/ContractComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ContractComponent.vue
@@ -45,55 +45,43 @@
   </CardWithHeader>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import StickyHeaderTable from "@/Shared/Layout/Table/StickyHeaderTable.vue";
-import { InfiniteScroll } from "@inertiajs/vue3";
 import ContractRowComponent from "./ContractRowComponent.vue";
 
-export default {
-    name: "ContractComponent",
-    components: {
-        InfiniteScroll,
-        ContractRowComponent,
-        StickyHeaderTable,
-        CardWithHeader,
-        EntityByIdBlock,
+const props = defineProps({
+    id: {
+        required: true,
+        type: Number
     },
-    props: {
-        id: {
-            required: true,
-            type: Number
-        },
-        type: {
-            required: false,
-            type: String,
-            default: 'character'
-        },
-        // The page scroll prop this card renders — contracts_<id> (all) on the character page and
-        // the "All" recruitment sub-tab, or watchlist_contracts_<id> on the "Watchlisted" sub-tab.
-        scrollKey: {
-            required: true,
-            type: String,
-        },
+    type: {
+        required: false,
+        type: String,
+        default: 'character'
     },
-    computed: {
-        headerTitles() {
-            return [
-                {title: 'Issuer', columnSpan: 2},
-                {title: 'Assignee', columnSpan: 2},
-                {title: 'Type', columnSpan: 2},
-                {title: 'Details', columnSpan: 4},
-                {title: 'Content', columnSpan: 1, srOnly: true},
-            ]
-        },
-        scrollBodyId() {
-            return `contracts-body-${this.id}`
-        },
-        scrollEntries() {
-            return this.$page.props[this.scrollKey]?.data ?? []
-        },
-    }
-}
+    // The page scroll prop this card renders — contracts_<id> (all) on the character page and
+    // the "All" recruitment sub-tab, or watchlist_contracts_<id> on the "Watchlisted" sub-tab.
+    scrollKey: {
+        required: true,
+        type: String,
+    },
+});
+
+const page = usePage();
+
+const headerTitles = computed(() => [
+    {title: 'Issuer', columnSpan: 2},
+    {title: 'Assignee', columnSpan: 2},
+    {title: 'Type', columnSpan: 2},
+    {title: 'Details', columnSpan: 4},
+    {title: 'Content', columnSpan: 1, srOnly: true},
+])
+
+const scrollBodyId = computed(() => `contracts-body-${props.id}`)
+
+const scrollEntries = computed(() => page.props[props.scrollKey]?.data ?? [])
 </script>

--- a/resources/js/Shared/Components/ItemLayout.vue
+++ b/resources/js/Shared/Components/ItemLayout.vue
@@ -67,48 +67,42 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import LocationSlot from "./LocationSlot.vue";
-export default {
-    name: "ItemLayout",
-    components: {LocationSlot},
-    props: {
-        items: {
-            type: Array,
-            required: true
-        },
-    },
-    data() {
-        return {
-            highslots: ['HiSlot0', 'HiSlot1', 'HiSlot2', 'HiSlot3', 'HiSlot4', 'HiSlot5', 'HiSlot6', 'HiSlot7'],
-            midslots: ['MedSlot0', 'MedSlot1', 'MedSlot2', 'MedSlot3', 'MedSlot4', 'MedSlot5', 'MedSlot6', 'MedSlot7'],
-            lowslots: ['LoSlot0', 'LoSlot1', 'LoSlot2', 'LoSlot3', 'LoSlot4', 'LoSlot5', 'LoSlot6', 'LoSlot7'],
-            rigslots: ['RigSlot0', 'RigSlot1', 'RigSlot2', 'RigSlot3', 'RigSlot4', 'RigSlot5', 'RigSlot6', 'RigSlot7'],
-            subsystems: ['SubSystemSlot0', 'SubSystemSlot1', 'SubSystemSlot2', 'SubSystemSlot3', 'SubSystemSlot4', 'SubSystemSlot5', 'SubSystemSlot6', 'SubSystemSlot7'],
-            fleet_hangar: ['FleetHangar'],
-            ship_hangar: ['ShipHangar'],
-            fighter_tubes: ['FighterTube0', 'FighterTube1', 'FighterTube2', 'FighterTube3', 'FighterTube4'],
-            dronebay: ['DroneBay', 'FighterBay'],
-            specialized: [
-                'SpecializedAmmoHold', 'SpecializedCommandCenterHold', 'SpecializedFuelBay', 'SpecializedGasHold',
-                'SpecializedIndustrialShipHold', 'SpecializedLargeShipHold', 'SpecializedMaterialBay', 'SpecializedMediumShipHold',
-                'SpecializedMineralHold', 'SpecializedOreHold', 'SpecializedPlanetaryCommoditiesHold', 'SpecializedSalvageHold',
-                'SpecializedShipHold', 'SpecializedSmallShipHold', 'SubSystemBay'
-            ],
-            everything_else: [
-                'AssetSafety', 'AutoFit', 'BoosterBay', 'Cargo', 'CorpseBay', 'Deliveries', 'FrigateEscapeBay',
-                'HiddenModifiers', 'Implant', 'Locked',  'QuafeBay',  'Skill', 'Unlocked', 'Wardrobe', 'Hangar', 'HangarAll'
-            ]
-        }
-    },
-    computed: {
-        gotSecondColumn() {
-            let possible_items = [...this.fighter_tubes, ...this.fleet_hangar, ...this.ship_hangar]
 
-            return !_.isUndefined(_.find(this.items, (item) => possible_items.includes(item.location_flag)))
-        }
-    }
-}
+const props = defineProps({
+    items: {
+        type: Array,
+        required: true
+    },
+});
+
+const highslots = ['HiSlot0', 'HiSlot1', 'HiSlot2', 'HiSlot3', 'HiSlot4', 'HiSlot5', 'HiSlot6', 'HiSlot7']
+const midslots = ['MedSlot0', 'MedSlot1', 'MedSlot2', 'MedSlot3', 'MedSlot4', 'MedSlot5', 'MedSlot6', 'MedSlot7']
+const lowslots = ['LoSlot0', 'LoSlot1', 'LoSlot2', 'LoSlot3', 'LoSlot4', 'LoSlot5', 'LoSlot6', 'LoSlot7']
+const rigslots = ['RigSlot0', 'RigSlot1', 'RigSlot2', 'RigSlot3', 'RigSlot4', 'RigSlot5', 'RigSlot6', 'RigSlot7']
+const subsystems = ['SubSystemSlot0', 'SubSystemSlot1', 'SubSystemSlot2', 'SubSystemSlot3', 'SubSystemSlot4', 'SubSystemSlot5', 'SubSystemSlot6', 'SubSystemSlot7']
+const fleet_hangar = ['FleetHangar']
+const ship_hangar = ['ShipHangar']
+const fighter_tubes = ['FighterTube0', 'FighterTube1', 'FighterTube2', 'FighterTube3', 'FighterTube4']
+const dronebay = ['DroneBay', 'FighterBay']
+const specialized = [
+    'SpecializedAmmoHold', 'SpecializedCommandCenterHold', 'SpecializedFuelBay', 'SpecializedGasHold',
+    'SpecializedIndustrialShipHold', 'SpecializedLargeShipHold', 'SpecializedMaterialBay', 'SpecializedMediumShipHold',
+    'SpecializedMineralHold', 'SpecializedOreHold', 'SpecializedPlanetaryCommoditiesHold', 'SpecializedSalvageHold',
+    'SpecializedShipHold', 'SpecializedSmallShipHold', 'SubSystemBay'
+]
+const everything_else = [
+    'AssetSafety', 'AutoFit', 'BoosterBay', 'Cargo', 'CorpseBay', 'Deliveries', 'FrigateEscapeBay',
+    'HiddenModifiers', 'Implant', 'Locked',  'QuafeBay',  'Skill', 'Unlocked', 'Wardrobe', 'Hangar', 'HangarAll'
+]
+
+const gotSecondColumn = computed(() => {
+    let possible_items = [...fighter_tubes, ...fleet_hangar, ...ship_hangar]
+
+    return !_.isUndefined(_.find(props.items, (item) => possible_items.includes(item.location_flag)))
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Mails/DesktopMailList.vue
+++ b/resources/js/Shared/Components/Mails/DesktopMailList.vue
@@ -47,40 +47,30 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import { InfiniteScroll, usePage } from "@inertiajs/vue3";
 import { computed } from "vue";
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import ResolveIdToName from "../../ResolveIdToName.vue";
 
-export default {
-    name: "DesktopMailList",
-    components: {ResolveIdToName, Time, EveImage, InfiniteScroll},
-    props: {
-        selectedId: {
-            required: false
-        },
+const props = defineProps({
+    selectedId: {
+        required: false
     },
-    emits: ['update:selectedId'],
-    setup(props, {emit}) {
+});
 
-        const page = usePage()
+const emit = defineEmits(['update:selectedId']);
 
-        const emitSelection = (selectedId) => emit('update:selectedId', selectedId)
+const page = usePage()
 
-        // Mail headers arrive as the page scroll prop; flag the selected one.
-        const mails = computed(() => _.map(page.props.mailHeaders?.data ?? [], result => ({
-            ...result,
-            current: _.isEqual(props.selectedId, result.id),
-        })))
+const emitSelection = (selectedId) => emit('update:selectedId', selectedId)
 
-        return {
-            mails,
-            emitSelection,
-        }
-    }
-}
+// Mail headers arrive as the page scroll prop; flag the selected one.
+const mails = computed(() => _.map(page.props.mailHeaders?.data ?? [], result => ({
+    ...result,
+    current: _.isEqual(props.selectedId, result.id),
+})))
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Mails/MobileMailList.vue
+++ b/resources/js/Shared/Components/Mails/MobileMailList.vue
@@ -55,7 +55,7 @@
   </InfiniteScroll>
 </template>
 
-<script>
+<script setup>
 import MailRepresentation from "./MailRepresentation.vue";
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
@@ -65,39 +65,20 @@ import { computed } from "vue";
 import { ChevronUpIcon } from "@heroicons/vue/20/solid";
 import {Disclosure, DisclosureButton, DisclosurePanel} from "@headlessui/vue";
 
-export default {
-    name: "MobileMailList",
-    components: {
-        MailRepresentation,
-        EveImage, Time, ResolveIdToName, InfiniteScroll,
-        ChevronUpIcon,
-        Disclosure,
-        DisclosureButton,
-        DisclosurePanel,
-    },
-    props: {
-        selectedId: {
-            type: Number,
-            required: false
-        }
-    },
-    emits: ['update:selectedId'],
-    setup(props, {emit}) {
-
-        const page = usePage()
-
-        const mailHeaders = computed(() => page.props.mailHeaders?.data ?? [])
-
-        const emitSelection = (selectedId) => emit('update:selectedId', selectedId)
-        const isSelected = (mail) => mail.id === props.selectedId
-
-        return {
-            mailHeaders,
-            emitSelection,
-            isSelected
-        }
+const props = defineProps({
+    selectedId: {
+        type: Number,
+        required: false
     }
-}
+});
+
+defineEmits(['update:selectedId']);
+
+const page = usePage()
+
+const mailHeaders = computed(() => page.props.mailHeaders?.data ?? [])
+
+const isSelected = (mail) => mail.id === props.selectedId
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/SelectComponent.vue
+++ b/resources/js/Shared/Components/SelectComponent.vue
@@ -68,47 +68,30 @@
   </Listbox>
 </template>
 
-<script>
+<script setup>
 import {ref, watch} from 'vue'
 import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions } from '@headlessui/vue'
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/vue/20/solid'
 import EveImage from "../EveImage.vue";
 
-export default {
-    components: {
-        EveImage,
-        Listbox,
-        ListboxButton,
-        ListboxLabel,
-        ListboxOption,
-        ListboxOptions,
-        CheckIcon,
-        ChevronUpDownIcon,
+const props = defineProps({
+    listLabel: {
+        required: false,
+        type: String
     },
-    props: {
-        listLabel: {
-            required: false,
-            type: String
-        },
-        selected: {
-            required: true,
-            type: Object
-        },
-        options: {
-            required: true,
-            type: Array
-        }
+    selected: {
+        required: true,
+        type: Object
     },
-    emits: ['update:selected'],
-    setup(props, {emit}) {
+    options: {
+        required: true,
+        type: Array
+    }
+});
 
-        const selectedOption = ref(_.find(props.options, option =>_.isEqual(option, props.selected)))
+const emit = defineEmits(['update:selected']);
 
-        watch(selectedOption, (newValue) => emit('update:selected',newValue))
+const selectedOption = ref(_.find(props.options, option =>_.isEqual(option, props.selected)))
 
-        return {
-            selectedOption,
-        }
-    },
-}
+watch(selectedOption, (newValue) => emit('update:selected',newValue))
 </script>

--- a/resources/js/Shared/Components/SelectedEntity.vue
+++ b/resources/js/Shared/Components/SelectedEntity.vue
@@ -18,23 +18,22 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
+import { usePage } from "@inertiajs/vue3";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
-export default {
-    name: "SelectedEntity",
-    components: {EntityByIdBlock},
-    computed: {
-        selectedIds() {
-            // Read the character_ids query params off the current URL (replacing Ziggy's
-            // route().params); supports both bracketed and plain array notation.
-            const query = this.$page.url.split('?')[1] ?? ''
-            const params = new URLSearchParams(query)
-            const selectedCharacterIds = params.getAll('character_ids[]').concat(params.getAll('character_ids'))
 
-            return _.map(selectedCharacterIds, (id) => parseInt(id))
-        }
-    }
-}
+const page = usePage();
+
+const selectedIds = computed(() => {
+    // Read the character_ids query params off the current URL (replacing Ziggy's
+    // route().params); supports both bracketed and plain array notation.
+    const query = page.url.split('?')[1] ?? ''
+    const params = new URLSearchParams(query)
+    const selectedCharacterIds = params.getAll('character_ids[]').concat(params.getAll('character_ids'))
+
+    return _.map(selectedCharacterIds, (id) => parseInt(id))
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/SlideOver/DispatchUpdateButton.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchUpdateButton.vue
@@ -12,19 +12,13 @@
   </teleport>
 </template>
 
-<script>
+<script setup>
+import { ref } from "vue";
 import HeaderButton from "@/Shared/Layout/HeaderButton.vue";
 import SlideOver from "@/Shared/Layout/SlideOver.vue";
 import DispatchUpdate from "./DispatchUpdate.vue";
-export default {
-  name: "DispatchUpdateButton",
-  components: {DispatchUpdate, SlideOver, HeaderButton},
-  data() {
-    return {
-      open: false
-    }
-  }
-}
+
+const open = ref(false)
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/SlideOver/DispatchableEntry.vue
+++ b/resources/js/Shared/Components/SlideOver/DispatchableEntry.vue
@@ -51,7 +51,7 @@
   </li>
 </template>
 
-<script>
+<script setup>
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import { PlayIcon, ArrowPathIcon, CheckCircleIcon, XCircleIcon} from "@heroicons/vue/24/outline"
@@ -60,67 +60,54 @@ import { usePage } from "@inertiajs/vue3";
 import { getJson, post } from "@/Functions/http";
 import { getBatchStatus, dispatch } from "@/actions/Seatplus/Web/Http/Controllers/Queue/DispatchJobController";
 
-export default {
-    name: "DispatchableEntry",
-    components: {Time, EveImage, PlayIcon, ArrowPathIcon, CheckCircleIcon, XCircleIcon},
-    props: {
-        entry: {
-            type: Object,
-            required: true
-        }
-    },
-    setup(props) {
-        const status = ref(_.get(props.entry, 'batch.state'))
-        const batch_id = ref(_.get(props.entry, 'batch.batch_id'))
-        const updateStatus = ref()
-        const dispatch_transfer_object = computed(() => usePage().props.dispatchTransferObject)
-        const time = computed(() => _.get(props.entry, 'batch.time'))
+const props = defineProps({
+    entry: {
+        type: Object,
+        required: true
+    }
+});
 
-        async function getStatus() {
-            const result = await getJson(getBatchStatus.url(batch_id.value))
-            status.value = result.state
-        }
+const status = ref(_.get(props.entry, 'batch.state'))
+const batch_id = ref(_.get(props.entry, 'batch.batch_id'))
+const updateStatus = ref()
+const dispatch_transfer_object = computed(() => usePage().props.dispatchTransferObject)
+const time = computed(() => _.get(props.entry, 'batch.time'))
 
-        onBeforeMount(() => {
-            if(batch_id.value)
-                getStatus()
+async function getStatus() {
+    const result = await getJson(getBatchStatus.url(batch_id.value))
+    status.value = result.state
+}
+
+onBeforeMount(() => {
+    if(batch_id.value)
+        getStatus()
+})
+
+watch(status, (newValue, oldValue) => {
+    if(newValue === 'pending')
+        updateStatus.value = setInterval(getStatus,1000);
+    if(oldValue === 'pending')
+        clearInterval(updateStatus.value)
+})
+
+onUnmounted(() => {
+    if (updateStatus.value)
+        clearInterval(updateStatus.value)
+})
+
+const dispatchJob = async () => {
+    try {
+        const response = await post(dispatch.url(), {
+            character_id: props.entry.character_id,
+            corporation_id: props.entry.corporation_id,
+            dispatch_transfer_object: dispatch_transfer_object.value,
         })
 
-        watch(status, (newValue, oldValue) => {
-            if(newValue === 'pending')
-                updateStatus.value = setInterval(getStatus,1000);
-            if(oldValue === 'pending')
-                clearInterval(updateStatus.value)
-        })
-
-        onUnmounted(() => {
-            if (updateStatus.value)
-                clearInterval(updateStatus.value)
-        })
-
-        const dispatchJob = async () => {
-            try {
-                const response = await post(dispatch.url(), {
-                    character_id: props.entry.character_id,
-                    corporation_id: props.entry.corporation_id,
-                    dispatch_transfer_object: dispatch_transfer_object.value,
-                })
-
-                batch_id.value = (await response.text()).trim()
-                status.value = 'pending'
-                getStatus()
-            } catch (error) {
-                console.error(error)
-            }
-        }
-
-        return {
-            status,
-            batch_id,
-            dispatch_transfer_object,
-            dispatchJob,
-            time
-        }
+        batch_id.value = (await response.text()).trim()
+        status.value = 'pending'
+        getStatus()
+    } catch (error) {
+        console.error(error)
     }
 }
 </script>

--- a/resources/js/Shared/Components/SlideOver/EntitySelection.vue
+++ b/resources/js/Shared/Components/SlideOver/EntitySelection.vue
@@ -32,120 +32,108 @@
   </WhenVisible>
 </template>
 
-<script>
+<script setup>
+import { computed, onBeforeMount, onBeforeUnmount, ref, watch } from "vue";
+import { router, usePage, WhenVisible } from "@inertiajs/vue3";
 import SelectionEntity from "./SelectionEntity.vue";
-import { router, WhenVisible } from "@inertiajs/vue3";
 
-export default {
-    name: "EntitySelection",
-    components: {SelectionEntity, WhenVisible},
-    props: {
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        },
-        type: {
-            type: String,
-            default: () => 'character'
-        },
-        search: {
-            type: String,
-            default: ''
-        }
+const props = defineProps({
+    dispatchTransferObject: {
+        required: true,
+        type: Object
     },
-    data() {
-        return {
-            initial_ids: [],
-            selected_ids: [],
-            searchTimer: null,
-        }
+    type: {
+        type: String,
+        default: () => 'character'
     },
-    computed: {
-        // The picker's affiliated list arrives as the lazily-resolved `affiliatedEntities` shared
-        // prop; undefined until <WhenVisible> has fired its first partial reload once the list
-        // scrolls into view.
-        results() {
-            return this.$page.props.affiliatedEntities ?? []
-        },
-        permission() {
-            return this.dispatchTransferObject.permission
-        },
-        corporationRoles() {
-            return (this.dispatchTransferObject.required_corporation_role ?? []).join(',')
-        },
-        // Mirror the old behaviour: only filter server-side once at least 3 characters are typed.
-        searchParam() {
-            return this.search.length >= 3 ? this.search : ''
-        },
-        // The picker context that rides along with the partial reload so the shared closure can
-        // resolve + filter the right entities. `preserveUrl` keeps this internal context out of the
-        // page URL (which the picker itself uses only for the `${type}_ids` selection).
-        reloadParams() {
-            return {
-                data: {
-                    type: this.type,
-                    permission: this.permission,
-                    corporationRoles: this.corporationRoles,
-                    // Namespaced so the picker's search never collides with a page's own `search`
-                    // query filter (e.g. the assets page) during the partial reload.
-                    search_aff: this.searchParam,
-                },
-                preserveUrl: true,
-            }
-        },
-        changed() {
-            return JSON.stringify(this.initial_ids) !== JSON.stringify(this.selected_ids)
-        }
-    },
-    watch: {
-        // Debounced re-request on search change. <WhenVisible> only fires on its initial
-        // intersection, so once the list is loaded a search change is served by an explicit partial
-        // reload of the same shared prop (the on-demand equivalent of the old debounced getJson).
-        search() {
-            clearTimeout(this.searchTimer)
-            this.searchTimer = setTimeout(() => this.reloadEntities(), 300)
-        }
-    },
-    beforeMount() {
-        // The current selection is carried in the page URL. Ziggy used to serialise it as
-        // `character_ids[0]=…`; Inertia serialises `character_ids[]=…` — both share the
-        // `${type}_ids` key prefix, so collect every matching entry.
-        const params = new URLSearchParams(window.location.search)
-        const ids = []
+    search: {
+        type: String,
+        default: ''
+    }
+});
 
-        for (const [key, value] of params.entries()) {
-            if (key.startsWith(`${this.type}_ids`)) {
-                ids.push(parseInt(value))
-            }
-        }
+const page = usePage();
 
-        this.selected_ids = ids
-        this.initial_ids = [...ids]
+const initial_ids = ref([])
+const selected_ids = ref([])
+const searchTimer = ref(null)
+
+// The picker's affiliated list arrives as the lazily-resolved `affiliatedEntities` shared
+// prop; undefined until <WhenVisible> has fired its first partial reload once the list
+// scrolls into view.
+const results = computed(() => page.props.affiliatedEntities ?? [])
+
+const permission = computed(() => props.dispatchTransferObject.permission)
+
+const corporationRoles = computed(() => (props.dispatchTransferObject.required_corporation_role ?? []).join(','))
+
+// Mirror the old behaviour: only filter server-side once at least 3 characters are typed.
+const searchParam = computed(() => props.search.length >= 3 ? props.search : '')
+
+// The picker context that rides along with the partial reload so the shared closure can
+// resolve + filter the right entities. `preserveUrl` keeps this internal context out of the
+// page URL (which the picker itself uses only for the `${type}_ids` selection).
+const reloadParams = computed(() => ({
+    data: {
+        type: props.type,
+        permission: permission.value,
+        corporationRoles: corporationRoles.value,
+        // Namespaced so the picker's search never collides with a page's own `search`
+        // query filter (e.g. the assets page) during the partial reload.
+        search_aff: searchParam.value,
     },
-    beforeUnmount() {
-        clearTimeout(this.searchTimer)
+    preserveUrl: true,
+}))
 
-        if (!this.changed) {
-            return
-        }
+const changed = computed(() => JSON.stringify(initial_ids.value) !== JSON.stringify(selected_ids.value))
 
-        if (this.selected_ids.length === 0) {
-            router.get(window.location.pathname)
-            return
-        }
-
-        router.get(window.location.pathname, { [`${this.type}_ids`]: this.selected_ids })
-    },
-    methods: {
-        reloadEntities() {
-            router.reload({
-                only: ['affiliatedEntities'],
-                data: this.reloadParams.data,
-                preserveUrl: true,
-            })
-        }
-    },
+function reloadEntities() {
+    router.reload({
+        only: ['affiliatedEntities'],
+        data: reloadParams.value.data,
+        preserveUrl: true,
+    })
 }
+
+// Debounced re-request on search change. <WhenVisible> only fires on its initial
+// intersection, so once the list is loaded a search change is served by an explicit partial
+// reload of the same shared prop (the on-demand equivalent of the old debounced getJson).
+watch(() => props.search, () => {
+    clearTimeout(searchTimer.value)
+    searchTimer.value = setTimeout(() => reloadEntities(), 300)
+})
+
+onBeforeMount(() => {
+    // The current selection is carried in the page URL. Ziggy used to serialise it as
+    // `character_ids[0]=…`; Inertia serialises `character_ids[]=…` — both share the
+    // `${type}_ids` key prefix, so collect every matching entry.
+    const params = new URLSearchParams(window.location.search)
+    const ids = []
+
+    for (const [key, value] of params.entries()) {
+        if (key.startsWith(`${props.type}_ids`)) {
+            ids.push(parseInt(value))
+        }
+    }
+
+    selected_ids.value = ids
+    initial_ids.value = [...ids]
+})
+
+onBeforeUnmount(() => {
+    clearTimeout(searchTimer.value)
+
+    if (!changed.value) {
+        return
+    }
+
+    if (selected_ids.value.length === 0) {
+        router.get(window.location.pathname)
+        return
+    }
+
+    router.get(window.location.pathname, { [`${props.type}_ids`]: selected_ids.value })
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/SlideOver/EntitySelectionButton.vue
+++ b/resources/js/Shared/Components/SlideOver/EntitySelectionButton.vue
@@ -45,49 +45,43 @@
   </teleport>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from "vue";
+import { usePage } from "@inertiajs/vue3";
 import HeaderButton from "../../Layout/HeaderButton.vue";
 import SlideOver from "../../Layout/SlideOver.vue";
 import EntitySelection from "./EntitySelection.vue";
 import { MagnifyingGlassIcon } from '@heroicons/vue/20/solid';
 
-export default {
-    name: "EntitySelectionButton",
-    components: {EntitySelection, SlideOver, HeaderButton, MagnifyingGlassIcon},
-    props: {
-        type: {
-            type: String,
-            default: () => 'character'
-        }
-    },
-    data() {
-        return {
-            open: false,
-            search: ''
-        }
-    },
-    computed: {
-        has_selected() {
-            // The picker writes the current selection into the page URL as `${type}_ids[…]`.
-            const params = new URLSearchParams(window.location.search)
+const props = defineProps({
+    type: {
+        type: String,
+        default: () => 'character'
+    }
+});
 
-            for (const key of params.keys()) {
-                if (key.startsWith(`${this.type}_ids`)) {
-                    return true
-                }
-            }
+const page = usePage();
 
-            return false
-        },
-        dispatchTransferObject() {
-            return this.$page.props.dispatch_transfer_object != null ? this.$page.props.dispatch_transfer_object : this.$page.props.dispatchTransferObject
+const open = ref(false)
+const search = ref('')
+
+const has_selected = computed(() => {
+    // The picker writes the current selection into the page URL as `${type}_ids[…]`.
+    const params = new URLSearchParams(window.location.search)
+
+    for (const key of params.keys()) {
+        if (key.startsWith(`${props.type}_ids`)) {
+            return true
         }
-    },
-    methods: {
-        openSlideOver() {
-            this.open = true
-        },
-    },
+    }
+
+    return false
+})
+
+const dispatchTransferObject = computed(() => page.props.dispatch_transfer_object != null ? page.props.dispatch_transfer_object : page.props.dispatchTransferObject)
+
+function openSlideOver() {
+    open.value = true
 }
 </script>
 

--- a/resources/js/Shared/Components/SlideOver/SelectionEntity.vue
+++ b/resources/js/Shared/Components/SlideOver/SelectionEntity.vue
@@ -29,44 +29,38 @@
   </li>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
-export default {
-    name: "SelectionEntity",
-    components: {EntityBlock},
-    props: {
-        entity: {
-            type: Object,
-            required: true
-        },
-        modelValue: {
-            type: Array,
-            default: () => []
-        }
+
+const props = defineProps({
+    entity: {
+        type: Object,
+        required: true
     },
-    emits: ['update:modelValue'],
-    computed: {
-        isSelected() {
-            return this.modelValue.includes(this.entity.id)
-        }
-    },
-    methods: {
-        toggle() {
-
-            const entity = this.entity
-            let selected = this.modelValue
-            let index = selected.indexOf(entity.id)
-
-
-            if(index >= 0) {
-                selected = _.remove(selected, (select) => select !== entity.id)
-            } else {
-                selected.push(entity.id)
-            }
-
-            this.$emit('update:modelValue', selected)
-        }
+    modelValue: {
+        type: Array,
+        default: () => []
     }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const isSelected = computed(() => props.modelValue.includes(props.entity.id))
+
+function toggle() {
+    const entity = props.entity
+    let selected = props.modelValue
+    let index = selected.indexOf(entity.id)
+
+
+    if(index >= 0) {
+        selected = _.remove(selected, (select) => select !== entity.id)
+    } else {
+        selected.push(entity.id)
+    }
+
+    emit('update:modelValue', selected)
 }
 </script>
 

--- a/resources/js/Shared/Components/Wallet/Journal/ExtendedWalletJournalRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Journal/ExtendedWalletJournalRowComponent.vue
@@ -44,24 +44,14 @@
   </div>
 </template>
 
-<script>
-
+<script setup>
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 
-export default {
-    name: "ExtendedWalletJournalRowComponent",
-    components: {EntityByIdBlock},
-    props: {
-        entry: {
-            required: true
-        }
-    },
-    data() {
-        return {
-            expanded: false,
-        }
+defineProps({
+    entry: {
+        required: true
     }
-}
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Wallet/Journal/WalletJournalComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Journal/WalletJournalComponent.vue
@@ -58,56 +58,45 @@
   </CardWithHeader>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import WalletJournalRowComponent from "./WalletJournalRowComponent.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
-import { InfiniteScroll } from "@inertiajs/vue3";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
 
-export default {
-    name: "WalletJournalComponent",
-    components: {
-        InfiniteScroll,
-        EntityByIdBlock,
-        WalletJournalRowComponent,
-        CardWithHeader
+const props = defineProps({
+    id: {
+        required: true,
+        type: Number
     },
-    props: {
-        id: {
-            required: true,
-            type: Number
-        },
-        division: {
-            required: false,
-            type: Object,
-            default: () => {}
-        },
-        filters: {
-            required: false,
-            type: Object,
-            default: () => new Object()
-        }
+    division: {
+        required: false,
+        type: Object,
+        default: () => {}
     },
-    computed: {
-        // The journal is delivered as a page scroll prop (WalletsController /
-        // CorporationWalletController::index): keyed per character, or per
-        // corporation+division for corporate wallets, and consumed by
-        // <InfiniteScroll :data="scrollKey">.
-        scrollKey() {
-            return this.division
-                ? `journal_${this.id}_${this.division.division_id}`
-                : `journal_${this.id}`
-        },
-        scrollBodyId() {
-            return this.division
-                ? `journal-body-${this.id}-${this.division.division_id}`
-                : `journal-body-${this.id}`
-        },
-        journalEntries() {
-            return this.$page.props[this.scrollKey]?.data ?? []
-        }
+    filters: {
+        required: false,
+        type: Object,
+        default: () => new Object()
     }
-}
+});
+
+const page = usePage();
+
+// The journal is delivered as a page scroll prop (WalletsController /
+// CorporationWalletController::index): keyed per character, or per
+// corporation+division for corporate wallets, and consumed by
+// <InfiniteScroll :data="scrollKey">.
+const scrollKey = computed(() => props.division
+    ? `journal_${props.id}_${props.division.division_id}`
+    : `journal_${props.id}`)
+
+const scrollBodyId = computed(() => props.division
+    ? `journal-body-${props.id}-${props.division.division_id}`
+    : `journal-body-${props.id}`)
+
+const journalEntries = computed(() => page.props[scrollKey.value]?.data ?? [])
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Wallet/Journal/WalletJournalRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Journal/WalletJournalRowComponent.vue
@@ -56,40 +56,34 @@
   </li>
 </template>
 
-<script>
+<script setup>
+import { ref } from "vue";
 import Time from "@/Shared/Time.vue";
 import ExtendedWalletJournalRowComponent from "./ExtendedWalletJournalRowComponent.vue";
+import { useTranslations } from "@/composables/useTranslations";
 
-export default {
-    name: "WalletJournalRowComponent",
-    components: {
-        ExtendedWalletJournalRowComponent, Time
+defineProps({
+    entry: {
+        required: true
     },
-    props: {
-        entry: {
-            required: true
-        },
-        even: {
-            required: true,
-            type: Number
-        }
-    },
-    data() {
-        return {
-            expanded: false
-        }
-    },
-    methods: {
-        getTranslation(entry) {
-
-            let string = 'web::wallet_journal.' + _.toString(entry.ref_type)
-
-            return this.$trans(string)
-        },
-        toggle() {
-            this.expanded = !this.expanded
-        }
+    even: {
+        required: true,
+        type: Number
     }
+});
+
+const { trans } = useTranslations();
+
+const expanded = ref(false)
+
+function getTranslation(entry) {
+    let string = 'web::wallet_journal.' + _.toString(entry.ref_type)
+
+    return trans(string)
+}
+
+function toggle() {
+    expanded.value = !expanded.value
 }
 </script>
 

--- a/resources/js/Shared/Components/Wallet/Transaction/ExtendedWalletTransactionRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Transaction/ExtendedWalletTransactionRowComponent.vue
@@ -70,23 +70,15 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import EveImage from "@/Shared/EveImage.vue"
-export default {
-    name: "ExtendedWalletTransactionRowComponent",
-    components: {EveImage, EntityByIdBlock},
-    props: {
-        entry: {
-            required: true
-        }
-    },
-    data() {
-        return {
-            expanded: false,
-        }
+
+defineProps({
+    entry: {
+        required: true
     }
-}
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Wallet/Transaction/WalletTransactionComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Transaction/WalletTransactionComponent.vue
@@ -57,48 +57,38 @@
   </CardWithHeader>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import WalletTransactionRowComponent from "./WalletTransactionRowComponent.vue";
-import { InfiniteScroll } from "@inertiajs/vue3";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
 
-export default {
-    name: "WalletTransactionComponent",
-    components: {
-        InfiniteScroll,
-        WalletTransactionRowComponent,
-        EntityByIdBlock, CardWithHeader
+const props = defineProps({
+    id: {
+        required: true,
+        type: Number
     },
-    props: {
-        id: {
-            required: true,
-            type: Number
-        },
-        division: {
-            required: false,
-            type: Object,
-            default: () => {}
-        }
-    },
-    computed: {
-        // Delivered as a page scroll prop (WalletsController / CorporationWalletController):
-        // keyed per character, or per corporation+division for corporate wallets.
-        scrollKey() {
-            return this.division
-                ? `transaction_${this.id}_${this.division.division_id}`
-                : `transaction_${this.id}`
-        },
-        scrollBodyId() {
-            return this.division
-                ? `transaction-body-${this.id}-${this.division.division_id}`
-                : `transaction-body-${this.id}`
-        },
-        transactionEntries() {
-            return this.$page.props[this.scrollKey]?.data ?? []
-        }
+    division: {
+        required: false,
+        type: Object,
+        default: () => {}
     }
-}
+});
+
+const page = usePage();
+
+// Delivered as a page scroll prop (WalletsController / CorporationWalletController):
+// keyed per character, or per corporation+division for corporate wallets.
+const scrollKey = computed(() => props.division
+    ? `transaction_${props.id}_${props.division.division_id}`
+    : `transaction_${props.id}`)
+
+const scrollBodyId = computed(() => props.division
+    ? `transaction-body-${props.id}-${props.division.division_id}`
+    : `transaction-body-${props.id}`)
+
+const transactionEntries = computed(() => page.props[scrollKey.value]?.data ?? [])
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Components/Wallet/Transaction/WalletTransactionRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Transaction/WalletTransactionRowComponent.vue
@@ -76,53 +76,45 @@
   </li>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from "vue";
 import EveImage from "@/Shared/EveImage.vue"
 import Time from "@/Shared/Time.vue";
 import ExtendedWalletTransactionRowComponent from "./ExtendedWalletTransactionRowComponent.vue";
 
-export default {
-    name: "WalletTransactionRowComponent",
-    components: {ExtendedWalletTransactionRowComponent, Time, EveImage },
-    props: {
-        entry: {
-            required: true
-        },
-        even: {
-            required: true,
-            type: Number
-        }
+const props = defineProps({
+    entry: {
+        required: true
     },
-    data() {
-        return {
-            expanded: false
-        }
-    },
-    computed: {
-        getTypeDescription() {
-
-            let group_name = _.get(this.entry.type, 'group.name')
-            let category_name = _.get(this.entry.type, 'entry.type.category.name')
-
-            if (_.isUndefined(group_name))
-                return ''
-
-            if(_.isUndefined(category_name))
-                return group_name
-
-            return group_name + ' | ' + category_name
-        }
-    },
-    methods: {
-        toggle() {
-            this.expanded = !this.expanded
-        },
-        getTotal() {
-            let total = this.entry.quantity * this.entry.unit_price
-
-            return total.toLocaleString() ?? ''
-        }
+    even: {
+        required: true,
+        type: Number
     }
+});
+
+const expanded = ref(false)
+
+const getTypeDescription = computed(() => {
+    let group_name = _.get(props.entry.type, 'group.name')
+    let category_name = _.get(props.entry.type, 'entry.type.category.name')
+
+    if (_.isUndefined(group_name))
+        return ''
+
+    if(_.isUndefined(category_name))
+        return group_name
+
+    return group_name + ' | ' + category_name
+})
+
+function toggle() {
+    expanded.value = !expanded.value
+}
+
+function getTotal() {
+    let total = props.entry.quantity * props.entry.unit_price
+
+    return total.toLocaleString() ?? ''
 }
 </script>
 

--- a/resources/js/Shared/Components/Wallet/WalletFilter.vue
+++ b/resources/js/Shared/Components/Wallet/WalletFilter.vue
@@ -46,55 +46,48 @@
   </Card>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from "vue";
 import Card from "../../Layout/Cards/Card.vue";
 import DismissibleButton from "@/Shared/Layout/Buttons/DismissibleButton.vue";
 
-export default {
-    name: "WalletFilter",
-    components: { Card, DismissibleButton },
-    props: {
-        // Selected ref_type strings (v-model).
-        modelValue: {
-            required: true,
-            type: Array
-        },
-        // Available ref_type options, provided by the controller (no autosuggest
-        // endpoint — hence no axios / Ziggy on this page).
-        refTypes: {
-            required: false,
-            type: Array,
-            default: () => []
-        }
+const props = defineProps({
+    // Selected ref_type strings (v-model).
+    modelValue: {
+        required: true,
+        type: Array
     },
-    emits: ['update:modelValue'],
-    data() {
-        return {
-            query: ''
-        }
-    },
-    computed: {
-        selected() {
-            return this.modelValue
-        },
-        filteredOptions() {
-            const query = this.query.toLowerCase()
-
-            return this.refTypes
-                .filter((type) => !this.selected.includes(type))
-                .filter((type) => type.toLowerCase().includes(query))
-                .slice(0, 20)
-        }
-    },
-    methods: {
-        select(option) {
-            this.$emit('update:modelValue', [...this.selected, option])
-            this.query = ''
-        },
-        remove(name) {
-            this.$emit('update:modelValue', this.selected.filter((type) => type !== name))
-        }
+    // Available ref_type options, provided by the controller (no autosuggest
+    // endpoint — hence no axios / Ziggy on this page).
+    refTypes: {
+        required: false,
+        type: Array,
+        default: () => []
     }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const query = ref('')
+
+const selected = computed(() => props.modelValue)
+
+const filteredOptions = computed(() => {
+    const q = query.value.toLowerCase()
+
+    return props.refTypes
+        .filter((type) => !selected.value.includes(type))
+        .filter((type) => type.toLowerCase().includes(q))
+        .slice(0, 20)
+})
+
+function select(option) {
+    emit('update:modelValue', [...selected.value, option])
+    query.value = ''
+}
+
+function remove(name) {
+    emit('update:modelValue', selected.value.filter((type) => type !== name))
 }
 </script>
 


### PR DESCRIPTION
## What

Phase 2 of migrating the web package's Options API Vue SFCs to **`<script setup>`**. This converts the **26 remaining `Shared/Components/*` files** not covered by phase 1 (#1624) — the stateful / logic-heavy ones:

- Wallet journal & transaction cards + rows (+ extended rows), `WalletFilter`, `WalletTab`
- `ContractComponent`, asset `AssetsComponent` / `CompactAssetListComponent` / `LocationName` / `AddManualLocationModal`
- Mail `DesktopMailList` / `MobileMailList`, `Autosuggest`, `SelectComponent` / `SelectedEntity`
- SlideOver machinery (`EntitySelection`, `EntitySelectionButton`, `SelectionEntity`, `DispatchableEntry`, `DispatchUpdateButton`)
- `CorporationHistoryComponent`, `TabComponent`, `ItemLayout`

## Base / stacking

Cut from `5.x`. Files are **disjoint** from #1624, so both PRs target `5.x` independently and merge without conflict. Combined, the two PRs leave **51** Options-API files (phases 3–4: `Pages/*`, `Shared/Layout`, `Shared/Modals`, `Sidebar`).

## Scope / guarantees

- **Pure style/API migration** — no `<template>`, `<style>`, `route()`, or HTTP changes.
- **ESLint: 0 errors**, and warnings are strictly *fewer* than the originals (25 → 15) — none introduced (remaining ones are pre-existing untyped/defaultless props, template-shadow, prop-name-casing).

## Conversion notes

- `this.$page` → `usePage()`; `this.$trans` → `useTranslations()` (`const { trans }`).
- `emits` + `this.$emit` → `defineEmits`; `setup(props, { emit })` flattened to top level.
- Dead `data()`/methods removed where unreferenced (unused `expanded` flags, `select`/`emitSelection`, stale computed) — a leftover unused binding is a `no-unused-vars` error under `<script setup>`.
- lodash `_` stays a **global** (never imported).

## Verification

- [x] `npm run lint` (ESLint) — 0 errors, no new warnings.
- [ ] Browser tests (`tests/Browser/`) — "Browser (vs core)" job / host. Surfaces: character wallet/contracts/assets/mail/skill/contacts, member-tracking slide-over picker, corp history, recruitment character-inspection tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)