### PR TITLE
refactor(js): migrate final 16 Shared/Layout + Modals to <script setup> (phase 4)

### DIFF
--- a/resources/js/Shared/InputGroup.vue
+++ b/resources/js/Shared/InputGroup.vue
@@ -8,28 +8,17 @@
   </div>
 </template>
 
-<script>
-  export default {
-      name: "InputGroup",
-      props: {
-          for: {
-              type: String,
-              required: true
-          },
-          label: {
-              type: String,
-              required: true
-          }
-      },
-      data() {
-          return {
-              error: ''
-          }
-      },
-      mounted() {
-
-      }
-  }
+<script setup>
+defineProps({
+    for: {
+        type: String,
+        required: true
+    },
+    label: {
+        type: String,
+        required: true
+    }
+});
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/Button.vue
+++ b/resources/js/Shared/Layout/Button.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="isInertiaButton ? 'Link': 'div'"
+    :is="isInertiaButton ? Link : 'div'"
     as="button"
     :href="href"
     :method="method"
@@ -13,49 +13,47 @@
   </component>
 </template>
 
-<script>
+<script setup>
 import { Link } from '@inertiajs/vue3';
-export default {
-    name: "Button",
-    components: {Link},
-    props: {
-        buttonSize: {
-            required: false,
-            default: 'medium',
-            type: String,
-            validator: size => [
-                'xs',
-                'small',
-                'medium',
-                'large',
-            ].includes(size)
-        },
-        href: {
-            required: false,
-            default: '',
-            type: String
-        },
-        method: {
-            required: false,
-            default: 'get',
-            type: String,
-            validator: method => [
-                'get',
-                'post',
-                'delete'
-            ].includes(method)
-        },
-        data: {
-            required: false,
-            type: Object,
-            default: () => new Object
-        },
-        isInertiaButton: {
-            type: Boolean,
-            required: false,
-            default: true
-        }
+
+defineProps({
+    buttonSize: {
+        required: false,
+        default: 'medium',
+        type: String,
+        validator: size => [
+            'xs',
+            'small',
+            'medium',
+            'large',
+        ].includes(size)
     },
-    emits: ['click'],
-}
+    href: {
+        required: false,
+        default: '',
+        type: String
+    },
+    method: {
+        required: false,
+        default: 'get',
+        type: String,
+        validator: method => [
+            'get',
+            'post',
+            'delete'
+        ].includes(method)
+    },
+    data: {
+        required: false,
+        type: Object,
+        default: () => new Object
+    },
+    isInertiaButton: {
+        type: Boolean,
+        required: false,
+        default: true
+    }
+});
+
+defineEmits(['click']);
 </script>

--- a/resources/js/Shared/Layout/Buttons/DismissibleButton.vue
+++ b/resources/js/Shared/Layout/Buttons/DismissibleButton.vue
@@ -23,26 +23,21 @@
   </span>
 </template>
 
-<script>
-export default {
-    name: "DismissibleButton",
-    props: {
-        id: {
-            type: Number,
-            required: true
-        },
-        name: {
-            type: String,
-            required: true
-        },
+<script setup>
+const props = defineProps({
+    id: {
+        type: Number,
+        required: true
     },
-    emits: ['remove'],
-    setup(props, { emit }) {
-        function removeEntry() {
-            emit('remove', props.id)
-        }
+    name: {
+        type: String,
+        required: true
+    },
+});
 
-        return {removeEntry}
-    }
+const emit = defineEmits(['remove']);
+
+function removeEntry() {
+    emit('remove', props.id)
 }
 </script>

--- a/resources/js/Shared/Layout/Eve/EntityByIdBlock.vue
+++ b/resources/js/Shared/Layout/Eve/EntityByIdBlock.vue
@@ -27,124 +27,106 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import {computed, onMounted, onUnmounted, ref} from "vue";
 import EveImage from "@/Shared/EveImage.vue"
-import {onMounted, onUnmounted, ref} from "vue";
 import { getJson } from "@/Functions/http";
 import { getEntityFromId } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
 
-export default {
-    name: "EntityByIdBlock",
-    components: {EveImage},
-    props: {
-        id: {
-            required: true,
-            type: Number
-        },
-        withSubText: {
-            required: false,
-            type: Boolean,
-            default: true
-        },
-        imageSize: {
-            required: false,
-            default: 12,
-            type: Number
-        },
-        nameFontSize: {
-            required: false,
-            default: 'lg',
-            type: String
-        }
+const props = defineProps({
+    id: {
+        required: true,
+        type: Number
     },
-    setup(props) {
-        const entityByIdBlockComponent = ref(null)
-        const isReady = ref(false)
-        const entity = ref(null)
-
-        const getEntity = async () => {
-            try {
-                const data = await getJson(getEntityFromId.url(props.id))
-
-                // resolve.id returns an empty payload ("") for ids it cannot resolve;
-                // only render once we actually have an entity object.
-                if (data && typeof data === 'object' && Object.keys(data).length > 0) {
-                    entity.value = data
-                    isReady.value = true
-                }
-            } catch (error) {
-                console.log(error)
-            }
-        }
-
-        const observer = new IntersectionObserver(function(entries) {
-            if(entries[0].isIntersecting === true) {
-                if(isReady.value)
-                    return
-
-                if(props.id >0) {
-                    getEntity()
-                }
-            }
-        }, { threshold: [1] });
-
-        onMounted(() => {
-
-            observer.observe(entityByIdBlockComponent.value);
-
-        })
-
-        onUnmounted(() => {
-            observer.disconnect()
-        })
-        
-        return {
-            entityByIdBlockComponent,
-            entity,
-            isReady
-        }
-
+    withSubText: {
+        required: false,
+        type: Boolean,
+        default: true
     },
-    computed: {
-        subText() {
-            return [_.get(this.entity, 'corporation.name'), _.get(this.entity, 'alliance.name')].filter( Boolean ).join(' | ')
-        },
-        name() {
-            return _.get(this.entity, 'name', 'missing name')
-        },
-        image_class() {
-            return `h-${this.imageSize} w-${this.imageSize} rounded-full`
-        },
-        name_class() {
-            return `text-${this.nameFontSize} leading-6 font-medium text-gray-900`
-        },
-        hasSubtext() {
+    imageSize: {
+        required: false,
+        default: 12,
+        type: Number
+    },
+    nameFontSize: {
+        required: false,
+        default: 'lg',
+        type: String
+    }
+});
 
-            if(!this.withSubText)
-                return false;
+const entityByIdBlockComponent = ref(null)
+const isReady = ref(false)
+const entity = ref(null)
 
-            return !!(this.subText);
-        },
-        sub_text_class() {
+const getEntity = async () => {
+    try {
+        const data = await getJson(getEntityFromId.url(props.id))
 
-            let size
-            switch (this.nameFontSize) {
-                case 'xs':
-                case 'sm':
-                case 'text-base':
-                    size = 'xs';
-                    break;
-                case 'lg':
-                    size = 'sm';
-                    break;
-                default:
-                    size = 'sm';
-            }
-
-            return `text-${size} text-gray-500 truncate`
+        // resolve.id returns an empty payload ("") for ids it cannot resolve;
+        // only render once we actually have an entity object.
+        if (data && typeof data === 'object' && Object.keys(data).length > 0) {
+            entity.value = data
+            isReady.value = true
         }
+    } catch (error) {
+        console.log(error)
     }
 }
+
+const observer = new IntersectionObserver(function(entries) {
+    if(entries[0].isIntersecting === true) {
+        if(isReady.value)
+            return
+
+        if(props.id >0) {
+            getEntity()
+        }
+    }
+}, { threshold: [1] });
+
+onMounted(() => {
+
+    observer.observe(entityByIdBlockComponent.value);
+
+})
+
+onUnmounted(() => {
+    observer.disconnect()
+})
+
+const subText = computed(() => [_.get(entity.value, 'corporation.name'), _.get(entity.value, 'alliance.name')].filter( Boolean ).join(' | '))
+
+const name = computed(() => _.get(entity.value, 'name', 'missing name'))
+
+const image_class = computed(() => `h-${props.imageSize} w-${props.imageSize} rounded-full`)
+
+const name_class = computed(() => `text-${props.nameFontSize} leading-6 font-medium text-gray-900`)
+
+const hasSubtext = computed(() => {
+    if(!props.withSubText)
+        return false;
+
+    return !!(subText.value);
+})
+
+const sub_text_class = computed(() => {
+    let size
+    switch (props.nameFontSize) {
+        case 'xs':
+        case 'sm':
+        case 'text-base':
+            size = 'xs';
+            break;
+        case 'lg':
+            size = 'sm';
+            break;
+        default:
+            size = 'sm';
+    }
+
+    return `text-${size} text-gray-500 truncate`
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/SimpleInlineList.vue
+++ b/resources/js/Shared/Layout/SimpleInlineList.vue
@@ -28,51 +28,38 @@
   </fieldset>
 </template>
 
-<script>
+<script setup>
+import {computed, getCurrentInstance, ref, watch} from "vue";
 
-import {getCurrentInstance} from "vue";
-
-export default {
-    name: "SimpleInlineList",
-    props: {
-        modelValue: {
-            type: String,
-            default: ''
-        },
-        options: {
-            required: false,
-            type: Array,
-            default: () => []
-        },
-        legend: {
-            required: false,
-            type: String,
-            default: 'legend'
-        }
+const props = defineProps({
+    modelValue: {
+        type: String,
+        default: ''
     },
-    emits: ['update:modelValue'],
-    setup() {
-
+    options: {
+        required: false,
+        type: Array,
+        default: () => []
     },
-    data() {
-        return {
-            picked: this.modelValue
-        }
-    },
-    computed: {
-        // Per-instance id so the radios' id/for/name are unique across multiple SimpleInlineList
-        // instances on the same page (e.g. one contacts card per character). Without this the
-        // duplicated `for`/`id` made clicking a later card's label toggle the first card's radio.
-        uid() {
-            return getCurrentInstance().uid
-        }
-    },
-    watch: {
-        picked(newValue) {
-            this.$emit('update:modelValue', newValue)
-        }
+    legend: {
+        required: false,
+        type: String,
+        default: 'legend'
     }
-}
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const picked = ref(props.modelValue)
+
+// Per-instance id so the radios' id/for/name are unique across multiple SimpleInlineList
+// instances on the same page (e.g. one contacts card per character). Without this the
+// duplicated `for`/`id` made clicking a later card's label toggle the first card's radio.
+const uid = computed(() => getCurrentInstance().uid)
+
+watch(picked, (newValue) => {
+    emit('update:modelValue', newValue)
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout/SlideOver.vue
+++ b/resources/js/Shared/Layout/SlideOver.vue
@@ -84,26 +84,15 @@
   </transition>
 </template>
 
-<script>
-export default {
-  name: "SlideOver",
-  props: {
-      open: Boolean
-  },
-  emits: ['update:open'],
-  data() {
-      return {
-          //open: this.value,
-      }
-  },
-  mounted() {
-      /*this.$eventBus.$on('open-slideOver', () => this.open = true)*/
-  },
-  methods: {
-      flipStatus() {
-          this.$emit('update:open', !this.open)
-      }
-  },
+<script setup>
+const props = defineProps({
+    open: Boolean
+});
+
+const emit = defineEmits(['update:open']);
+
+function flipStatus() {
+    emit('update:open', !props.open)
 }
 </script>
 

--- a/resources/js/Shared/Layout/Tabs/BarWithUnderline.vue
+++ b/resources/js/Shared/Layout/Tabs/BarWithUnderline.vue
@@ -51,7 +51,6 @@
 </template>
 
 <script>
-import {ref} from "vue";
 import {useValidateObject} from "@/Functions/useValidateObject";
 
 let schema = {
@@ -61,36 +60,31 @@ let schema = {
 
 schema.id.required = true
 schema.name.required = true
+</script>
 
-export default {
-    name: "BarWithUnderline",
-    props: {
-        tabs: {
-            type: Array,
-            required: true,
-            validator: tabs => _.chain(tabs)
-                .map(tab => useValidateObject(tab, schema))
-                .filter()
-                .value()
-                .length === tabs.length
-        },
+<script setup>
+import {ref} from "vue";
+
+const props = defineProps({
+    tabs: {
+        type: Array,
+        required: true,
+        validator: tabs => _.chain(tabs)
+            .map(tab => useValidateObject(tab, schema))
+            .filter()
+            .value()
+            .length === tabs.length
     },
-    emits: ['select'],
-    setup(props, {emit}) {
-        const activeTab = ref(props.tabs[0])
+});
 
-        const isActive = (entry) => _.isEqual(entry, activeTab.value)
-        const select = (tab) => {
-            emit('select', tab)
-            activeTab.value = tab
-        }
+const emit = defineEmits(['select']);
 
-        return {
-            activeTab,
-            isActive,
-            select
-        }
-    }
+const activeTab = ref(props.tabs[0])
+
+const isActive = (entry) => _.isEqual(entry, activeTab.value)
+const select = (tab) => {
+    emit('select', tab)
+    activeTab.value = tab
 }
 </script>
 

--- a/resources/js/Shared/Modals/Modal.vue
+++ b/resources/js/Shared/Modals/Modal.vue
@@ -44,35 +44,31 @@
   </div>
 </template>
 
-<script>
-  export default {
-      name: "Modal",
-      props: {
-          modelValue: {
-              type: Boolean,
-              default: false
-          }
-      },
-emits: ['update:modelValue'],
-      data() {
-          return {
-              open: this.modelValue
-          }
-      },
-      watch: {
-        modelValue(newVal) {
-              this.open = newVal
-          },
-          open(newVal) {
-              this.$emit('update:modelValue', newVal)
-          }
-      },
-      methods: {
-          toggle() {
-              this.open = !this.open
-          }
-      }
-  }
+<script setup>
+import { ref, watch } from "vue";
+
+const props = defineProps({
+    modelValue: {
+        type: Boolean,
+        default: false
+    }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const open = ref(props.modelValue)
+
+watch(() => props.modelValue, (newVal) => {
+    open.value = newVal
+})
+
+watch(open, (newVal) => {
+    emit('update:modelValue', newVal)
+})
+
+function toggle() {
+    open.value = !open.value
+}
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Modals/ModalWithFooter.vue
+++ b/resources/js/Shared/Modals/ModalWithFooter.vue
@@ -69,40 +69,35 @@
   </Modal>
 </template>
 
-<script>
-    import Modal from "./Modal.vue"
-    export default {
-        name: "ModalWithFooter",
-        components: {Modal},
-        props: {
-            modelValue: {
-              required: true
-            },
-            cancelButton: {
-                type: Boolean,
-                default: true
-            }
-        },
-emits: ['update:modelValue'],
-        data() {
-            return {
-                open: this.modelValue
-            }
-        },
-        watch: {
-          modelValue(newVal) {
-                this.open = newVal
-            },
-            open(newVal) {
-                this.$emit('update:modelValue', newVal)
-            }
-        },
-        methods: {
-            toggle() {
-                this.open = !this.open
-            }
-        }
+<script setup>
+import { ref, watch } from "vue";
+import Modal from "./Modal.vue"
+
+const props = defineProps({
+    modelValue: {
+        required: true
+    },
+    cancelButton: {
+        type: Boolean,
+        default: true
     }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const open = ref(props.modelValue)
+
+watch(() => props.modelValue, (newVal) => {
+    open.value = newVal
+})
+
+watch(open, (newVal) => {
+    emit('update:modelValue', newVal)
+})
+
+function toggle() {
+    open.value = !open.value
+}
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Modals/WithDismissButtonModal.vue
+++ b/resources/js/Shared/Modals/WithDismissButtonModal.vue
@@ -98,43 +98,28 @@
   </TransitionRoot>
 </template>
 
-<script>
+<script setup>
 import { computed } from 'vue'
 import { Dialog, DialogOverlay, TransitionChild, TransitionRoot } from '@headlessui/vue'
 import { XMarkIcon } from '@heroicons/vue/24/outline'
 
-export default {
-    name: "WithDismissButtonModal",
-    components: {
-        Dialog,
-        DialogOverlay,
-        TransitionChild,
-        TransitionRoot,
-        XMarkIcon,
+const props = defineProps({
+    modelValue: {
+        required: true,
+        type: Boolean
     },
-    props: {
-        modelValue: {
-            required: true,
-            type: Boolean
-        },
-        width: {
-            required: false,
-            type: String,
-            validator: value => ['lg', 'xl', '2xl', '3xl', '4xl', '5xl'].includes(value),
-            default: 'lg'
-        }
-    },
-emits: ['update:modelValue'],
-    setup(props, {emit}) {
-        const open = computed(() => props.modelValue)
-        const close = () => emit('update:modelValue', false)
+    width: {
+        required: false,
+        type: String,
+        validator: value => ['lg', 'xl', '2xl', '3xl', '4xl', '5xl'].includes(value),
+        default: 'lg'
+    }
+});
 
-        return {
-            open,
-            close
-        }
-    },
-}
+const emit = defineEmits(['update:modelValue']);
+
+const open = computed(() => props.modelValue)
+const close = () => emit('update:modelValue', false)
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Pagination.vue
+++ b/resources/js/Shared/Pagination.vue
@@ -128,68 +128,54 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, ref } from "vue";
 import { Link } from '@inertiajs/vue3';
-    export default {
-        name: "Pagination",
-        components: {Link},
-        props: {
-            collection: {
-                type    : Object,
-                required: true
-            },
-            offset: {
-                type: Number,
-                default: 5
-            }
-        },
-        data() {
-            return {
-                tinted: true
-            }
-        },
-        computed: {
-            pages() {
-                let pages = [];
-                let from = this.collection.meta.current_page - Math.floor(this.offset / 2);
-                if (from < 1) {
-                    from = 1;
-                }
-                let to = from + this.offset - 1;
-                if (to > this.collection.meta.last_page) {
-                    to = this.collection.meta.last_page;
-                }
-                while (from <= to) {
-                    pages.push(from);
-                    from++;
-                }
-                return pages;
-            },
-            currentPage() {
-                return this.collection.meta.current_page
-            },
-            prevDisabled() {
-                return this.collection.meta.current_page <= 1
-            },
-            nextDisabled() {
-                return this.collection.meta.current_page >= this.collection.meta.last_page
-            }
-        },
-        methods: {
-            isCurrentPage(page) {
-                return this.collection.meta.current_page === page;
-            },
-            buildHref(page) {
 
-                let uri = window.location.search.substring(1);
-                let searchParams = new URLSearchParams(uri);
-
-                searchParams.set("page", page);
-
-                return this.collection.meta.path + '?' + searchParams.toString();
-            },
-        },
+const props = defineProps({
+    collection: {
+        type    : Object,
+        required: true
+    },
+    offset: {
+        type: Number,
+        default: 5
     }
+});
+
+const tinted = ref(true)
+
+const pages = computed(() => {
+    let pages = [];
+    let from = props.collection.meta.current_page - Math.floor(props.offset / 2);
+    if (from < 1) {
+        from = 1;
+    }
+    let to = from + props.offset - 1;
+    if (to > props.collection.meta.last_page) {
+        to = props.collection.meta.last_page;
+    }
+    while (from <= to) {
+        pages.push(from);
+        from++;
+    }
+    return pages;
+})
+
+const currentPage = computed(() => props.collection.meta.current_page)
+
+const prevDisabled = computed(() => props.collection.meta.current_page <= 1)
+
+const nextDisabled = computed(() => props.collection.meta.current_page >= props.collection.meta.last_page)
+
+function buildHref(page) {
+    let uri = window.location.search.substring(1);
+    let searchParams = new URLSearchParams(uri);
+
+    searchParams.set("page", page);
+
+    return props.collection.meta.path + '?' + searchParams.toString();
+}
 </script>
 
 <style scoped>

--- a/resources/js/Shared/ResolveIdToName.vue
+++ b/resources/js/Shared/ResolveIdToName.vue
@@ -9,72 +9,62 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import {onMounted, onUnmounted, ref} from "vue";
 import { getJson } from "@/Functions/http";
 import { getEntityFromId } from "@/actions/Seatplus/Web/Http/Controllers/Shared/HelperController";
 
-export default {
-    name: "ResolveIdToName",
-    props: {
-        id: {
-            type: Number,
-            required: true
-        },
-        tailwindClass: {
-            type: String,
-            required: false,
-            default: 'text-sm whitespace-nowrap text-gray-500'
-        }
+const props = defineProps({
+    id: {
+        type: Number,
+        required: true
     },
-    setup(props) {
-        const isLoading = ref(false)
-        const isComplete = ref(false)
-        const name = ref('')
-        const unknownIdRef = ref(null)
-
-
-        const fetch = async () => {
-
-            if(isLoading.value || isComplete.value)
-                return
-
-            isLoading.value = true
-
-            await getJson(getEntityFromId.url(props.id))
-                .then(result => {
-                    name.value = result.name
-                    isComplete.value = true
-                })
-                .catch(error => console.log(error));
-
-            isLoading.value = false
-        }
-
-        const observer = new IntersectionObserver(function(entries) {
-            if(entries[0].isIntersecting === true) {
-                if(isComplete.value)
-                    return
-
-                fetch()
-            }
-        }, { threshold: [1] });
-
-        onMounted(() => {
-            observer.observe(unknownIdRef.value);
-        })
-
-        onUnmounted(() => {
-            observer.disconnect()
-        })
-
-        return {
-            name,
-            isComplete,
-            unknownIdRef
-        }
+    tailwindClass: {
+        type: String,
+        required: false,
+        default: 'text-sm whitespace-nowrap text-gray-500'
     }
+});
+
+const isLoading = ref(false)
+const isComplete = ref(false)
+const name = ref('')
+const unknownIdRef = ref(null)
+
+
+const fetch = async () => {
+
+    if(isLoading.value || isComplete.value)
+        return
+
+    isLoading.value = true
+
+    await getJson(getEntityFromId.url(props.id))
+        .then(result => {
+            name.value = result.name
+            isComplete.value = true
+        })
+        .catch(error => console.log(error));
+
+    isLoading.value = false
 }
+
+const observer = new IntersectionObserver(function(entries) {
+    if(entries[0].isIntersecting === true) {
+        if(isComplete.value)
+            return
+
+        fetch()
+    }
+}, { threshold: [1] });
+
+onMounted(() => {
+    observer.observe(unknownIdRef.value);
+})
+
+onUnmounted(() => {
+    observer.disconnect()
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/SeatPlusSelect.vue
+++ b/resources/js/Shared/SeatPlusSelect.vue
@@ -41,30 +41,27 @@
   </div>
 </template>
 
-<script>
-export default {
-    name: "SeatPlusSelect",
-    props: ['modelValue', 'id'],
-    emits: ['update:modelValue'],
-    data() {
-        return {
-            selection: this.modelValue
-        }
-    },
-    computed: {
-        error() {
-            return _.get(this.$page, `props.errors[${this.id}][0]`)
-        }
-    },
-    watch: {
-        selection(newValue) {
-            this.$emit('update:modelValue', newValue)
-        },
-        modelValue(newValue) {
-            this.selection = newValue
-        }
-    },
-}
+<script setup>
+import { computed, ref, watch } from "vue";
+import { usePage } from "@inertiajs/vue3";
+
+const props = defineProps(['modelValue', 'id']);
+
+const emit = defineEmits(['update:modelValue']);
+
+const page = usePage();
+
+const selection = ref(props.modelValue)
+
+const error = computed(() => _.get(page, `props.errors[${props.id}][0]`))
+
+watch(selection, (newValue) => {
+    emit('update:modelValue', newValue)
+})
+
+watch(() => props.modelValue, (newValue) => {
+    selection.value = newValue
+})
 </script>
 
 <style scoped>

--- a/resources/js/Shared/SidebarLayout/ImpersonatingBanner.vue
+++ b/resources/js/Shared/SidebarLayout/ImpersonatingBanner.vue
@@ -53,21 +53,16 @@
   </div>
 </template>
 
-<script>
-import { Link } from '@inertiajs/vue3';
+<script setup>
+import { computed } from "vue";
+import { Link, usePage } from '@inertiajs/vue3';
 import StopImpersonateController from "@/actions/Seatplus/Web/Http/Controllers/Shared/StopImpersonateController";
-  export default {
-    name: "ImpersonatingBanner",
-      components: {Link},
-      computed: {
-        name() {
-            return this.$page.props.user.data.mainCharacter?.name ?? 'Unknown'
-        },
-        stopUrl() {
-            return StopImpersonateController.url()
-        }
-      }
-  }
+
+const page = usePage();
+
+const name = computed(() => page.props.user.data.mainCharacter?.name ?? 'Unknown')
+
+const stopUrl = computed(() => StopImpersonateController.url())
 </script>
 
 <style scoped>

--- a/resources/js/Shared/SimpleToggle.vue
+++ b/resources/js/Shared/SimpleToggle.vue
@@ -16,34 +16,25 @@
   </span>
 </template>
 
-<script>
-export default {
-    name: "SimpleToggle",
-    props: {
-        bgClass: {
-            type: String,
-            default: 'bg-indigo-600'
-        },
-        modelValue: {
-            type: Boolean,
-            default: false
-        }
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+    bgClass: {
+        type: String,
+        default: 'bg-indigo-600'
     },
-    emits: ['update:modelValue'],
-    data() {
-        return {
-            focused: false /*This Needed?*/
-        };
-    },
-    computed: {
-        trackClass() {
-            return this.modelValue ? this.bgClass : 'bg-gray-200';
-        }
-    },
-    methods: {
-        toggle() {
-            this.$emit('update:modelValue', !this.modelValue);
-        }
+    modelValue: {
+        type: Boolean,
+        default: false
     }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const trackClass = computed(() => props.modelValue ? props.bgClass : 'bg-gray-200')
+
+function toggle() {
+    emit('update:modelValue', !props.modelValue);
 }
 </script>

--- a/resources/js/Shared/Time.vue
+++ b/resources/js/Shared/Time.vue
@@ -2,7 +2,8 @@
   <span :key="seconds"> {{ getTimeFromNow() }} </span>
 </template>
 
-<script>
+<script setup>
+import { nextTick, ref } from "vue"
 import dayjs from "dayjs"
 import customParseFormat from "dayjs/plugin/customParseFormat"
 import relativeTime from "dayjs/plugin/relativeTime"
@@ -10,37 +11,27 @@ import relativeTime from "dayjs/plugin/relativeTime"
 dayjs.extend(customParseFormat);
 dayjs.extend(relativeTime)
 
-export default {
-    name: "Time",
-    props: {
-        timestamp: {
-            type: String,
-            required: true
-        },
-        format: {
-            type: String,
-            required: false
-        },
+const props = defineProps({
+    timestamp: {
+        type: String,
+        required: true
     },
-    data() {
-        return {
-            seconds: 0
-        }
+    format: {
+        type: String,
+        required: false
     },
-    created () {
-        this.$nextTick(() => {
+});
 
-            setInterval(()  => {
-                this.seconds += 1
-            }, 1000)
-        })
-    },
-    methods: {
-        getTimeFromNow() {
+const seconds = ref(0)
 
-            return this.format ? dayjs(this.timestamp, this.format).fromNow() : dayjs(this.timestamp).fromNow()
-        }
-    }
+nextTick(() => {
+    setInterval(()  => {
+        seconds.value += 1
+    }, 1000)
+})
+
+function getTimeFromNow() {
+    return props.format ? dayjs(props.timestamp, props.format).fromNow() : dayjs(props.timestamp).fromNow()
 }
 </script>
 


### PR DESCRIPTION
## What

**Final phase** of migrating the web package's Options API Vue SFCs to **`<script setup>`**. Converts the last **16** files — the most stateful Shared components:

- Modals: `Modal`, `ModalWithFooter`, `WithDismissButtonModal`
- `Layout/SlideOver`, `SimpleInlineList`, `BarWithUnderline`
- `Button`, `Buttons/DismissibleButton`, `Eve/EntityByIdBlock`
- `Time`, `Pagination`, `InputGroup`, `SeatPlusSelect`, `SimpleToggle`, `ResolveIdToName`, `SidebarLayout/ImpersonatingBanner`

## Completes the migration

With phases 1–4 (#1624, #1625, #1626, this), **zero Options-API SFCs remain on `5.x`**. Cut from `5.x` on files disjoint from the other three PRs — all four merge in any order.

## Scope / guarantees

- **Pure style/API migration** — no behaviour change.
- **ESLint: 0 errors**; warnings strictly fewer than the originals (10 → 5, none introduced).

## Conversion notes

- **v-model modals**: `data(){ open }` + the `modelValue`/`open` watch pair → `const open = ref(props.modelValue)` + `watch(() => props.modelValue, …)` / `watch(open, …)`.
- **`Button.vue`**: dynamic `<component :is>` referenced the component by **string** (`:is="'Link'"`), which only resolves via Options `components:` registration. `<script setup>` has no such registry, so it now passes the imported component directly: `:is="isInertiaButton ? Link : 'div'"`.
- `emits` + `this.$emit` → `defineEmits`; module-scoped `defineProps`-validator code (`BarWithUnderline` `schema`) → companion plain `<script>` block; `this.$nextTick` → `nextTick`; template refs via `ref()`; `this.$page` → `usePage()`.
- Dead members dropped (empty `data`/`mounted`, unused `focused`/`error`/`isCurrentPage`) to satisfy `no-unused-vars`.
- lodash `_` stays a **global** (never imported).

## Verification

- [x] `npm run lint` (ESLint) — 0 errors, no new warnings.
- [ ] Browser tests (`tests/Browser/`) — "Browser (vs core)" job / host. These are shared primitives used across nearly every page (modals, slide-over picker, pagination, entity blocks, toggles), so the full browser suite is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)