### PR TITLE
refactor(js): migrate 35 Pages to <script setup> (phase 3)

### DIFF
--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -58,41 +58,35 @@
 </template>
 
 <script>
-
 import EmptyLayout from "@/Shared/Layout/AuthLayout/EmptyLayout.vue";
+
+export default {
+    layout: EmptyLayout,
+}
+</script>
+
+<script setup>
+import { computed, ref } from "vue";
 import AppHead from "@/Shared/AppHead.vue";
-import { router } from "@inertiajs/vue3";
+import { router, usePage } from "@inertiajs/vue3";
 import { localeName } from "@/i18n/localeName";
 import { update as postLocale } from "@/actions/Seatplus/Web/Http/Controllers/LocaleController";
 import RedirectSSOController from "@/actions/Seatplus/Auth/Http/Controllers/Auth/RedirectSSOController";
 
-export default {
-    name: "Login",
-    components: {AppHead},
-    layout: (h, page) => h(EmptyLayout, () => page),
-    data() {
-        return {
-            selectedLocale: this.$page.props.locale,
-        }
-    },
-    computed: {
-        locales() {
-            return this.$page.props.locales || []
-        },
-        ssoUrl() {
-            return RedirectSSOController.url()
-        }
-    },
-    methods: {
-        localeName,
-        // `translations` is a reactive Inertia prop now — the redirect back re-renders
-        // in the newly-selected language without a full page reload.
-        switchLocale() {
-            router.post(postLocale.url(), { locale: this.selectedLocale }, {
-                preserveScroll: true,
-            })
-        }
-    }
+const page = usePage();
+
+const selectedLocale = ref(page.props.locale)
+
+const locales = computed(() => page.props.locales || [])
+
+const ssoUrl = computed(() => RedirectSSOController.url())
+
+// `translations` is a reactive Inertia prop now — the redirect back re-renders
+// in the newly-selected language without a full page reload.
+function switchLocale() {
+    router.post(postLocale.url(), { locale: selectedLocale.value }, {
+        preserveScroll: true,
+    })
 }
 </script>
 

--- a/resources/js/Pages/Auth/MissingRequiredScopes.vue
+++ b/resources/js/Pages/Auth/MissingRequiredScopes.vue
@@ -81,20 +81,23 @@
 </template>
 
 <script>
-    import EveImage from "@/Shared/EveImage.vue"
-    import ImpersonatingBanner from "@/Shared/SidebarLayout/ImpersonatingBanner.vue";
-    import EmptyLayout from "@/Shared/Layout/AuthLayout/EmptyLayout.vue";
-    import AppHead from "@/Shared/AppHead.vue";
-    export default {
-        name: "MissingRequiredScopes",
-        components: {AppHead, ImpersonatingBanner, EveImage},
-        layout: (h, page) => h(EmptyLayout, () => page),
-        props: {
-            characters: {
-                required: true
-            }
-        }
+import EmptyLayout from "@/Shared/Layout/AuthLayout/EmptyLayout.vue";
+
+export default {
+    layout: EmptyLayout,
+}
+</script>
+
+<script setup>
+import EveImage from "@/Shared/EveImage.vue"
+import ImpersonatingBanner from "@/Shared/SidebarLayout/ImpersonatingBanner.vue";
+import AppHead from "@/Shared/AppHead.vue";
+
+defineProps({
+    characters: {
+        required: true
     }
+});
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -89,15 +89,15 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import {computed, ref, watch} from 'vue'
+import { router } from "@inertiajs/vue3";
+import { SwitchGroup, Switch, SwitchLabel } from '@headlessui/vue'
 import PageHeader from "@/Shared/Layout/PageHeader.vue"
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 import AssetsComponent from "@/Shared/Components/Assets/AssetsComponent.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
-import {computed, ref, watch} from 'vue'
-import { router } from "@inertiajs/vue3";
-import { SwitchGroup, Switch, SwitchLabel } from '@headlessui/vue'
 import SelectedEntity from "@/Shared/Components/SelectedEntity.vue";
 import ComboboxMultiselect from "@/Shared/Components/ComboboxMultiselect.vue";
 import { ls } from "@/Functions/useLocalStorage";
@@ -106,104 +106,79 @@ import { ls } from "@/Functions/useLocalStorage";
 const COMPACT_VIEW_KEY = 'assets.compactView'
 const COMPACT_VIEW_TTL = 365 * 24 * 60 * 60 * 1000
 
-export default {
-    name: "Assets",
-    components: {
-        ComboboxMultiselect,
-        SelectedEntity,
-        RequiredScopesWarning,
-        DispatchUpdateButton,
-        AssetsComponent,
-        EntitySelectionButton,
-        PageHeader,
-        Switch,
-        SwitchGroup,
-        SwitchLabel
+const props = defineProps({
+    dispatchTransferObject: {
+        required: true,
+        type: Object,
+        default: () => {}
     },
-    props: {
-        dispatchTransferObject: {
-            required: true,
-            type: Object,
-            default: () => {}
-        },
-        characterIds: {
-            required: true,
-            type: Array,
-            default: () => []
-        },
-        // Regions/systems present in the characters' locations — options for the filters.
-        filterOptions: {
-            required: false,
-            type: Object,
-            default: () => ({ regions: [], systems: [] })
-        },
+    characterIds: {
+        required: true,
+        type: Array,
+        default: () => []
     },
-    setup(props) {
-        const switchValue = ref(ls.get(COMPACT_VIEW_KEY) ?? false)
-        // Hydrate the search box from the URL so a shared/reloaded ?search=… link shows its term.
-        const search = ref(new URLSearchParams(window.location.search).get('search'))
-        // True while a filter reload is in flight, so the list can show it's updating.
-        const searching = ref(false)
-        const regions = ref([])
-        const systems = ref([])
+    // Regions/systems present in the characters' locations — options for the filters.
+    filterOptions: {
+        required: false,
+        type: Object,
+        default: () => ({ regions: [], systems: [] })
+    },
+});
 
-        const cleanParams = computed(() => {
-            return {
-                search: search.value === "" ? null : search.value,
-                character_ids: props.characterIds,
-                regions: _.map(regions.value, 'id'),
-                systems: _.map(systems.value, 'id')
-            }
-        })
+const switchValue = ref(ls.get(COMPACT_VIEW_KEY) ?? false)
+// Hydrate the search box from the URL so a shared/reloaded ?search=… link shows its term.
+const search = ref(new URLSearchParams(window.location.search).get('search'))
+// True while a filter reload is in flight, so the list can show it's updating.
+const searching = ref(false)
+const regions = ref([])
+const systems = ref([])
 
-        // The filter actually applied to the list (updated when a reload fires). Per-location lazy
-        // loads bind to this — not the live search input — so they refetch in sync with the shell
-        // list rather than on every keystroke.
-        const appliedFilter = ref(cleanParams.value)
-
-        // Reload only the `assets` scroll prop with the current filters; reset so
-        // <InfiniteScroll> replaces the list with the filtered first page instead of merging.
-        const reload = () => {
-            appliedFilter.value = cleanParams.value
-
-            router.reload({
-                only: ['assets'],
-                reset: ['assets'],
-                data: cleanParams.value,
-                preserveState: true,
-                preserveScroll: true,
-                // Filters are sent to the server but kept out of the browser URL (stays /character/assets).
-                preserveUrl: true,
-                onStart: () => { searching.value = true },
-                onFinish: () => { searching.value = false },
-            })
-        }
-
-        const debouncedReload = _.debounce(reload, 500)
-
-        // Search reloads on 3+ chars or when cleared; region/system selections reload immediately.
-        watch(search, (newValue) => {
-            if (! newValue || _.size(newValue) >= 3) {
-                debouncedReload()
-            }
-        })
-
-        watch([regions, systems], () => reload(), { deep: true })
-
-        watch(switchValue, (value) => ls.set(COMPACT_VIEW_KEY, value, COMPACT_VIEW_TTL))
-
-        return {
-            search,
-            regions,
-            systems,
-            switchValue,
-            searching,
-            cleanParams,
-            appliedFilter,
-            pageTitle: 'Character Assets',
-        }
+const cleanParams = computed(() => {
+    return {
+        search: search.value === "" ? null : search.value,
+        character_ids: props.characterIds,
+        regions: _.map(regions.value, 'id'),
+        systems: _.map(systems.value, 'id')
     }
+})
+
+// The filter actually applied to the list (updated when a reload fires). Per-location lazy
+// loads bind to this — not the live search input — so they refetch in sync with the shell
+// list rather than on every keystroke.
+const appliedFilter = ref(cleanParams.value)
+
+// Reload only the `assets` scroll prop with the current filters; reset so
+// <InfiniteScroll> replaces the list with the filtered first page instead of merging.
+const reload = () => {
+    appliedFilter.value = cleanParams.value
+
+    router.reload({
+        only: ['assets'],
+        reset: ['assets'],
+        data: cleanParams.value,
+        preserveState: true,
+        preserveScroll: true,
+        // Filters are sent to the server but kept out of the browser URL (stays /character/assets).
+        preserveUrl: true,
+        onStart: () => { searching.value = true },
+        onFinish: () => { searching.value = false },
+    })
 }
+
+const debouncedReload = _.debounce(reload, 500)
+
+// Search reloads on 3+ chars or when cleared; region/system selections reload immediately.
+watch(search, (newValue) => {
+    if (! newValue || _.size(newValue) >= 3) {
+        debouncedReload()
+    }
+})
+
+watch([regions, systems], () => reload(), { deep: true })
+
+watch(switchValue, (value) => ls.set(COMPACT_VIEW_KEY, value, COMPACT_VIEW_TTL))
+
+const pageTitle = 'Character Assets'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/Contact/Index.vue
+++ b/resources/js/Pages/Character/Contact/Index.vue
@@ -49,41 +49,30 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import { Deferred } from "@inertiajs/vue3";
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import CharacterContactsComponent from "@/Shared/Components/Contacts/CharacterContactsComponent.vue";
-export default {
-    name: "Index",
-    components: {
-        Deferred,
-        CharacterContactsComponent,
-        RequiredScopesWarning,
-        DispatchUpdateButton,
-        EntitySelectionButton, PageHeader},
-    props: {
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        },
-        characters: {
-            required: true,
-            type: Array
-        },
-        contacts: {
-            type: Object,
-            default: () => ({})
-        }
+
+defineProps({
+    dispatchTransferObject: {
+        required: true,
+        type: Object
     },
-    data() {
-        return {
-            pageTitle: 'Character Contacts',
-        }
+    characters: {
+        required: true,
+        type: Array
+    },
+    contacts: {
+        type: Object,
+        default: () => ({})
     }
-}
+});
+
+const pageTitle = 'Character Contacts'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/Contract/ContractDetails.vue
+++ b/resources/js/Pages/Character/Contract/ContractDetails.vue
@@ -9,38 +9,29 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import ContractDetailsComponent from "@/Shared/Components/Contracts/ContractDetailsComponent.vue";
 import { index as characterContracts } from "@/actions/Seatplus/Web/Http/Controllers/Character/ContractsController";
-export default {
-    name: "ContractDetails",
-    components: {
-        ContractDetailsComponent,
-        PageHeader
+
+defineProps({
+    contract: {
+        required: true,
+        type: Object
     },
-    props: {
-        contract: {
-            required: true,
-            type: Object
-        },
-        activeSidebarElement: {
-            type: String,
-            required: true
-        }
-    },
-    data() {
-        return {
-            pageTitle: 'Contract Details',
-            breadcrumbs: [
-                {
-                    name: 'Character Contracts',
-                    route: characterContracts.url()
-                }
-            ]
-        }
-    },
-}
+    activeSidebarElement: {
+        type: String,
+        required: true
+    }
+});
+
+const pageTitle = 'Contract Details'
+const breadcrumbs = [
+    {
+        name: 'Character Contracts',
+        route: characterContracts.url()
+    }
+]
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/Contract/Index.vue
+++ b/resources/js/Pages/Character/Contract/Index.vue
@@ -22,37 +22,25 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 import ContractComponent from "@/Shared/Components/Contracts/ContractComponent.vue";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 
-export default {
-    name: "Index",
-    components: {
-      DispatchUpdateButton,
-      RequiredScopesWarning,
-        ContractComponent,
-        EntitySelectionButton,
-        PageHeader},
-    props: {
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        },
-        characters: {
-            required: true,
-            type: Array
-        }
+defineProps({
+    dispatchTransferObject: {
+        required: true,
+        type: Object
     },
-  data() {
-      return {
-        pageTitle: 'Character Contracts'
-      }
-  }
-}
+    characters: {
+        required: true,
+        type: Array
+    }
+});
+
+const pageTitle = 'Character Contracts'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/ItemDetails.vue
+++ b/resources/js/Pages/Character/ItemDetails.vue
@@ -22,55 +22,34 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { ref } from "vue";
 import EveImage from "@/Shared/EveImage.vue"
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import ItemLayout from "@/Shared/Components/ItemLayout.vue";
-import { prefix } from "metric-prefix";
 import AppHead from "@/Shared/AppHead.vue";
 import { index as assetsRoute, item as itemRoute } from "@/actions/Seatplus/Web/Http/Controllers/Character/AssetsController";
 
-export default {
-    name: "ItemDetails",
-    components : {AppHead, ItemLayout, PageHeader, EveImage},
-    props: {
-        item: {
-            type    : Object,
-            required: true
-        },
+const props = defineProps({
+    item: {
+        type    : Object,
+        required: true
     },
-    data() {
-        return {
-            object: _.first(this.item.data),
-            breadcrumbs: [
-                {
-                    name: 'Character Assets',
-                    route: assetsRoute.url()
-                }
-            ]
-        }
-    },
-    created() {
-        if(this.object.container)
-            this.breadcrumbs.push({
-                name: this.object.container.name,
-                route: itemRoute.url({character_id: this.object.owner_id, item_id: this.object.container.item_id})
-            })
-    },
-    methods: {
-        getMetricPrefix(numeric_value) {
+});
 
-            return prefix(numeric_value, {precision: 3, unit: 'm³'})
-        },
-        url(asset) {
-
-            return _.isEmpty(asset.content) ? '' : itemRoute.url({character_id: asset.owner_id, item_id: asset.item_id})
-        },
-        hasContent(content) {
-            return !_.isEmpty(content)
-        }
+const object = _.first(props.item.data)
+const breadcrumbs = ref([
+    {
+        name: 'Character Assets',
+        route: assetsRoute.url()
     }
-}
+])
+
+if(object.container)
+    breadcrumbs.value.push({
+        name: object.container.name,
+        route: itemRoute.url({character_id: object.owner_id, item_id: object.container.item_id})
+    })
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/Mail/Index.vue
+++ b/resources/js/Pages/Character/Mail/Index.vue
@@ -34,43 +34,36 @@
 </template>
 
 <script>
+export default {
+    layout: null,
+}
+</script>
+
+<script setup>
+import {ref} from "vue";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 import MultiColumnLayout from "@/Shared/SidebarLayout/MultiColumnLayout.vue";
-import {ref} from "vue";
 import MailRepresentation from "@/Shared/Components/Mails/MailRepresentation.vue";
 import DesktopMailList from "@/Shared/Components/Mails/DesktopMailList.vue";
 import MobileMailList from "@/Shared/Components/Mails/MobileMailList.vue";
-export default {
-    name: "Index",
-    components: {
-        MobileMailList,
-        DesktopMailList,
-        MailRepresentation,
-        MultiColumnLayout, EntitySelectionButton, DispatchUpdateButton, PageHeader, RequiredScopesWarning},
-    layout: null,
-    props: {
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        },
-        characterIds: {
-            required: true,
-            type: Array
-        }
+
+defineProps({
+    dispatchTransferObject: {
+        required: true,
+        type: Object
     },
-    setup() {
-
-        const selectedId = ref(null)
-
-        return {
-            pageTitle: 'Character Mails',
-            selectedId
-        }
+    characterIds: {
+        required: true,
+        type: Array
     }
-}
+});
+
+const selectedId = ref(null)
+
+const pageTitle = 'Character Mails'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/Skill/Index.vue
+++ b/resources/js/Pages/Character/Skill/Index.vue
@@ -70,41 +70,34 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import { Deferred } from "@inertiajs/vue3";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 import SkillsComponent from "@/Shared/Components/Skills/SkillsComponent.vue";
-export default {
-    name: "Index",
-    components: {Deferred, SkillsComponent, EntitySelectionButton, DispatchUpdateButton, PageHeader, RequiredScopesWarning},
-    props: {
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        },
-        character_ids: {
-            required: true,
-            type: Array
-        },
-        skills: {
-            type: Object,
-            default: () => ({})
-        },
-        skillQueue: {
-            type: Object,
-            default: () => ({})
-        }
-    },
-    setup() {
 
-        return {
-            pageTitle: 'Character Skills'
-        }
+defineProps({
+    dispatchTransferObject: {
+        required: true,
+        type: Object
+    },
+    character_ids: {
+        required: true,
+        type: Array
+    },
+    skills: {
+        type: Object,
+        default: () => ({})
+    },
+    skillQueue: {
+        type: Object,
+        default: () => ({})
     }
-}
+});
+
+const pageTitle = 'Character Skills'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Character/Wallet/Index.vue
+++ b/resources/js/Pages/Character/Wallet/Index.vue
@@ -27,70 +27,53 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import {computed, ref, watch} from "vue";
+import { router } from "@inertiajs/vue3";
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import WalletComponent from "@/Shared/Components/Wallet/WalletComponent.vue";
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import WalletFilter from "@/Shared/Components/Wallet/WalletFilter.vue";
-import { router } from "@inertiajs/vue3";
 
-export default {
-    name: "Index",
-    components: {
-        WalletFilter,
-      RequiredScopesWarning,
-      DispatchUpdateButton,
-        EntitySelectionButton,
-        WalletComponent,
-        PageHeader
+const props = defineProps({
+    dispatchTransferObject: {
+        required: true,
+        type: Object
     },
-    props: {
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        },
-        character_ids: {
-            required: true,
-            type: Array
-        },
-        // Available ref_type options for the filter (WalletsController::index) —
-        // passed as a prop so the filter needs no autosuggest endpoint (no axios/Ziggy).
-        ref_types: {
-            required: false,
-            type: Array,
-            default: () => []
-        }
+    character_ids: {
+        required: true,
+        type: Array
     },
-    data() {
-        return {
-            pageTitle: 'Character Wallets',
-            filter: [] // selected ref_type strings
-        }
-    },
-    computed: {
-        // Scroll-prop keys for every character card (WalletsController::index).
-        journalKeys() {
-            return this.character_ids.map((id) => `journal_${id}`)
-        }
-    },
-    watch: {
-        // The ref_type filter is a page-level query param: reload only the journal
-        // scroll props so <InfiniteScroll> resets to the filtered first page.
-        filter(newValue) {
-            router.reload({
-                only: this.journalKeys,
-                // reset: without it InfiniteScroll *merges* the filtered page onto the
-                // existing rows instead of replacing them, so the filter looks ignored.
-                reset: this.journalKeys,
-                data: { ref_type: newValue },
-                preserveState: true,
-                preserveScroll: true,
-            })
-        }
+    // Available ref_type options for the filter (WalletsController::index) —
+    // passed as a prop so the filter needs no autosuggest endpoint (no axios/Ziggy).
+    ref_types: {
+        required: false,
+        type: Array,
+        default: () => []
     }
-}
+});
+
+const pageTitle = 'Character Wallets'
+const filter = ref([]) // selected ref_type strings
+
+// Scroll-prop keys for every character card (WalletsController::index).
+const journalKeys = computed(() => props.character_ids.map((id) => `journal_${id}`))
+
+// The ref_type filter is a page-level query param: reload only the journal
+// scroll props so <InfiniteScroll> resets to the filtered first page.
+watch(filter, (newValue) => {
+    router.reload({
+        only: journalKeys.value,
+        // reset: without it InfiniteScroll *merges* the filtered page onto the
+        // existing rows instead of replacing them, so the filter looks ignored.
+        reset: journalKeys.value,
+        data: { ref_type: newValue },
+        preserveState: true,
+        preserveScroll: true,
+    })
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Commands.vue
+++ b/resources/js/Pages/Configuration/Commands.vue
@@ -10,24 +10,16 @@
   </span>
 </template>
 
-<script>
+<script setup>
+import { router } from "@inertiajs/vue3";
+import { clear } from "@/actions/Seatplus/Web/Http/Controllers/Configuration/CommandsController";
 
-  import { router } from "@inertiajs/vue3";
-  import { clear } from "@/actions/Seatplus/Web/Http/Controllers/Configuration/CommandsController";
-
-  export default {
-    name: "Commands",
-
-    methods: {
-
-      clearCache() {
-        router.post(clear.url()).
-        catch(function (error) {
-          console.log(error)
-        })
-      }
-    }
-  }
+function clearCache() {
+    router.post(clear.url()).
+    catch(function (error) {
+        console.log(error)
+    })
+}
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/HorizonStats.vue
+++ b/resources/js/Pages/Configuration/HorizonStats.vue
@@ -137,61 +137,45 @@
   </div>
 </template>
 
-<script>
-    import { router } from '@inertiajs/vue3'
-    // horizon.index is a Laravel Horizon (vendor) named route; use its Wayfinder @/routes helper.
-    import { index as horizonIndex } from "@/routes/horizon";
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { router, usePage } from '@inertiajs/vue3'
+// horizon.index is a Laravel Horizon (vendor) named route; use its Wayfinder @/routes helper.
+import { index as horizonIndex } from "@/routes/horizon";
 
-    export default {
-        name: "HorizonStats",
-        data() {
-            return {
-                timer: '',
-                symbols: {
-                    'running'   : '<path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>',
-                    'inactive'  : '<path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path><path d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"></path>',
-                    'paused'    : '<path d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>'
-                }
-            }
-        },
-        computed : {
-            // Horizon stats arrive as the `queueStats` optional Inertia prop, refreshed by the
-            // partial reload in refreshStats() — no client-side HTTP.
-            stats() {
-                return this.$page.props.queueStats ?? {}
-            },
-            horizonUrl() {
-                return horizonIndex.url()
-            },
-            isLoading: function () {
-                var obj = this.stats;
-                for(var key in obj) {
-                    if(Object.prototype.hasOwnProperty.call(obj, key))
-                        return false;
-                }
-                return true;
-            }
-        },
-        mounted() {
-            this.refreshStats()
+const page = usePage()
 
-            this.timer = setInterval(() => {
-                this.refreshStats()
-            }, 5000)
-        },
-        methods: {
-            /**
-             * Pull a fresh queueStats prop from the server via an Inertia partial reload.
-             */
-            refreshStats() {
-                router.reload({ only: ['queueStats'] })
-            }
-        },
+const timer = ref('')
+const symbols = {
+    'running'   : '<path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>',
+    'inactive'  : '<path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path><path d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"></path>',
+    'paused'    : '<path d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>'
+}
 
-        beforeUnmount () {
-            clearInterval(this.timer)
-        }
-    }
+// Horizon stats arrive as the `queueStats` optional Inertia prop, refreshed by the
+// partial reload in refreshStats() — no client-side HTTP.
+const stats = computed(() => page.props.queueStats ?? {})
+
+const horizonUrl = computed(() => horizonIndex.url())
+
+/**
+ * Pull a fresh queueStats prop from the server via an Inertia partial reload.
+ */
+function refreshStats() {
+    router.reload({ only: ['queueStats'] })
+}
+
+onMounted(() => {
+    refreshStats()
+
+    timer.value = setInterval(() => {
+        refreshStats()
+    }, 5000)
+})
+
+onBeforeUnmount(() => {
+    clearInterval(timer.value)
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Schedules/SchedulesCreate.vue
+++ b/resources/js/Pages/Configuration/Schedules/SchedulesCreate.vue
@@ -45,7 +45,7 @@
         <span class="inline-flex rounded-md shadow-xs">
           <Link
             method="post"
-            :data="$data"
+            :data="{ expression, job }"
             preserve-state
             :href="storeUrl"
             class="inline-flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-hidden focus:border-indigo-700 focus:ring-indigo active:bg-indigo-700 transition duration-150 ease-in-out"
@@ -58,41 +58,33 @@
   </div>
 </template>
 
-<script>
-    import InputGroup from "@/Shared/InputGroup.vue"
-    import SeatPlusSelect from "@/Shared/SeatPlusSelect.vue"
-    import { Link } from '@inertiajs/vue3';
-    import AppHead from "@/Shared/AppHead.vue";
-    import SchedulesPost from "@/actions/Seatplus/Web/Http/Controllers/Configuration/Schedules/SchedulesPost";
-    export default {
-        name: "SchedulesCreate",
-        components: {AppHead, SeatPlusSelect, InputGroup, Link},
-        computed: {
-            storeUrl() {
-                return SchedulesPost.url()
-            }
-        },
-        props: {
-            cron: {
-                type: Object,
-                required: true
-            },
-            jobs: {
-                type: Array,
-                required: true
-            },
-            activeSidebarElement: {
-                type: String,
-                required: true
-            }
-        },
-        data() {
-            return {
-                expression: '',
-                job: ''
-            }
-        }
+<script setup>
+import { computed, ref } from "vue";
+import { Link } from '@inertiajs/vue3';
+import InputGroup from "@/Shared/InputGroup.vue"
+import SeatPlusSelect from "@/Shared/SeatPlusSelect.vue"
+import AppHead from "@/Shared/AppHead.vue";
+import SchedulesPost from "@/actions/Seatplus/Web/Http/Controllers/Configuration/Schedules/SchedulesPost";
+
+defineProps({
+    cron: {
+        type: Object,
+        required: true
+    },
+    jobs: {
+        type: Array,
+        required: true
+    },
+    activeSidebarElement: {
+        type: String,
+        required: true
     }
+});
+
+const expression = ref('')
+const job = ref('')
+
+const storeUrl = computed(() => SchedulesPost.url())
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Schedules/SchedulesDetails.vue
+++ b/resources/js/Pages/Configuration/Schedules/SchedulesDetails.vue
@@ -44,7 +44,7 @@
           <Link
             method="post"
             as="button"
-            :data="$data"
+            :data="{ expression, job }"
             preserve-state
             :href="storeUrl"
             class="inline-flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-hidden focus:border-indigo-700 focus:ring-indigo active:bg-indigo-700 transition duration-150 ease-in-out"
@@ -57,51 +57,42 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, nextTick, onMounted, ref } from "vue";
+import { Link } from '@inertiajs/vue3';
 import InputGroup from "@/Shared/InputGroup.vue"
 import SeatPlusSelect from "@/Shared/SeatPlusSelect.vue"
-import { Link } from '@inertiajs/vue3';
 import AppHead from "@/Shared/AppHead.vue";
 import SchedulesDelete from "@/actions/Seatplus/Web/Http/Controllers/Configuration/Schedules/SchedulesDelete";
 import SchedulesPost from "@/actions/Seatplus/Web/Http/Controllers/Configuration/Schedules/SchedulesPost";
-export default {
-    name: "SchedulesDetails",
-    components: {AppHead, SeatPlusSelect, InputGroup, Link},
-    props: {
-        schedule: {
-            type: Object,
-            required: true
-        },
-        cron: {
-            type: Object,
-            required: true
-        },
-        activeSidebarElement: {
-            type: String,
-            required: true
-        }
-    },
-    computed: {
-        deleteUrl() {
-            return SchedulesDelete.url(this.schedule.id)
-        },
-        storeUrl() {
-            return SchedulesPost.url()
-        }
-    },
-    data() {
-        return {
-            expression: '',
-            job: this.schedule.job
-        }
-    },
-    mounted() {
-        this.$nextTick(function () {
-            this.expression = this.schedule.expression
-        })
 
+const props = defineProps({
+    schedule: {
+        type: Object,
+        required: true
+    },
+    cron: {
+        type: Object,
+        required: true
+    },
+    activeSidebarElement: {
+        type: String,
+        required: true
     }
-}
+});
+
+const expression = ref('')
+const job = ref(props.schedule.job)
+
+const deleteUrl = computed(() => SchedulesDelete.url(props.schedule.id))
+
+const storeUrl = computed(() => SchedulesPost.url())
+
+onMounted(() => {
+    nextTick(function () {
+        expression.value = props.schedule.expression
+    })
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Schedules/SchedulesIndex.vue
+++ b/resources/js/Pages/Configuration/Schedules/SchedulesIndex.vue
@@ -84,39 +84,32 @@
   </Settings>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
+import { Link } from '@inertiajs/vue3';
 import Settings from "@/Pages/Configuration/Settings.vue"
 import WideListElement from "@/Shared/WideListElement.vue"
-import { Link } from '@inertiajs/vue3';
 import AppHead from "@/Shared/AppHead.vue";
 import ScheduleDetail from "@/actions/Seatplus/Web/Http/Controllers/Configuration/Schedules/ScheduleDetail";
 import SchedulesCreate from "@/actions/Seatplus/Web/Http/Controllers/Configuration/Schedules/SchedulesCreate";
-export default {
-    name: "SchedulesIndex",
-    components: {AppHead, Settings, WideListElement, Link},
-    props: {
-        schedules: {
-            type: Array,
-            required: true
-        },
-        expressions: {
-            type: Object,
-            required: true
-        }
+
+const props = defineProps({
+    schedules: {
+        type: Array,
+        required: true
     },
-    computed: {
-        inversedExpressions() {
-            return _.invert(this.expressions)
-        },
-        createUrl() {
-            return SchedulesCreate.url()
-        }
-    },
-    methods: {
-        detailsUrl(scheduleId) {
-            return ScheduleDetail.url(scheduleId)
-        }
+    expressions: {
+        type: Object,
+        required: true
     }
+});
+
+const inversedExpressions = computed(() => _.invert(props.expressions))
+
+const createUrl = computed(() => SchedulesCreate.url())
+
+function detailsUrl(scheduleId) {
+    return ScheduleDetail.url(scheduleId)
 }
 </script>
 

--- a/resources/js/Pages/Configuration/Scopes/CharacterScopes.vue
+++ b/resources/js/Pages/Configuration/Scopes/CharacterScopes.vue
@@ -14,45 +14,36 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, ref, watch } from "vue";
 import ScopeToggle from "./ScopeToggle.vue";
-export default {
-    name: "CharacterScopes",
-    components: {ScopeToggle},
-    props: {
-        scopes: {
-            type: Object,
-            required: true
-        },
-        selectedScopes: {
-            type: Array,
-            required: false,
-            default: () => []
-        }
+
+const props = defineProps({
+    scopes: {
+        type: Object,
+        required: true
     },
-    emits: ['update:selectedScopes'],
-    data() {
-        return {
-            selected: this.selectedScopes
-        }
-    },
-    computed: {
-        flavours: function () {
-            return _.map(this.scopes, (value, prop) => ({
-                text: _.capitalize(prop),
-                value: value
-            }));
-        },
-        scopesAsString() {
-            return _.toString(this.selectedScopes)
-        }
-    },
-    watch: {
-        selected(newValue) {
-            this.$emit('update:selectedScopes', newValue)
-        }
+    selectedScopes: {
+        type: Array,
+        required: false,
+        default: () => []
     }
-}
+});
+
+const emit = defineEmits(['update:selectedScopes']);
+
+const selected = ref(props.selectedScopes)
+
+const flavours = computed(() => _.map(props.scopes, (value, prop) => ({
+    text: _.capitalize(prop),
+    value: value
+})))
+
+const scopesAsString = computed(() => _.toString(props.selectedScopes))
+
+watch(selected, (newValue) => {
+    emit('update:selectedScopes', newValue)
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Scopes/CorporationScopes.vue
+++ b/resources/js/Pages/Configuration/Scopes/CorporationScopes.vue
@@ -14,77 +14,64 @@
   </div>
 </template>
 
-<script>
-import ScopeToggle from "./ScopeToggle.vue";
+<script setup>
 import {computed, ref, watch} from "vue";
-export default {
-    name: "CorporationScopes",
-    components: {ScopeToggle},
-    props: {
-        scopes: {
-            type: Object,
-            required: true
-        },
-        selectedScopes: {
-            type    : Array,
-            required: false,
-            default: () => []
-        }
+import ScopeToggle from "./ScopeToggle.vue";
+
+const props = defineProps({
+    scopes: {
+        type: Object,
+        required: true
     },
-    emits: ['update:selectedScopes'],
-    setup(props, { emit }) {
+    selectedScopes: {
+        type    : Array,
+        required: false,
+        default: () => []
+    }
+});
 
-        const selected = ref(filter())
-        const scopes= ref(_.toArray(props.scopes))
+const emit = defineEmits(['update:selectedScopes']);
 
-        function filter() {
+function filter() {
 
-            if(!props.selectedScopes.includes('esi-characters.read_corporation_roles.v1')) {
+    if(!props.selectedScopes.includes('esi-characters.read_corporation_roles.v1')) {
 
-                emit('update:selectedScopes', _.pullAll(props.selectedScopes, _.flatten(_.toArray(props.scopes))))
-            }
+        emit('update:selectedScopes', _.pullAll(props.selectedScopes, _.flatten(_.toArray(props.scopes))))
+    }
 
-            return props.selectedScopes
-        }
-
-        const hasCorporationScopesSelected = computed( () =>  {
-            return _.chain(scopes.value)
-                .toArray()
-                .flatten()
-                .intersection(selected.value)
-                .value().length > 0
-        })
-
-        watch(selected, (newValue) => {
-
-            // add corporation division if wallet or assets is selected
-            if(_.intersection(['esi-wallet.read_corporation_wallets.v1', 'esi-assets.read_corporation_assets.v1'], newValue).length > 0)
-                newValue.push('esi-corporations.read_divisions.v1')
-
-            // if any corporation scope is selected and role is not yet selected, push role scope
-            if(hasCorporationScopesSelected.value && !newValue.includes('esi-characters.read_corporation_roles.v1'))
-                newValue.push('esi-characters.read_corporation_roles.v1')
-
-            emit('update:selectedScopes', _.uniq(newValue))
-        })
-
-
-        return {
-            selected
-        }
-    },
-    computed: {
-        flavours: function () {
-            return _.map(this.scopes, (value, prop) => ({
-                text: _.capitalize(prop),
-                value: value
-            }));
-        },
-        scopesAsString() {
-            return _.toString(this.selectedScopes)
-        },
-    },
+    return props.selectedScopes
 }
+
+const selected = ref(filter())
+const scopes = ref(_.toArray(props.scopes))
+
+const hasCorporationScopesSelected = computed( () =>  {
+    return _.chain(scopes.value)
+        .toArray()
+        .flatten()
+        .intersection(selected.value)
+        .value().length > 0
+})
+
+watch(selected, (newValue) => {
+
+    // add corporation division if wallet or assets is selected
+    if(_.intersection(['esi-wallet.read_corporation_wallets.v1', 'esi-assets.read_corporation_assets.v1'], newValue).length > 0)
+        newValue.push('esi-corporations.read_divisions.v1')
+
+    // if any corporation scope is selected and role is not yet selected, push role scope
+    if(hasCorporationScopesSelected.value && !newValue.includes('esi-characters.read_corporation_roles.v1'))
+        newValue.push('esi-characters.read_corporation_roles.v1')
+
+    emit('update:selectedScopes', _.uniq(newValue))
+})
+
+const flavours = computed(() => _.map(props.scopes, (value, prop) => ({
+    text: _.capitalize(prop),
+    value: value
+})))
+
+const scopesAsString = computed(() => _.toString(props.selectedScopes))
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Scopes/OverviewScopeSettings.vue
+++ b/resources/js/Pages/Configuration/Scopes/OverviewScopeSettings.vue
@@ -111,60 +111,41 @@
   </Settings>
 </template>
 
-<script>
-    import Settings from "@/Pages/Configuration/Settings.vue"
-    import WideListElement from "@/Shared/WideListElement.vue"
-    import EveImage from "@/Shared/EveImage.vue"
-    import { Link } from '@inertiajs/vue3';
-    import AppHead from "@/Shared/AppHead.vue";
-    // SsoSettingsController@index is mapped to three route names; @/actions can't tell them
-    // apart, so use the @/routes named-route helpers.
-    import { scopes as viewGlobalScopes } from "@/routes/view/global";
-    import { settings as viewScopesSettings } from "@/routes/view/scopes";
-    import { scopes as viewCreateScopes } from "@/routes/view/create";
+<script setup>
+import { computed } from "vue";
+import { Link } from '@inertiajs/vue3';
+import Settings from "@/Pages/Configuration/Settings.vue"
+import WideListElement from "@/Shared/WideListElement.vue"
+import EveImage from "@/Shared/EveImage.vue"
+import AppHead from "@/Shared/AppHead.vue";
+// SsoSettingsController@index is mapped to three route names; @/actions can't tell them
+// apart, so use the @/routes named-route helpers.
+import { scopes as viewGlobalScopes } from "@/routes/view/global";
+import { settings as viewScopesSettings } from "@/routes/view/scopes";
+import { scopes as viewCreateScopes } from "@/routes/view/create";
 
-    export default {
-        name: "OverviewScopeSettings",
-        components: {AppHead, WideListElement, EveImage, Settings, Link},
-        props: {
-            available_scopes: {
-                type: Object,
-                required: true
-            },
-            entries: {
-                type: Array,
-                required: true
-            },
-        },
-        data() {
-            return {
-                layoutObject: {
-                    pageHeader: 'Server Settings',
-                    pageDescription: 'Scope',
-                    activeSidebarElement: 'server.settings'
-                },
-            }
-        },
-        computed: {
-            entities() {
-                return _.filter(this.entries, (entry) => entry.selectedEntity.id)
-            },
-            hasGlobalScopes() {
-                return _.size(this.entities) !== _.size(this.entries)
-            },
-            globalScopesUrl() {
-                return viewGlobalScopes.url()
-            },
-            createScopesViewUrl() {
-                return viewCreateScopes.url()
-            }
-        },
-        methods: {
-            scopesSettingsUrl(entityId) {
-                return viewScopesSettings.url(entityId)
-            }
-        },
-    }
+const props = defineProps({
+    available_scopes: {
+        type: Object,
+        required: true
+    },
+    entries: {
+        type: Array,
+        required: true
+    },
+});
+
+const entities = computed(() => _.filter(props.entries, (entry) => entry.selectedEntity.id))
+
+const hasGlobalScopes = computed(() => _.size(entities.value) !== _.size(props.entries))
+
+const globalScopesUrl = computed(() => viewGlobalScopes.url())
+
+const createScopesViewUrl = computed(() => viewCreateScopes.url())
+
+function scopesSettingsUrl(entityId) {
+    return viewScopesSettings.url(entityId)
+}
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Scopes/ScopeSettings.vue
+++ b/resources/js/Pages/Configuration/Scopes/ScopeSettings.vue
@@ -120,121 +120,89 @@
   </div>
 </template>
 
-<script>
-
+<script setup>
+import { computed, onMounted, ref } from "vue";
+import { Link, usePage } from '@inertiajs/vue3';
 import CharacterScopes from "./CharacterScopes.vue"
 import CorporationScopes from "./CorporationScopes.vue"
 import EveImage from "@/Shared/EveImage.vue"
 import EsiMultiselect from "@/Shared/Components/EsiMultiselect.vue";
 import PageHeader from "@/Shared/Layout/PageHeader.vue"
 import RadioListWithDescription from "@/Shared/Layout/RadioListWithDescription.vue";
-import { Link, router } from '@inertiajs/vue3';
 import { create as createScopes, deleteSsoScopeSetting } from "@/actions/Seatplus/Web/Http/Controllers/Configuration/SsoSettings/SsoSettingsController";
 
-export default {
-    name: "ScopeSettings",
-    components: {
-        EsiMultiselect,
-        RadioListWithDescription,
-        PageHeader, EveImage, CorporationScopes, CharacterScopes, Link},
-    props: {
-        available_scopes: {
-            type: Object,
-            required: true
-        },
-        entity: {
-            type: Object,
-            required: false,
-            default: function () {return {}}
-        },
-        options: {
-            type: Array,
-            required: true
-        }
+const props = defineProps({
+    available_scopes: {
+        type: Object,
+        required: true
     },
-    data() {
-        return {
-            selectedEntities: [],
-            selected_scopes: _.toArray(_.get(this.entity, 'selected_scopes', {})),
-            creationMode: this.$page.props.activeSidebarElement === 'view.create.scopes',
-            selectedModula: 0
-        }
+    entity: {
+        type: Object,
+        required: false,
+        default: function () {return {}}
     },
-    computed: {
-        object() {
-
-            if(_.isUndefined(this.entity.morphable))
-                return {}
-
-            const object =  {
-                name: this.entity.morphable.name,
-                id: this.entity.morphable_id
-            }
-
-            this.entity.morphable.corporation_id
-                ? object.corporation_id = this.entity.morphable.corporation_id
-                : object.alliance_id = this.entity.morphable.alliance_id
-
-            return object
-        },
-        createScopesUrl() {
-            return createScopes.url()
-        },
-        deleteScopesUrl() {
-            return deleteSsoScopeSetting.url(this.object.id)
-        },
-        type() {
-            return this.options[this.selectedModula].title
-        },
-        isGlobal() {
-            return this.options[this.selectedModula].title === 'global';
-        },
-        selectedScopesError() {
-            return _.get(this.$page, 'props.errors.selectedScopes[0]')
-        },
-        selectedEntitiesError() {
-            return _.get(this.$page, 'props.errors.selectedEntities[0]')
-        },
-        scopesAsString() {
-            return _.toString(this.selected_scopes)
-        },
-        pageTitle() {
-
-            let mode = this.creationMode ? 'Create' : 'Edit'
-
-            return `${mode} Scope Settings`
-        },
-    },
-    mounted() {
-        if (_.isUndefined(this.entity.selected_scopes)) {
-            return
-        }
-
-        this.selectedEntities = [{
-            id: this.entity.morphable_id,
-            type: this.entity.morphable_type === "Seatplus\\Eveapi\\Models\\Corporation\\CorporationInfo" ? 'corporation' : 'alliance'
-        }]
-    },
-    created: function () {
-        this.selectedModula = this.creationMode ? 0 : _.findIndex(this.options, {'title': this.entity?.type});
-    },
-    methods: {
-        post() {
-
-            const url = createScopes.url();
-
-            const data = {
-                selectedScopes: this.selectedScopes,
-                selectedEntities: this.selectedEntities != null ? this.selectedEntities : {
-                    id: 'id',
-                    category: 'category',
-                }
-            }
-
-            return router.post(url, data)
-        }
+    options: {
+        type: Array,
+        required: true
     }
-}
+});
+
+const page = usePage()
+
+const selectedEntities = ref([])
+const selected_scopes = ref(_.toArray(_.get(props.entity, 'selected_scopes', {})))
+const creationMode = page.props.activeSidebarElement === 'view.create.scopes'
+const selectedModula = ref(0)
+
+const object = computed(() => {
+
+    if(_.isUndefined(props.entity.morphable))
+        return {}
+
+    const object =  {
+        name: props.entity.morphable.name,
+        id: props.entity.morphable_id
+    }
+
+    props.entity.morphable.corporation_id
+        ? object.corporation_id = props.entity.morphable.corporation_id
+        : object.alliance_id = props.entity.morphable.alliance_id
+
+    return object
+})
+
+const createScopesUrl = computed(() => createScopes.url())
+
+const deleteScopesUrl = computed(() => deleteSsoScopeSetting.url(object.value.id))
+
+const type = computed(() => props.options[selectedModula.value].title)
+
+const isGlobal = computed(() => props.options[selectedModula.value].title === 'global')
+
+const selectedScopesError = computed(() => _.get(page, 'props.errors.selectedScopes[0]'))
+
+const selectedEntitiesError = computed(() => _.get(page, 'props.errors.selectedEntities[0]'))
+
+const scopesAsString = computed(() => _.toString(selected_scopes.value))
+
+const pageTitle = computed(() => {
+    let mode = creationMode ? 'Create' : 'Edit'
+
+    return `${mode} Scope Settings`
+})
+
+selectedModula.value = creationMode ? 0 : _.findIndex(props.options, {'title': props.entity?.type});
+
+onMounted(() => {
+    if (_.isUndefined(props.entity.selected_scopes)) {
+        return
+    }
+
+    selectedEntities.value = [{
+        id: props.entity.morphable_id,
+        type: props.entity.morphable_type === "Seatplus\\Eveapi\\Models\\Corporation\\CorporationInfo" ? 'corporation' : 'alliance'
+    }]
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Scopes/ScopeToggle.vue
+++ b/resources/js/Pages/Configuration/Scopes/ScopeToggle.vue
@@ -23,61 +23,43 @@
   </SwitchGroup>
 </template>
 
-<script>
+<script setup>
 import { ref, watch} from 'vue'
 import { Switch, SwitchGroup, SwitchLabel } from '@headlessui/vue'
 
-export default {
-    name: "ScopeToggle",
-    components: {
-        Switch,
-        SwitchGroup,
-        SwitchLabel,
+const props = defineProps({
+    scope: {
+        type: Object,
+        required: true
     },
-    props: {
-        scope: {
-            type: Object,
-            required: true
-        },
-        selected: {
-            type: Array,
-            required: false,
-            default: () => []
-        }
-    },
-    emits: ['update:selected'],
-    setup(props, context) {
-
-        const intersection = _.intersection(props.selected, props.scope.value)
-
-        const enabled = ref(_.isEqual([...props.scope.value].sort(), intersection.sort()))
-        const selected = ref(props.selected)
-
-        watch(enabled,() => {
-
-            if(enabled.value) {
-
-                context.emit('update:selected', _.uniq([...selected.value, ...props.scope.value]))
-
-            } else {
-
-                // 1. remove scope props
-                selected.value = selected.value.filter( (el) => !props.scope.value.includes(el))
-
-                context.emit('update:selected', selected.value)
-            }
-        })
-
-        return {
-            enabled,
-        }
-    },
-    methods: {
-        test() {
-            console.log('test')
-        }
+    selected: {
+        type: Array,
+        required: false,
+        default: () => []
     }
-}
+});
+
+const emit = defineEmits(['update:selected']);
+
+const intersection = _.intersection(props.selected, props.scope.value)
+
+const enabled = ref(_.isEqual([...props.scope.value].sort(), intersection.sort()))
+const selected = ref(props.selected)
+
+watch(enabled,() => {
+
+    if(enabled.value) {
+
+        emit('update:selected', _.uniq([...selected.value, ...props.scope.value]))
+
+    } else {
+
+        // 1. remove scope props
+        selected.value = selected.value.filter( (el) => !props.scope.value.includes(el))
+
+        emit('update:selected', selected.value)
+    }
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/Settings.vue
+++ b/resources/js/Pages/Configuration/Settings.vue
@@ -62,61 +62,53 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, onMounted, ref, watch } from "vue";
+import { router, usePage } from '@inertiajs/vue3'
 import Commands from "@/Pages/Configuration/Commands.vue"
 import HorizonStats from "./HorizonStats.vue"
-import { router } from '@inertiajs/vue3'
 
-export default {
-    name: "Settings",
-    components: {HorizonStats, Commands},
-    data() {
-        return {
-            pageTitle: 'Server Settings',
-            currentRoute: '',
-        }
-    },
-    computed: {
-        // Nav tabs are static config, shared eagerly by HandleInertiaRequests as page chrome —
-        // read them off the page props rather than fetching them after mount.
-        navTabs() {
-            return this.$page.props.settingsNavigation ?? []
-        }
-    },
-    watch: {
-        currentRoute(currentRoute) {
-            if(this.isActive(currentRoute))
-                return
+const page = usePage()
 
-            this.visitRoute(currentRoute)
-        }
-    },
-    mounted() {
-        const active = this.navTabs.find(navTab => this.isActive(navTab.route))
-        if (active)
-            this.currentRoute = active.route
-    },
-    methods: {
-        isActive(name) {
-            // activeSidebarElement is the current route name, shared by HandleInertiaRequests.
-            return this.$page.props.activeSidebarElement === name;
-        },
-        getRoute(name) {
-            return this.navTabs.find(navTab => navTab.route === name)?.url
-        },
-        visitRoute(name) {
+const currentRoute = ref('')
 
-            const url = this.getRoute(name)
+// Nav tabs are static config, shared eagerly by HandleInertiaRequests as page chrome —
+// read them off the page props rather than fetching them after mount.
+const navTabs = computed(() => page.props.settingsNavigation ?? [])
 
-            if (!url)
-                return
-
-            router.visit(url,{
-                method: 'get',
-                preserveScroll: true
-            })
-        }
-    }
+function isActive(name) {
+    // activeSidebarElement is the current route name, shared by HandleInertiaRequests.
+    return page.props.activeSidebarElement === name;
 }
+
+function getRoute(name) {
+    return navTabs.value.find(navTab => navTab.route === name)?.url
+}
+
+function visitRoute(name) {
+
+    const url = getRoute(name)
+
+    if (!url)
+        return
+
+    router.visit(url,{
+        method: 'get',
+        preserveScroll: true
+    })
+}
+
+watch(currentRoute, (value) => {
+    if(isActive(value))
+        return
+
+    visitRoute(value)
+})
+
+onMounted(() => {
+    const active = navTabs.value.find(navTab => isActive(navTab.route))
+    if (active)
+        currentRoute.value = active.route
+})
 </script>
 

--- a/resources/js/Pages/Configuration/UserList.vue
+++ b/resources/js/Pages/Configuration/UserList.vue
@@ -48,62 +48,47 @@
   </Settings>
 </template>
 
-<script>
-    import Pagination from "@/Shared/Pagination.vue"
-    import { router } from '@inertiajs/vue3'
-    import Settings from "./Settings.vue"
-    import UserListElement from "./UserListElement.vue";
-    import AppHead from "@/Shared/AppHead.vue";
+<script setup>
+import { ref, watch } from "vue";
+import { router } from '@inertiajs/vue3'
+import Pagination from "@/Shared/Pagination.vue"
+import Settings from "./Settings.vue"
+import UserListElement from "./UserListElement.vue";
+import AppHead from "@/Shared/AppHead.vue";
 
-    export default {
-        name: "UserList",
-        components: {AppHead, UserListElement, Settings, Pagination},
-        props: {
-            users: {
-                type: Object,
-                required: true
-            }
-        },
-        data() {
-            return {
-                search: this.getSearchParams(),
-            }
-        },
-        watch: {
-            search() {
-
-                // Rebuild the current URL's query string (replacing Ziggy's route().params +
-                // route(current)) and re-visit the same page with the updated search/page.
-                const params = new URLSearchParams(window.location.search)
-
-                if(params.has('search_param') && this.search === '')
-                    params.delete('search_param')
-
-                if(this.search)
-                    params.set('search_param', this.search)
-
-                params.set('page', '1')
-
-                router.visit(`${window.location.pathname}?${params.toString()}`, {
-                    preserveScroll: true,
-                    preserveState: true,
-                    only: ['users'],
-                })
-            }
-        },
-        methods: {
-            characterWithoutMain(user) {
-
-                return _.reject(user.characters, function (character) {
-                    const {mainCharacter} = user
-                    return _.isEqual(character.character_id, mainCharacter.character_id)
-                })
-            },
-            getSearchParams() {
-                return new URLSearchParams(window.location.search).get('search_param') ?? ''
-            }
-        }
+defineProps({
+    users: {
+        type: Object,
+        required: true
     }
+});
+
+function getSearchParams() {
+    return new URLSearchParams(window.location.search).get('search_param') ?? ''
+}
+
+const search = ref(getSearchParams())
+
+watch(search, () => {
+
+    // Rebuild the current URL's query string (replacing Ziggy's route().params +
+    // route(current)) and re-visit the same page with the updated search/page.
+    const params = new URLSearchParams(window.location.search)
+
+    if(params.has('search_param') && search.value === '')
+        params.delete('search_param')
+
+    if(search.value)
+        params.set('search_param', search.value)
+
+    params.set('page', '1')
+
+    router.visit(`${window.location.pathname}?${params.toString()}`, {
+        preserveScroll: true,
+        preserveState: true,
+        only: ['users'],
+    })
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/UserListElement.vue
+++ b/resources/js/Pages/Configuration/UserListElement.vue
@@ -33,35 +33,28 @@
   </li>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import { Link } from '@inertiajs/vue3';
 import { impersonate } from "@/actions/Seatplus/Web/Http/Controllers/Configuration/SeatPlusController";
-export default {
-    name: "UserListElement",
-    components: {EntityBlock, Link},
-    props: {
-        user: {
-            type: Object,
-            required: true
-        },
-        index: {
-            type: Number,
-            required: true
-        }
+
+const props = defineProps({
+    user: {
+        type: Object,
+        required: true
     },
-    computed: {
-        impersonateUrl() {
-            return impersonate.url(this.user.id)
-        },
-        characters() {
-            return _.reject(this.user.characters, (character)  => _.isEqual(character.character_id, this.user.mainCharacter.character_id))
-        },
-        characterNames() {
-            return _.join(_.map(this.characters, (character) => character.name), ', ')
-        }
+    index: {
+        type: Number,
+        required: true
     }
-}
+});
+
+const impersonateUrl = computed(() => impersonate.url(props.user.id))
+
+const characters = computed(() => _.reject(props.user.characters, (character) => _.isEqual(character.character_id, props.user.mainCharacter.character_id)))
+
+const characterNames = computed(() => _.join(_.map(characters.value, (character) => character.name), ', '))
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Configuration/UserSettings.vue
+++ b/resources/js/Pages/Configuration/UserSettings.vue
@@ -149,82 +149,68 @@
   </div>
 </template>
 
-<script>
-    import PageHeader from "@/Shared/Layout/PageHeader.vue";
-    import SelectComponent from "@/Shared/Components/SelectComponent.vue";
-    import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
-    import {computed, ref, watch} from "vue";
-    import { useForm, usePage, Link } from "@inertiajs/vue3";
-    import { localeName } from "@/i18n/localeName";
-    import LogoutController from "@/actions/Seatplus/Web/Http/Controllers/Auth/LogoutController";
-    import { update as postLocale } from "@/actions/Seatplus/Web/Http/Controllers/LocaleController";
-    import SwitchMainCharacterController from "@/actions/Seatplus/Auth/Http/Controllers/SwitchMainCharacterController";
-    
-    export default {
-        name: "UserSettings",
-        components: {EntityBlock, SelectComponent, PageHeader, Link},
-        props: {
-            user: {
-                type: Object,
-                required: true
-            }
-        },
-        setup(props) {
-            const selected = ref({
-                character_id: _.get(props.user, 'data.mainCharacter.character_id'),
-                name: _.get(props.user, 'data.mainCharacter.name'),
-            })
+<script setup>
+import {computed, ref, watch} from "vue";
+import { useForm, usePage, Link } from "@inertiajs/vue3";
+import PageHeader from "@/Shared/Layout/PageHeader.vue";
+import SelectComponent from "@/Shared/Components/SelectComponent.vue";
+import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
+import { localeName } from "@/i18n/localeName";
+import LogoutController from "@/actions/Seatplus/Web/Http/Controllers/Auth/LogoutController";
+import { update as postLocale } from "@/actions/Seatplus/Web/Http/Controllers/LocaleController";
+import SwitchMainCharacterController from "@/actions/Seatplus/Auth/Http/Controllers/SwitchMainCharacterController";
 
-            const form = useForm({
-                character_id: _.get(props.user, 'data.mainCharacter.character_id')
-            })
-
-            const options = computed(() => {
-                let characters = _.get(props.user, 'data.characters', [])
-
-                return _.map(characters, character => {
-                    return {
-                        character_id: character.character_id,
-                        name: character.name
-                    }
-                })
-            })
-
-            watch(selected, () =>  {
-                // The route is PUT main-character/switch/{new_character_id}; the id goes in the
-                // path (the controller ignores the body), so build the URL with the selected id.
-                form.put(SwitchMainCharacterController.url({ new_character_id: selected.value.character_id }))
-            })
-
-            const page = usePage()
-
-            const locales = computed(() => _.get(page.props, 'locales', {}))
-
-            const localeForm = useForm({
-                locale: _.get(page.props, 'locale'),
-            })
-
-            // `translations` is a reactive Inertia prop now — the redirect back re-renders
-            // in the newly-selected language without a full page reload.
-            const updateLocale = () => {
-                localeForm.post(postLocale.url(), {
-                    preserveScroll: true,
-                })
-            }
-
-            return {
-                selected,
-                pageTitle: 'User Settings',
-                form,
-                options,
-                locales,
-                localeForm,
-                updateLocale,
-                localeName,
-                logoutUrl: LogoutController.url()
-            }
-        }
+const props = defineProps({
+    user: {
+        type: Object,
+        required: true
     }
+});
+
+const selected = ref({
+    character_id: _.get(props.user, 'data.mainCharacter.character_id'),
+    name: _.get(props.user, 'data.mainCharacter.name'),
+})
+
+const form = useForm({
+    character_id: _.get(props.user, 'data.mainCharacter.character_id')
+})
+
+const options = computed(() => {
+    let characters = _.get(props.user, 'data.characters', [])
+
+    return _.map(characters, character => {
+        return {
+            character_id: character.character_id,
+            name: character.name
+        }
+    })
+})
+
+watch(selected, () =>  {
+    // The route is PUT main-character/switch/{new_character_id}; the id goes in the
+    // path (the controller ignores the body), so build the URL with the selected id.
+    form.put(SwitchMainCharacterController.url({ new_character_id: selected.value.character_id }))
+})
+
+const page = usePage()
+
+const locales = computed(() => _.get(page.props, 'locales', {}))
+
+const localeForm = useForm({
+    locale: _.get(page.props, 'locale'),
+})
+
+const pageTitle = 'User Settings'
+const logoutUrl = LogoutController.url()
+
+// `translations` is a reactive Inertia prop now — the redirect back re-renders
+// in the newly-selected language without a full page reload.
+const updateLocale = () => {
+    localeForm.post(postLocale.url(), {
+        preserveScroll: true,
+    })
+}
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Corporation/MemberTracking/MemberTracking.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTracking.vue
@@ -19,36 +19,25 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import PageHeader from "@/Shared/Layout/PageHeader.vue"
 import MemberTrackingComponent from "./MemberTrackingComponent.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 
-export default {
-    name: "MemberTracking",
-    components: {
-        EntitySelectionButton,
-      RequiredScopesWarning,
-      DispatchUpdateButton,
-      MemberTrackingComponent, PageHeader},
-    props: {
-        corporations: {
-            type: Array,
-            required: true
-        },
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        }
+defineProps({
+    corporations: {
+        type: Array,
+        required: true
     },
-  data() {
-      return {
-        pageTitle: 'Corporation Member Tracking'
-      }
-  }
-}
+    dispatchTransferObject: {
+        required: true,
+        type: Object
+    }
+});
+
+const pageTitle = 'Corporation Member Tracking'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Corporation/MemberTracking/MemberTrackingComponent.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTrackingComponent.vue
@@ -90,42 +90,30 @@
   </CardWithHeader>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
+import { InfiniteScroll, usePage } from "@inertiajs/vue3";
 import CardWithHeader from "@/Shared/Layout/Cards/CardWithHeader.vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import MemberTrackingListElement from "./MemberTrackingListElement.vue";
 import MemberTrackingListElementForSmallDevices from "./MemberTrackingListElementForSmallDevices.vue";
-import { InfiniteScroll } from "@inertiajs/vue3";
 
-export default {
-    name: "MemberTrackingComponent",
-    components: {
-        InfiniteScroll,
-        MemberTrackingListElementForSmallDevices,
-        MemberTrackingListElement,
-        EntityBlock,
-        CardWithHeader
+const props = defineProps({
+    corporation: {
+        required: true,
+        type: Object
     },
-    props: {
-        corporation: {
-            required: true,
-            type: Object
-        },
-    },
-    computed: {
-        // The members list is delivered as a page scroll prop keyed per corporation
-        // (MemberTrackingController::index) and consumed by <InfiniteScroll :data="scrollKey">.
-        scrollKey() {
-            return `members_${this.corporation.corporation_id}`
-        },
-        scrollBodyId() {
-            return `members-body-${this.corporation.corporation_id}`
-        },
-        members() {
-            return this.$page.props[this.scrollKey]?.data ?? []
-        }
-    }
-}
+});
+
+const page = usePage();
+
+// The members list is delivered as a page scroll prop keyed per corporation
+// (MemberTrackingController::index) and consumed by <InfiniteScroll :data="scrollKey">.
+const scrollKey = computed(() => `members_${props.corporation.corporation_id}`)
+
+const scrollBodyId = computed(() => `members-body-${props.corporation.corporation_id}`)
+
+const members = computed(() => page.props[scrollKey.value]?.data ?? [])
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElement.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElement.vue
@@ -46,29 +46,24 @@
   </li>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import Time from "@/Shared/Time.vue";
-export default {
-    name: "MemberTrackingListElement",
-    components: {Time, EntityByIdBlock, EntityBlock},
-    props: {
-        member: {
-            required: true,
-            type: Object
-        },
-        even: {
-            required: true,
-            type: Number
-        }
+
+const props = defineProps({
+    member: {
+        required: true,
+        type: Object
     },
-    computed: {
-        locationName() {
-            return _.get(this.member, 'location.name', 'Unknown Location')
-        }
+    even: {
+        required: true,
+        type: Number
     }
-}
+});
+
+const locationName = computed(() => _.get(props.member, 'location.name', 'Unknown Location'))
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElementForSmallDevices.vue
+++ b/resources/js/Pages/Corporation/MemberTracking/MemberTrackingListElementForSmallDevices.vue
@@ -87,32 +87,21 @@
   </li>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 import EveImage from "@/Shared/EveImage.vue";
 import Time from "@/Shared/Time.vue";
 
-export default {
-    name: "MemberTrackingListElementForSmallDevices",
-    components: {Time, EveImage, EntityByIdBlock, EntityBlock},
-    props: {
-        member: {
-            required: true,
-            type: Object
-        }
-    },
-    computed: {
-        locationName() {
-            return _.get(this.member, 'location.name', 'Unknown Location')
-        }
-    },
-    methods: {
-        has(string) {
-            return _.has(this.member, string)
-        }
+const props = defineProps({
+    member: {
+        required: true,
+        type: Object
     }
-}
+});
+
+const locationName = computed(() => _.get(props.member, 'location.name', 'Unknown Location'))
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Corporation/Wallets/Wallet.vue
+++ b/resources/js/Pages/Corporation/Wallets/Wallet.vue
@@ -20,32 +20,25 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import RequiredScopesWarning from "@/Shared/SidebarLayout/RequiredScopesWarning.vue";
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import DispatchUpdateButton from "@/Shared/Components/SlideOver/DispatchUpdateButton.vue";
 import WalletComponent from "@/Shared/Components/Wallet/WalletComponent.vue";
 import EntitySelectionButton from "@/Shared/Components/SlideOver/EntitySelectionButton.vue";
 
-export default {
-    name: "Wallet",
-    components: {EntitySelectionButton, WalletComponent, DispatchUpdateButton, PageHeader, RequiredScopesWarning},
-    props: {
-        corporationDivisions: {
-            type: Array,
-            required: true
-        },
-        dispatchTransferObject: {
-            required: true,
-            type: Object
-        }
+defineProps({
+    corporationDivisions: {
+        type: Array,
+        required: true
     },
-    data() {
-        return {
-            pageTitle: 'Corporation Wallets'
-        }
+    dispatchTransferObject: {
+        required: true,
+        type: Object
     }
-}
+});
+
+const pageTitle = 'Corporation Wallets'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Dashboard/CharacterApplication.vue
+++ b/resources/js/Pages/Dashboard/CharacterApplication.vue
@@ -46,71 +46,57 @@
   </ul>
 </template>
 
-<script>
-import EveImage from "@/Shared/EveImage.vue"
+<script setup>
 import {computed, ref} from "vue";
 import { router, usePage } from '@inertiajs/vue3'
+import EveImage from "@/Shared/EveImage.vue"
 import {UserPlusIcon, UserMinusIcon} from "@heroicons/vue/20/solid";
 import { apply as postApplication, pullCharacterApplication } from "@/actions/Seatplus/Web/Http/Controllers/Recruitment/ApplicationsController";
 
-export default {
-    name: "CharacterApplication",
-    components: {EveImage, UserPlusIcon, UserMinusIcon},
-    props: {
-        enlistment: {
-            type: Object,
-            required: true
-        },
-        applicationResults: {
-            type: Array,
-            required: true
-        }
+const props = defineProps({
+    enlistment: {
+        type: Object,
+        required: true
     },
-    setup(props) {
-
-        const applications = ref(props.applicationResults)
-
-        const ownedCharacters = computed(() => usePage().props.user.data.characters)
-        const applicants = computed(() => {
-
-            if(!hasApplications.value || props.enlistment.type !== 'character')
-                return []
-
-            return _.map(applications.value, (application) => _.get(application, 'applicationable')) //applicationResults.results.value
-
-        })
-        const hasApplications = computed(() =>  !!applications.value) //applicationResults.results.value
-        
-        const hasApplied = (character_id) =>  _.findIndex(applicants.value, {character_id: character_id}) > -1
-
-        const apply = (character_id) => router.post(postApplication.url(), {
-            corporation_id: props.enlistment.corporation_id,
-            character_id: character_id
-        }, {
-            onSuccess: () => applications.value.push({
-                applicationable: {
-                    character_id: character_id
-                }
-            }),
-            preserveState: true
-        })
-
-        const remove = (character_id) => router.delete(pullCharacterApplication.url(character_id), {
-            preserveState: true,
-            onSuccess: () => _.remove(applications.value, function (application) {
-                return _.isEqual(application.applicationable.character_id, character_id)
-            })
-        })
-
-        
-        return {
-            hasApplied,
-            ownedCharacters,
-            apply,
-            remove
-        }
+    applicationResults: {
+        type: Array,
+        required: true
     }
-}
+});
+
+const applications = ref(props.applicationResults)
+
+const ownedCharacters = computed(() => usePage().props.user.data.characters)
+const applicants = computed(() => {
+
+    if(!hasApplications.value || props.enlistment.type !== 'character')
+        return []
+
+    return _.map(applications.value, (application) => _.get(application, 'applicationable')) //applicationResults.results.value
+
+})
+const hasApplications = computed(() =>  !!applications.value) //applicationResults.results.value
+
+const hasApplied = (character_id) =>  _.findIndex(applicants.value, {character_id: character_id}) > -1
+
+const apply = (character_id) => router.post(postApplication.url(), {
+    corporation_id: props.enlistment.corporation_id,
+    character_id: character_id
+}, {
+    onSuccess: () => applications.value.push({
+        applicationable: {
+            character_id: character_id
+        }
+    }),
+    preserveState: true
+})
+
+const remove = (character_id) => router.delete(pullCharacterApplication.url(character_id), {
+    preserveState: true,
+    onSuccess: () => _.remove(applications.value, function (application) {
+        return _.isEqual(application.applicationable.character_id, character_id)
+    })
+})
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Dashboard/Characters.vue
+++ b/resources/js/Pages/Dashboard/Characters.vue
@@ -70,35 +70,26 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
 import LeftAligned from "@/Shared/Layout/DataDisplay/LeftAligned.vue";
 import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import LeftAlignedData from "@/Shared/Layout/DataDisplay/LeftAlignedData.vue";
 import Time from "@/Shared/Time.vue";
 import RedirectSSOController from "@/actions/Seatplus/Auth/Http/Controllers/Auth/RedirectSSOController";
-export default {
-    name: "Characters",
-    components: {Time, LeftAlignedData, EntityBlock, LeftAligned},
-    props: {
-        characters: {
-            type: Array,
-            required: true
-        },
-        enlistments: {
-            type: Array,
-            default: () => []
-        }
-    },
-    computed: {
-        ssoUrl() {
-            return RedirectSSOController.url()
-        },
-        hasOpenEnlistments() {
-            return !_.isEmpty(this.enlistments)
-        }
-    }
 
-}
+defineProps({
+    characters: {
+        type: Array,
+        required: true
+    },
+    enlistments: {
+        type: Array,
+        default: () => []
+    }
+});
+
+const ssoUrl = computed(() => RedirectSSOController.url())
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Dashboard/Enlistment.vue
+++ b/resources/js/Pages/Dashboard/Enlistment.vue
@@ -78,9 +78,9 @@
   </teleport>
 </template>
 
-<script>
-import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
+<script setup>
 import {computed, ref} from "vue";
+import EntityBlock from "@/Shared/Layout/Eve/EntityBlock.vue";
 import ModalWithFooter from "@/Shared/Modals/ModalWithFooter.vue";
 import EveImage from "@/Shared/EveImage.vue";
 import CharacterApplication from "./CharacterApplication.vue";
@@ -88,31 +88,21 @@ import {UserPlusIcon, UserMinusIcon} from "@heroicons/vue/20/solid";
 import { Link } from '@inertiajs/vue3';
 import { apply, pullUserApplication } from "@/actions/Seatplus/Web/Http/Controllers/Recruitment/ApplicationsController";
 
-export default {
-    name: "Enlistment",
-    components: {CharacterApplication, EveImage, ModalWithFooter, EntityBlock, UserPlusIcon, UserMinusIcon, Link},
-    props: {
-        enlistment: {
-            type: Object,
-            required: true
-        }
-    },
-    setup(props) {
-
-        const openModal = ref(false)
-
-        // The server attaches the user's open applications for this enlistment's
-        // corporation (OnboardingController), so no client-side fetch is needed.
-        const hasApplications = computed(() => !_.isEmpty(props.enlistment.applications))
-
-        return {
-            hasApplications,
-            openModal,
-            postApplicationUrl: apply.url(),
-            deleteUserApplicationUrl: pullUserApplication.url(),
-        }
+const props = defineProps({
+    enlistment: {
+        type: Object,
+        required: true
     }
-}
+});
+
+const openModal = ref(false)
+
+// The server attaches the user's open applications for this enlistment's
+// corporation (OnboardingController), so no client-side fetch is needed.
+const hasApplications = computed(() => !_.isEmpty(props.enlistment.applications))
+
+const postApplicationUrl = apply.url()
+const deleteUserApplicationUrl = pullUserApplication.url()
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Dashboard/Index.vue
+++ b/resources/js/Pages/Dashboard/Index.vue
@@ -11,26 +11,18 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import PageHeader from "@/Shared/Layout/PageHeader.vue"
 import Characters from "./Characters.vue"
 
-export default {
-    name: "Index",
-    components: {Characters, PageHeader},
-    props: {
-        characters: {
-            type: Array,
-            default: () => []
-        },
+defineProps({
+    characters: {
+        type: Array,
+        default: () => []
     },
-    setup() {
+});
 
-        return {
-            pageTitle: 'Home',
-        }
-    },
-}
+const pageTitle = 'Home'
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Error.vue
+++ b/resources/js/Pages/Error.vue
@@ -63,41 +63,38 @@
 </template>
 
 <script>
+export default {
+    layout: null,
+}
+</script>
+
+<script setup>
+import { computed } from "vue";
 import { Link } from '@inertiajs/vue3';
 import { home } from "@/actions/Seatplus/Web/Http/Controllers/HomeController";
 
-export default {
-    name: "Error",
-    components: { Link },
-    layout: null,
-    props: {
-        status: {
-            type: Number,
-            required: true
-        }
-    },
-    computed: {
-        homeUrl() {
-            return home.url()
-        },
-        title() {
-            return {
-                503: 'Service Unavailable',
-                500: 'Server Error',
-                404: 'Page Not Found',
-                403: 'Forbidden',
-            }[this.status]
-        },
-        description() {
-            return {
-                503: 'Sorry, we are doing some maintenance. Please check back soon.',
-                500: 'Whoops, something went wrong on our servers.',
-                404: 'Sorry, the page you are looking for could not be found.',
-                403: 'Sorry, you are forbidden from accessing this page.',
-            }[this.status]
-        },
+const props = defineProps({
+    status: {
+        type: Number,
+        required: true
     }
-}
+});
+
+const homeUrl = computed(() => home.url())
+
+const title = computed(() => ({
+    503: 'Service Unavailable',
+    500: 'Server Error',
+    404: 'Page Not Found',
+    403: 'Forbidden',
+}[props.status]))
+
+const description = computed(() => ({
+    503: 'Sorry, we are doing some maintenance. Please check back soon.',
+    500: 'Whoops, something went wrong on our servers.',
+    404: 'Sorry, the page you are looking for could not be found.',
+    403: 'Sorry, you are forbidden from accessing this page.',
+}[props.status]))
 </script>
 
 <style scoped>

--- a/resources/js/Pages/Recruitment/Review/Application.vue
+++ b/resources/js/Pages/Recruitment/Review/Application.vue
@@ -162,68 +162,51 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, reactive } from "vue";
+import {router} from "@inertiajs/vue3";
 import PageHeader from "@/Shared/Layout/PageHeader.vue";
 import HeaderButton from "@/Shared/Layout/HeaderButton.vue";
 import TabComponent from "@/Shared/Components/CharacterInspection/TabComponent.vue";
 import {IdentificationIcon} from '@heroicons/vue/24/outline'
 import UpdateCharacterComponent from "@/Shared/Components/CharacterInspection/UpdateCharacterComponent.vue";
-import {router} from "@inertiajs/vue3";
 import ImpersonateRecruit from "@/actions/Seatplus/Web/Http/Controllers/Recruitment/ImpersonateRecruit";
 import { reviewApplication } from "@/actions/Seatplus/Web/Http/Controllers/Recruitment/ApplicationsController";
 
-export default {
-    name: "Application",
-    components: {
-        UpdateCharacterComponent,
-        TabComponent,
-        HeaderButton,
-        PageHeader,
-        IdentificationIcon
+const props = defineProps({
+    recruit: {
+        required: true,
+        type: Object
     },
-    props: {
-        recruit: {
-            required: true,
-            type: Object
-        },
-        application: {
-            required: true,
-            type: Object
-        },
-        watchlist: {
-            required: true,
-            type: Object
-        },
-        activeSidebarElement: {
-            required: true,
-            type: String
-        }
+    application: {
+        required: true,
+        type: Object
     },
-    data() {
-        return {
-            pageTitle: 'Application',
-            form: {
-                decision: null,
-                explanation: null
-            }
-        }
+    watchlist: {
+        required: true,
+        type: Object
     },
-    computed: {
-        characters() {
-            return _.map(this.recruit.characters, (character) => character.name ).join(', ')
-        },
-        canImpersonate() {
-            return this.recruit.id && this.application.status === 'open'
-        }
-    },
-    methods: {
-        impersonate() {
-            return router.visit(ImpersonateRecruit.url(this.application.id))
-        },
-        submit() {
-            return router.post(reviewApplication.url(this.application.id), this.form);
-        }
+    activeSidebarElement: {
+        required: true,
+        type: String
     }
+});
+
+const form = reactive({
+    decision: null,
+    explanation: null
+})
+
+const characters = computed(() => _.map(props.recruit.characters, (character) => character.name).join(', '))
+
+const canImpersonate = computed(() => props.recruit.id && props.application.status === 'open')
+
+function impersonate() {
+    return router.visit(ImpersonateRecruit.url(props.application.id))
+}
+
+function submit() {
+    return router.post(reviewApplication.url(props.application.id), form);
 }
 </script>
 


### PR DESCRIPTION
## What

Phase 3 of migrating the web package's Options API Vue SFCs to **`<script setup>`**. This converts **all 35 remaining `Pages/*` files** — auth, dashboard, character (assets/contacts/contracts/mail/skill/wallet/item-details), corporation (member-tracking, wallets), recruitment review, and the configuration/scopes screens.

## Base / stacking

Cut from `5.x`. Files are **disjoint** from #1624 (phase 1) and #1625 (phase 2), so all three target `5.x` independently and merge without conflict. After this, only **Phase 4** remains (~16 `Shared/Layout` + 3 `Shared/Modals` + Sidebar/SlideOver).

## Scope / guarantees

- **Pure style/API migration** — no behaviour change; `route()`/`axios` were already removed on 5.x.
- **ESLint: 0 errors**; warnings strictly *fewer* than the originals (36 → 15, none introduced — the remainder are pre-existing prop-casing / template-shadow / `v-html` / hyphenation style warnings).

## Conversion notes

- **Page `layout`** → companion plain `<script>` block (`export default { layout: … }`) beside `<script setup>`, per house convention (`EnableEsiSearch`, `Onboarding/Index`). The legacy `layout: (h, page) => h(EmptyLayout, …)` render form is simplified to the component form `layout: EmptyLayout`.
- `<script setup>` has no `$data`, so `SchedulesCreate`/`SchedulesDetails` bind `<Link>` data explicitly (`:data="{ expression, job }"`).
- `this.$page` → `usePage()`; `this.$nextTick` → `nextTick`; `emits` + `this.$emit` → `defineEmits`; `data()`/`setup()` flattened. Template `$trans`/`$page` are **global properties** — left unchanged.
- Dead, unreferenced members removed (`isLoading`, `characterWithoutMain`, `has`, `post`, `test`, stray `pageTitle`/`layoutObject`) to satisfy `no-unused-vars`.
- lodash `_` stays a **global** (never imported).

## Verification

- [x] `npm run lint` (ESLint) — 0 errors, no new warnings.
- [ ] Browser tests (`tests/Browser/`) — "Browser (vs core)" job / host. Surfaces: login, dashboard, all character pages, corp member-tracking & wallets, configuration/scopes/schedules/user-list, recruitment review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)