### PR TITLE
test(browser): add iPhone capture for recruitment update-character review

### DIFF
--- a/tests/Browser/RecruitmentLifecycleTest.php
+++ b/tests/Browser/RecruitmentLifecycleTest.php
@@ -269,7 +269,7 @@ it('reviews — the inspection tabs render the applicant\'s data', function (str
     snap($page, "recruitment-review-tab-contracts-{$device}");
 })->with(['desktop', 'iphone']);
 
-it('reviews — a reviewer dispatches an on-demand character update (fetch, no axios)', function () {
+it('reviews — a reviewer dispatches an on-demand character update (fetch, no axios)', function (string $device) {
     $character = actingAsCharacter();
     makeRecruiterOfCorporation($character, 'can accept or deny applications');
 
@@ -277,10 +277,10 @@ it('reviews — a reviewer dispatches an on-demand character update (fetch, no a
     $application = seedApplicantAtStage($character->corporation_id, 'Jane Applicant', stage: 0);
     cache()->flush();
 
-    // Desktop-only, like the tab test above. The applicant header renders an Update control per
-    // covered character; the migrated UpdateCharacterComponent dispatches the batch update via the
-    // native fetch (http.js + Wayfinder), not axios.
-    $page = visit("/recruitment/application/{$application->id}");
+    // The applicant header renders an Update control per covered character; the migrated
+    // UpdateCharacterComponent dispatches the batch update via the native fetch (http.js +
+    // Wayfinder), not axios. Captured on both viewports for the Desktop | iPhone matrix.
+    $page = deviceVisit($device, "/recruitment/application/{$application->id}");
     $page->assertNoSmoke();
     $page->waitForText('Jane Applicant');
 
@@ -291,5 +291,5 @@ it('reviews — a reviewer dispatches an on-demand character update (fetch, no a
     $page->waitForText('updating');
     $page->assertNoSmoke();
 
-    snap($page, 'recruitment-review-update-character-desktop');
-});
+    snap($page, "recruitment-review-update-character-{$device}");
+})->with(['desktop', 'iphone']);


### PR DESCRIPTION
## What

The Desktop | iPhone screenshot matrix was missing an **iPhone** cell for `recruitment-review-update-character`. That test (`reviews — a reviewer dispatches an on-demand character update`) was hardcoded **desktop-only** — it used `visit()` and a fixed `recruitment-review-update-character-desktop` snap name, unlike the sibling review-tabs test which is parametrized `->with(['desktop', 'iphone'])`.

## Change

Parametrize the test with `->with(['desktop', 'iphone'])` and drive the viewport via `deviceVisit($device, …)` (iPhone 15), exactly like the tabs test. The snap name becomes `recruitment-review-update-character-{$device}`.

- **Desktop snap name is unchanged** (`…-desktop`), so the existing desktop capture is unaffected.
- Adds the new `recruitment-review-update-character-iphone` capture. `snap()` is a screenshot artifact (`$page->screenshot`), not a baseline assertion, so there's nothing to commit and no comparison to break.

## Verification

- [x] `php -l` clean.
- [ ] Browser run (host / "Browser (vs core)" CI) — confirms the iPhone capture renders and the Update click/`updating` flow works at the mobile viewport (the Update control sits in the applicant review card, which stacks below the tabs on iPhone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)