### PR TITLE
chore(js): take Frontend Lint to zero warnings (formatting + prop hygiene)

### DIFF
--- a/resources/js/Pages/Auth/MissingRequiredScopes.vue
+++ b/resources/js/Pages/Auth/MissingRequiredScopes.vue
@@ -98,6 +98,7 @@ const { trans } = useTranslations();
 
 defineProps({
     characters: {
+        type: Array,
         required: true
     }
 });

--- a/resources/js/Pages/Character/Assets.vue
+++ b/resources/js/Pages/Character/Assets.vue
@@ -108,12 +108,10 @@ const COMPACT_VIEW_TTL = 365 * 24 * 60 * 60 * 1000
 
 const props = defineProps({
     dispatchTransferObject: {
-        required: true,
         type: Object,
         default: () => {}
     },
     characterIds: {
-        required: true,
         type: Array,
         default: () => []
     },

--- a/resources/js/Pages/Character/Contract/ContractDetails.vue
+++ b/resources/js/Pages/Character/Contract/ContractDetails.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="space-y-3">
-    <PageHeader :page-title="pageTitle" :breadcrumbs="breadcrumbs" />
+    <PageHeader
+      :page-title="pageTitle"
+      :breadcrumbs="breadcrumbs"
+    />
 
     <ContractDetailsComponent
       v-if="contract.items.length > 0"

--- a/resources/js/Pages/Character/Mail/Index.vue
+++ b/resources/js/Pages/Character/Mail/Index.vue
@@ -15,7 +15,7 @@
         </PageHeader>
 
         <div class="block lg:hidden">
-          <MobileMailList v-model:selectedId="selectedId" />
+          <MobileMailList v-model:selected-id="selectedId" />
         </div>
 
         <div class="hidden md:block space-y-3">
@@ -28,7 +28,7 @@
       </div>
     </div>
     <template #aside>
-      <DesktopMailList v-model:selectedId="selectedId" />
+      <DesktopMailList v-model:selected-id="selectedId" />
     </template>
   </MultiColumnLayout>
 </template>

--- a/resources/js/Pages/Character/Skill/Index.vue
+++ b/resources/js/Pages/Character/Skill/Index.vue
@@ -82,6 +82,7 @@ defineProps({
         required: true,
         type: Object
     },
+    // eslint-disable-next-line vue/prop-name-casing -- controller-provided Inertia prop; mirrors the PHP payload key
     character_ids: {
         required: true,
         type: Array

--- a/resources/js/Pages/Character/Skill/Index.vue
+++ b/resources/js/Pages/Character/Skill/Index.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="space-y-3">
-
     <RequiredScopesWarning :dispatch-transfer-object="dispatchTransferObject" />
 
     <PageHeader :page-title="pageTitle">

--- a/resources/js/Pages/Character/Wallet/Index.vue
+++ b/resources/js/Pages/Character/Wallet/Index.vue
@@ -42,12 +42,14 @@ const props = defineProps({
         required: true,
         type: Object
     },
+    // eslint-disable-next-line vue/prop-name-casing -- controller-provided Inertia prop; mirrors the PHP payload key
     character_ids: {
         required: true,
         type: Array
     },
     // Available ref_type options for the filter (WalletsController::index) —
     // passed as a prop so the filter needs no autosuggest endpoint (no axios/Ziggy).
+    // eslint-disable-next-line vue/prop-name-casing -- controller-provided Inertia prop; mirrors the PHP payload key
     ref_types: {
         required: false,
         type: Array,

--- a/resources/js/Pages/Configuration/HorizonStats.vue
+++ b/resources/js/Pages/Configuration/HorizonStats.vue
@@ -97,6 +97,7 @@
         <div class="px-4 py-5 sm:p-6">
           <div class="flex items-center">
             <div class="shrink-0 bg-indigo-500 rounded-md p-3">
+              <!-- eslint-disable vue/no-v-html -- static, in-component SVG path markup -->
               <svg
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -107,6 +108,7 @@
                 class="h-6 w-6 text-white"
                 v-html="symbols[stats.status]"
               />
+              <!-- eslint-enable vue/no-v-html -->
             </div>
             <div class="ml-5 w-0 flex-1">
               <dl>

--- a/resources/js/Pages/Configuration/Performance/Overview.vue
+++ b/resources/js/Pages/Configuration/Performance/Overview.vue
@@ -10,11 +10,12 @@
       </template>
 
       <Card>
-        <Line :data="getDate(data)" :options="options" />
+        <Line
+          :data="getDate(data)"
+          :options="options"
+        />
       </Card>
     </Deferred>
-
-
   </div>
 </template>
 

--- a/resources/js/Pages/Configuration/Schedules/SchedulesCreate.vue
+++ b/resources/js/Pages/Configuration/Schedules/SchedulesCreate.vue
@@ -14,9 +14,9 @@
               v-model="expression"
             >
               <option
-                v-for="(expression,description, index) in cron"
+                v-for="(cronExpression, description, index) in cron"
                 :key="index"
-                :value="expression"
+                :value="cronExpression"
               >
                 {{ description }}
               </option>
@@ -31,11 +31,11 @@
               v-model="job"
             >
               <option
-                v-for="(job, index) in jobs"
+                v-for="(jobName, index) in jobs"
                 :key="index"
-                :value="job"
+                :value="jobName"
               >
-                {{ job }}
+                {{ jobName }}
               </option>
             </SeatPlusSelect>
           </InputGroup>

--- a/resources/js/Pages/Configuration/Schedules/SchedulesDetails.vue
+++ b/resources/js/Pages/Configuration/Schedules/SchedulesDetails.vue
@@ -14,9 +14,9 @@
               v-model="expression"
             >
               <option
-                v-for="(expression, description, index) in cron"
+                v-for="(cronExpression, description, index) in cron"
                 :key="index"
-                :value="expression"
+                :value="cronExpression"
               >
                 {{ description }}
               </option>

--- a/resources/js/Pages/Configuration/Scopes/OverviewScopeSettings.vue
+++ b/resources/js/Pages/Configuration/Scopes/OverviewScopeSettings.vue
@@ -125,6 +125,7 @@ import { settings as viewScopesSettings } from "@/routes/view/scopes";
 import { scopes as viewCreateScopes } from "@/routes/view/create";
 
 const props = defineProps({
+    // eslint-disable-next-line vue/prop-name-casing -- controller-provided Inertia prop; mirrors the PHP payload key
     available_scopes: {
         type: Object,
         required: true

--- a/resources/js/Pages/Configuration/Scopes/ScopeSettings.vue
+++ b/resources/js/Pages/Configuration/Scopes/ScopeSettings.vue
@@ -132,6 +132,7 @@ import RadioListWithDescription from "@/Shared/Layout/RadioListWithDescription.v
 import { create as createScopes, deleteSsoScopeSetting } from "@/actions/Seatplus/Web/Http/Controllers/Configuration/SsoSettings/SsoSettingsController";
 
 const props = defineProps({
+    // eslint-disable-next-line vue/prop-name-casing -- controller-provided Inertia prop; mirrors the PHP payload key
     available_scopes: {
         type: Object,
         required: true

--- a/resources/js/Pages/Configuration/Settings.vue
+++ b/resources/js/Pages/Configuration/Settings.vue
@@ -34,12 +34,14 @@
                   :class="[{'ml-8': index >0}, isActive(navTab.route) ? 'border-indigo-500 text-indigo-600 focus:text-indigo-800 focus:border-indigo-700' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:text-gray-700 focus:border-gray-300','group focus:outline-hidden inline-flex items-center py-4 px-1 border-b-2 font-medium text-sm leading-5 cursor-pointer']"
                   @click="visitRoute(navTab.route)"
                 >
+                  <!-- eslint-disable vue/no-v-html -- server-provided nav icon SVG markup -->
                   <svg
                     :class="['-ml-0.5 mr-2 h-5 w-5', isActive(navTab.route) ? 'text-indigo-500 group-focus:text-indigo-600' : 'text-gray-400 group-hover:text-gray-500 group-focus:text-gray-600']"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                     v-html="navTab.logo"
                   />
+                  <!-- eslint-enable vue/no-v-html -->
                   <span>{{ navTab.name }}</span>
                 </div>
               </nav>

--- a/resources/js/Pages/Recruitment/Manage/Index.vue
+++ b/resources/js/Pages/Recruitment/Manage/Index.vue
@@ -26,7 +26,7 @@
             label="Corporation"
             :show-label="false"
             placeholder="Search any corporation"
-            @selectedObject="selection => openForm.corporation = selection"
+            @selected-object="selection => openForm.corporation = selection"
           />
           <div
             v-if="openForm.errors.corporation_id"

--- a/resources/js/Pages/Recruitment/Manage/ManagePostingCard.vue
+++ b/resources/js/Pages/Recruitment/Manage/ManagePostingCard.vue
@@ -150,7 +150,7 @@
           <Autosuggest
             :key="itemsKey"
             placeholder="Search for items"
-            @selectedObject="addItem"
+            @selected-object="addItem"
           />
           <div class="mt-2 flex flex-wrap gap-2">
             <DismissibleButton

--- a/resources/js/Shared/AppHead.vue
+++ b/resources/js/Shared/AppHead.vue
@@ -19,7 +19,11 @@ const icon = computed(() => {
 
 <template>
   <Head :title="appTitle ? `${appTitle} - Seatplus` : 'Seatplus'">
-    <link rel="icon" type="image/svg+xml" :href="icon">
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      :href="icon"
+    >
     <slot />
   </Head>
 </template>

--- a/resources/js/Shared/AppHead.vue
+++ b/resources/js/Shared/AppHead.vue
@@ -6,6 +6,7 @@ import { Head, usePage } from '@inertiajs/vue3';
 defineProps({
     appTitle: {
         type: String,
+        default: null,
     },
 })
 

--- a/resources/js/Shared/Components/AccessControl/WizardSteps.vue
+++ b/resources/js/Shared/Components/AccessControl/WizardSteps.vue
@@ -27,73 +27,73 @@
         role="list"
         class="rounded-md border border-gray-300 md:flex md:divide-y-0"
       >
-      <li
-        v-for="(step, stepIdx) in steps"
-        :key="step.key"
-        class="relative md:flex md:flex-1"
-      >
-        <!-- Complete -->
-        <span
-          v-if="statusOf(stepIdx) === 'complete'"
-          class="flex w-full items-center"
+        <li
+          v-for="(step, stepIdx) in steps"
+          :key="step.key"
+          class="relative md:flex md:flex-1"
         >
-          <span class="flex items-center px-6 py-4 text-sm font-medium">
-            <span class="flex size-10 shrink-0 items-center justify-center rounded-full bg-indigo-600">
-              <CheckIcon
-                class="size-6 text-white"
-                aria-hidden="true"
-              />
-            </span>
-            <span class="ml-4 text-sm font-medium text-gray-900">{{ step.label }}</span>
-          </span>
-        </span>
-
-        <!-- Current -->
-        <span
-          v-else-if="statusOf(stepIdx) === 'current'"
-          class="flex items-center px-6 py-4 text-sm font-medium"
-          aria-current="step"
-        >
-          <span class="flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-indigo-600">
-            <span class="text-indigo-600">{{ stepNumber(stepIdx) }}</span>
-          </span>
-          <span class="ml-4 text-sm font-medium text-indigo-600">{{ step.label }}</span>
-        </span>
-
-        <!-- Upcoming -->
-        <span
-          v-else
-          class="flex items-center"
-        >
-          <span class="flex items-center px-6 py-4 text-sm font-medium">
-            <span class="flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-gray-300">
-              <span class="text-gray-500">{{ stepNumber(stepIdx) }}</span>
-            </span>
-            <span class="ml-4 text-sm font-medium text-gray-500">{{ step.label }}</span>
-          </span>
-        </span>
-
-        <!-- Arrow separator for md screens and up -->
-        <template v-if="stepIdx !== steps.length - 1">
-          <div
-            class="absolute top-0 right-0 hidden h-full w-5 md:block"
-            aria-hidden="true"
+          <!-- Complete -->
+          <span
+            v-if="statusOf(stepIdx) === 'complete'"
+            class="flex w-full items-center"
           >
-            <svg
-              class="size-full text-gray-300"
-              viewBox="0 0 22 80"
-              fill="none"
-              preserveAspectRatio="none"
+            <span class="flex items-center px-6 py-4 text-sm font-medium">
+              <span class="flex size-10 shrink-0 items-center justify-center rounded-full bg-indigo-600">
+                <CheckIcon
+                  class="size-6 text-white"
+                  aria-hidden="true"
+                />
+              </span>
+              <span class="ml-4 text-sm font-medium text-gray-900">{{ step.label }}</span>
+            </span>
+          </span>
+
+          <!-- Current -->
+          <span
+            v-else-if="statusOf(stepIdx) === 'current'"
+            class="flex items-center px-6 py-4 text-sm font-medium"
+            aria-current="step"
+          >
+            <span class="flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-indigo-600">
+              <span class="text-indigo-600">{{ stepNumber(stepIdx) }}</span>
+            </span>
+            <span class="ml-4 text-sm font-medium text-indigo-600">{{ step.label }}</span>
+          </span>
+
+          <!-- Upcoming -->
+          <span
+            v-else
+            class="flex items-center"
+          >
+            <span class="flex items-center px-6 py-4 text-sm font-medium">
+              <span class="flex size-10 shrink-0 items-center justify-center rounded-full border-2 border-gray-300">
+                <span class="text-gray-500">{{ stepNumber(stepIdx) }}</span>
+              </span>
+              <span class="ml-4 text-sm font-medium text-gray-500">{{ step.label }}</span>
+            </span>
+          </span>
+
+          <!-- Arrow separator for md screens and up -->
+          <template v-if="stepIdx !== steps.length - 1">
+            <div
+              class="absolute top-0 right-0 hidden h-full w-5 md:block"
+              aria-hidden="true"
             >
-              <path
-                d="M0 -2L20 40L0 82"
-                vector-effect="non-scaling-stroke"
-                stroke="currentcolor"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </div>
-        </template>
+              <svg
+                class="size-full text-gray-300"
+                viewBox="0 0 22 80"
+                fill="none"
+                preserveAspectRatio="none"
+              >
+                <path
+                  d="M0 -2L20 40L0 82"
+                  vector-effect="non-scaling-stroke"
+                  stroke="currentcolor"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+          </template>
         </li>
       </ol>
     </nav>

--- a/resources/js/Shared/Components/Assets/AddManualLocationModal.vue
+++ b/resources/js/Shared/Components/Assets/AddManualLocationModal.vue
@@ -113,8 +113,10 @@ import { create as createManualLocation } from "@/actions/Seatplus/Web/Http/Cont
 
 const props = defineProps({
     modelValue: {
+        type: Boolean,
         required: true
     },
+    // eslint-disable-next-line vue/prop-name-casing -- mirrors the location_id passed by asset rows; renaming is non-functional churn
     location_id: {
         required: true,
         type: Number

--- a/resources/js/Shared/Components/Assets/ItemList.vue
+++ b/resources/js/Shared/Components/Assets/ItemList.vue
@@ -5,7 +5,7 @@
       :items="items"
     />
     <WideAssetListComponent
-        v-else
+      v-else
       :items="items"
     />
   </div>

--- a/resources/js/Shared/Components/Assets/ItemList.vue
+++ b/resources/js/Shared/Components/Assets/ItemList.vue
@@ -22,7 +22,6 @@
       type: Array
     },
     compact: {
-      required: true,
       default: false,
       type: Boolean
     }

--- a/resources/js/Shared/Components/Autosuggest.vue
+++ b/resources/js/Shared/Components/Autosuggest.vue
@@ -28,7 +28,7 @@
         <ListboxOption
           v-for="option in options"
           :key="option"
-          v-slot="{ selected }"
+          v-slot="{ selected: isSelected }"
           :value="option"
           class="text-gray-900 hover:text-white hover:bg-indigo-600 cursor-default select-none relative py-2 pl-8 pr-4"
         >
@@ -37,13 +37,13 @@
             :entity="option"
             class="block truncate"
             :image-size="5"
-            :name-class="selected ? 'font-semibold' : 'font-medium' + ' ' + 'text-sm leading 6 text-gray-900'"
+            :name-class="isSelected ? 'font-semibold' : 'font-medium' + ' ' + 'text-sm leading 6 text-gray-900'"
           />
           <div v-else>
             {{ option.name }}
           </div>
           <span
-            v-show="selected"
+            v-show="isSelected"
             class="absolute inset-y-0 left-0 flex items-center pl-1.5"
           >
             <CheckIcon class="h-5 w-5" />
@@ -71,7 +71,8 @@ import { typesOrGroupsOrCategories } from "@/actions/Seatplus/Web/Http/Controlle
 defineProps({
     label: {
         required: false,
-        type: String
+        type: String,
+        default: null
     },
     placeholder: {
         required: true,

--- a/resources/js/Shared/Components/CharacterInspection/TabComponent.vue
+++ b/resources/js/Shared/Components/CharacterInspection/TabComponent.vue
@@ -144,11 +144,13 @@ const props = defineProps({
     },
     targetCorporation: {
         type: Object,
-        required: false
+        required: false,
+        default: null
     },
     application: {
         type: Object,
-        required: false
+        required: false,
+        default: null
     }
 });
 

--- a/resources/js/Shared/Components/Contracts/ContractDetailsComponent.vue
+++ b/resources/js/Shared/Components/Contracts/ContractDetailsComponent.vue
@@ -30,7 +30,7 @@
               <template #avatar>
                 <span class="inline-block relative">
                   <EveImage
-                          v-if="item.type"
+                    v-if="item.type"
                     :tailwind_class="'h-12 w-12 rounded-full text-white shadow-solid bg-white'"
                     :object="item.type"
                     :size="128"
@@ -118,7 +118,7 @@
               <template #avatar>
                 <span class="inline-block relative">
                   <EveImage
-                          v-if="item.type"
+                    v-if="item.type"
                     :tailwind_class="'h-12 w-12 rounded-full text-white shadow-solid bg-white'"
                     :object="item.type"
                     :size="128"

--- a/resources/js/Shared/Components/EsiMultiselect.vue
+++ b/resources/js/Shared/Components/EsiMultiselect.vue
@@ -31,7 +31,6 @@ import {ref, watch} from "vue";
 
 const props = defineProps({
     modelValue: {
-        required: true,
         type: Array,
         default: () => []
     },

--- a/resources/js/Shared/Components/Mails/DesktopMailList.vue
+++ b/resources/js/Shared/Components/Mails/DesktopMailList.vue
@@ -56,7 +56,9 @@ import ResolveIdToName from "../../ResolveIdToName.vue";
 
 const props = defineProps({
     selectedId: {
-        required: false
+        type: Number,
+        required: false,
+        default: null
     },
 });
 

--- a/resources/js/Shared/Components/Mails/MailRepresentation.vue
+++ b/resources/js/Shared/Components/Mails/MailRepresentation.vue
@@ -51,10 +51,12 @@
           <dt class="text-sm font-medium text-gray-500">
             Message
           </dt>
+          <!-- eslint-disable vue/no-v-html -- mail body is server-rendered EVE mail HTML -->
           <dd
             class="mt-1 text-sm text-gray-900"
             v-html="message.body"
           />
+          <!-- eslint-enable vue/no-v-html -->
         </div>
       </dl>
     </div>

--- a/resources/js/Shared/Components/Mails/MobileMailList.vue
+++ b/resources/js/Shared/Components/Mails/MobileMailList.vue
@@ -68,7 +68,8 @@ import {Disclosure, DisclosureButton, DisclosurePanel} from "@headlessui/vue";
 const props = defineProps({
     selectedId: {
         type: Number,
-        required: false
+        required: false,
+        default: null
     }
 });
 

--- a/resources/js/Shared/Components/SelectComponent.vue
+++ b/resources/js/Shared/Components/SelectComponent.vue
@@ -36,7 +36,7 @@
           <ListboxOption
             v-for="option in options"
             :key="option.id"
-            v-slot="{ active, selected }"
+            v-slot="{ active, selected: isSelected }"
             as="template"
             :value="option"
           >
@@ -46,13 +46,13 @@
                   :object="option"
                   tailwind_class="shrink-0 h-6 w-6 rounded-full"
                 />
-                <span :class="[selected ? 'font-semibold' : 'font-normal', 'ml-3 block truncate']">
+                <span :class="[isSelected ? 'font-semibold' : 'font-normal', 'ml-3 block truncate']">
                   {{ option.name }}
                 </span>
               </div>
 
               <span
-                v-if="selected"
+                v-if="isSelected"
                 :class="[active ? 'text-white' : 'text-indigo-600', 'absolute inset-y-0 right-0 flex items-center pr-4']"
               >
                 <CheckIcon
@@ -77,7 +77,8 @@ import EveImage from "../EveImage.vue";
 const props = defineProps({
     listLabel: {
         required: false,
-        type: String
+        type: String,
+        default: null
     },
     selected: {
         required: true,

--- a/resources/js/Shared/Components/Wallet/Journal/ExtendedWalletJournalRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Journal/ExtendedWalletJournalRowComponent.vue
@@ -49,7 +49,8 @@ import EntityByIdBlock from "@/Shared/Layout/Eve/EntityByIdBlock.vue";
 
 defineProps({
     entry: {
-        required: true
+        required: true,
+        type: Object
     }
 });
 </script>

--- a/resources/js/Shared/Components/Wallet/Journal/WalletJournalBalanceChart.vue
+++ b/resources/js/Shared/Components/Wallet/Journal/WalletJournalBalanceChart.vue
@@ -12,7 +12,10 @@
       </div>
     </template>
     <div class="relative max-h-48 overflow-y-auto">
-      <Line :data="chartData" :options="chartOptions" />
+      <Line
+        :data="chartData"
+        :options="chartOptions"
+      />
     </div>
   </CardWithHeader>
 </template>

--- a/resources/js/Shared/Components/Wallet/Journal/WalletJournalRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Journal/WalletJournalRowComponent.vue
@@ -64,7 +64,8 @@ import { useTranslations } from "@/composables/useTranslations";
 
 defineProps({
     entry: {
-        required: true
+        required: true,
+        type: Object
     },
     even: {
         required: true,

--- a/resources/js/Shared/Components/Wallet/Transaction/ExtendedWalletTransactionRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Transaction/ExtendedWalletTransactionRowComponent.vue
@@ -76,7 +76,8 @@ import EveImage from "@/Shared/EveImage.vue"
 
 defineProps({
     entry: {
-        required: true
+        required: true,
+        type: Object
     }
 });
 </script>

--- a/resources/js/Shared/Components/Wallet/Transaction/WalletTransactionRowComponent.vue
+++ b/resources/js/Shared/Components/Wallet/Transaction/WalletTransactionRowComponent.vue
@@ -84,7 +84,8 @@ import ExtendedWalletTransactionRowComponent from "./ExtendedWalletTransactionRo
 
 const props = defineProps({
     entry: {
-        required: true
+        required: true,
+        type: Object
     },
     even: {
         required: true,

--- a/resources/js/Shared/Components/Wallet/WalletComponent.vue
+++ b/resources/js/Shared/Components/Wallet/WalletComponent.vue
@@ -38,7 +38,8 @@ defineProps({
     },
     division: {
         required: false,
-        type: Object
+        type: Object,
+        default: null
     },
     filters: {
         required: false,

--- a/resources/js/Shared/EveImage.vue
+++ b/resources/js/Shared/EveImage.vue
@@ -36,7 +36,9 @@ const props = defineProps({
         type: Number,
         default: 32
     },
+    // eslint-disable-next-line vue/prop-name-casing -- consumed as :tailwind_class by many call sites; renaming is wide, non-functional churn
     tailwind_class: {
+        type: String,
         required: false,
         default: "h-12 w-12 rounded-full"
     },

--- a/resources/js/Shared/Layout/HeaderButton.vue
+++ b/resources/js/Shared/Layout/HeaderButton.vue
@@ -12,6 +12,7 @@
 <script setup>
 defineProps({
     secondary: {
+        type: Boolean,
         default: false,
     },
 });

--- a/resources/js/Shared/Layout/PageHeader.vue
+++ b/resources/js/Shared/Layout/PageHeader.vue
@@ -22,7 +22,10 @@ const getBack = computed(() => {
 </script>
 
 <template>
-  <AppHead v-if="pageTitle" :app-title="pageTitle" />
+  <AppHead
+    v-if="pageTitle"
+    :app-title="pageTitle"
+  />
 
   <div>
     <div v-if="breadcrumbs.length > 0">
@@ -46,7 +49,10 @@ const getBack = computed(() => {
         </Link>
       </nav>
       <nav class="hidden sm:flex items-center text-sm leading-5 font-medium">
-        <template v-for="breadcrumb of breadcrumbs" :key="breadcrumb.route">
+        <template
+          v-for="breadcrumb of breadcrumbs"
+          :key="breadcrumb.route"
+        >
           <Link
             :href="breadcrumb.route"
             class="text-gray-500 hover:text-gray-700 transition duration-150 ease-in-out"

--- a/resources/js/Shared/Layout/Table/StickyHeaderTableRow.vue
+++ b/resources/js/Shared/Layout/Table/StickyHeaderTableRow.vue
@@ -11,7 +11,6 @@
 defineProps({
     numberColumns: {
         type: Number,
-        required: true,
         default: 1
     }
 });

--- a/resources/js/Shared/Modals/ModalWithFooter.vue
+++ b/resources/js/Shared/Modals/ModalWithFooter.vue
@@ -75,6 +75,7 @@ import Modal from "./Modal.vue"
 
 const props = defineProps({
     modelValue: {
+        type: Boolean,
         required: true
     },
     cancelButton: {

--- a/resources/js/Shared/Pagination.vue
+++ b/resources/js/Shared/Pagination.vue
@@ -72,7 +72,10 @@
             </svg>
           </Link>
 
-          <span v-for="page in pages" :key="page">
+          <span
+            v-for="page in pages"
+            :key="page"
+          >
             <Link
               :href="buildHref(page)"
               class="hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium focus:z-10 focus:outline-hidden focus:border-indigo-300 focus:ring-indigo active:bg-indigo-200 active:text-gray-700 transition ease-in-out duration-150 hover:bg-indigo-50"

--- a/resources/js/Shared/SeatPlusSelect.vue
+++ b/resources/js/Shared/SeatPlusSelect.vue
@@ -45,7 +45,16 @@
 import { computed, ref, watch } from "vue";
 import { usePage } from "@inertiajs/vue3";
 
-const props = defineProps(['modelValue', 'id']);
+const props = defineProps({
+    modelValue: {
+        type: [String, Number],
+        default: null,
+    },
+    id: {
+        type: String,
+        default: null,
+    },
+});
 
 const emit = defineEmits(['update:modelValue']);
 

--- a/resources/js/Shared/Time.vue
+++ b/resources/js/Shared/Time.vue
@@ -18,7 +18,8 @@ const props = defineProps({
     },
     format: {
         type: String,
-        required: false
+        required: false,
+        default: null
     },
 });
 

--- a/resources/js/Shared/Toasts/Toast.vue
+++ b/resources/js/Shared/Toasts/Toast.vue
@@ -32,19 +32,46 @@ const isError = ref(props.toast.appearance === 'error')
     <div class="p-4">
       <div class="flex items-start">
         <div class="shrink-0">
-          <CheckCircleIcon v-if="isSuccess" class="h-6 w-6 text-green-400" aria-hidden="true" />
-          <InformationCircleIcon v-if="isInfo" class="h-6 w-6 text-blue-400" aria-hidden="true" />
-          <ExclamationCircleIcon v-if="isWarning" class="h-6 w-6 text-amber-400" aria-hidden="true" />
-          <XCircleIcon v-if="isError" class="h-6 w-6 text-red-400" aria-hidden="true" />
+          <CheckCircleIcon
+            v-if="isSuccess"
+            class="h-6 w-6 text-green-400"
+            aria-hidden="true"
+          />
+          <InformationCircleIcon
+            v-if="isInfo"
+            class="h-6 w-6 text-blue-400"
+            aria-hidden="true"
+          />
+          <ExclamationCircleIcon
+            v-if="isWarning"
+            class="h-6 w-6 text-amber-400"
+            aria-hidden="true"
+          />
+          <XCircleIcon
+            v-if="isError"
+            class="h-6 w-6 text-red-400"
+            aria-hidden="true"
+          />
         </div>
         <div class="ml-3 w-0 flex-1 pt-0.5">
-          <p class="text-sm font-medium text-gray-900">{{ $trans(`web::notifications.${toast.appearance}`) }}</p>
-          <p class="mt-1 text-sm text-gray-500">{{ toast.message }}</p>
+          <p class="text-sm font-medium text-gray-900">
+            {{ $trans(`web::notifications.${toast.appearance}`) }}
+          </p>
+          <p class="mt-1 text-sm text-gray-500">
+            {{ toast.message }}
+          </p>
         </div>
         <div class="ml-4 flex shrink-0">
-          <button type="button" @click="remove" class="inline-flex rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+          <button
+            type="button"
+            class="inline-flex rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            @click="remove"
+          >
             <span class="sr-only">Close</span>
-            <XMarkIcon class="h-5 w-5" aria-hidden="true" />
+            <XMarkIcon
+              class="h-5 w-5"
+              aria-hidden="true"
+            />
           </button>
         </div>
       </div>

--- a/resources/js/Shared/Toasts/Toasts.vue
+++ b/resources/js/Shared/Toasts/Toasts.vue
@@ -45,20 +45,20 @@ const handleFlashMessages = async (flash) => {
   <div class="fixed inset-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end">
     <div class="max-w-sm w-full">
       <transition-group
-              tag="div"
-              :enter-active-class="visible.length > 1 ? 'transform ease-out delay-300 duration-300 transition': 'transform ease-out duration-300 transition'"
-              enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
-              enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
-              leave-active-class="transition ease-in duration-500"
-              leave-from-class="opacity-100"
-              leave-to-class="opacity-0"
-              move-class="transition ease-in-out duration-500"
+        tag="div"
+        :enter-active-class="visible.length > 1 ? 'transform ease-out delay-300 duration-300 transition': 'transform ease-out duration-300 transition'"
+        enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
+        enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
+        leave-active-class="transition ease-in duration-500"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+        move-class="transition ease-in-out duration-500"
       >
         <Toast
-                v-for="(toast, idx) in visible"
-                :key="toast.id"
-                :toast="toast"
-                :class="[{'mt-4': idx > 0 }]"
+          v-for="(toast, idx) in visible"
+          :key="toast.id"
+          :toast="toast"
+          :class="[{'mt-4': idx > 0 }]"
         />
       </transition-group>
     </div>


### PR DESCRIPTION
## What

Takes the web package's **Frontend Lint** to **zero warnings** across `resources/js` (was ~154). Two parts:

1. **Auto-fixable formatting** (`eslint --fix`, template-only): `vue/max-attributes-per-line` ("… should be on a new line"), `vue/html-indent`, content-newline, attribute/event hyphenation.
2. **Manual, behaviour-preserving fixes** for the ~41 warnings `--fix` can't resolve.

Runs against the **v10 ESLint toolchain** (matching CI), so `npm run lint` locally = CI. Independent of / rebased on the now-merged `<script setup>` migration.

## Manual fixes

- **`require-prop-types`** — add explicit `type:` to untyped props (`entry`→Object, `secondary`→Boolean, `characters`→Array, …).
- **`require-default-prop`** — add `default: null` to optional props (`label`, `format`, `selectedId`, `division`, `targetCorporation`, `application`, …).
- **`no-required-prop-with-default`** — make the prop optional (drop `required: true`, keep the default as fallback) → preserves behaviour.
- **`no-template-shadow`** — rename shadowing template locals (slot `selected` → `isSelected`; `v-for` `expression`/`job` → `cronExpression`/`jobName`).
- **`prop-name-casing`** — targeted `eslint-disable` **with reason** on the snake_case props that mirror the PHP→Inertia payload keys (`character_ids`, `ref_types`, `available_scopes`, `tailwind_class`, `location_id`). Renaming these would break the controller→component contract; per `CLAUDE.md` a project-wide camelCase move is a separate tracked effort. (See discussion below re: updating that guidance.)
- **`no-v-html`** — block `eslint-disable` **with reason** on the three intentional cases (mail HTML body; static / server-provided SVG icon markup).

## Result

`npm run lint` → **exit 0, no warnings.** No `<script>` logic changed except the behaviour-preserving prop-definition tidy-ups above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)