### PR TITLE
fix(web): QueueStatsService degrades instead of 500-ing under a faked queue

### DIFF
--- a/src/Services/QueueStatsService.php
+++ b/src/Services/QueueStatsService.php
@@ -15,12 +15,19 @@ class QueueStatsService
      */
     public function get(): array
     {
-        return [
-            'queue_count' => collect(resolve(WorkloadRepository::class)->get())
-                ->sum('length'),
-            'error_count' => app(JobRepository::class)->countRecentlyFailed(),
-            'status' => $this->currentStatus(),
-        ];
+        try {
+            return [
+                'queue_count' => collect(resolve(WorkloadRepository::class)->get())
+                    ->sum('length'),
+                'error_count' => app(JobRepository::class)->countRecentlyFailed(),
+                'status' => $this->currentStatus(),
+            ];
+        } catch (\Throwable) {
+            // Best-effort widget: Horizon's workload/wait-time calc needs a real queue driver and a
+            // running Horizon. Under a faked or unavailable queue (tests use Queue::fake(), which has
+            // no RedisQueue::readyNow()) it throws — degrade to empty stats rather than 500 the page.
+            return ['queue_count' => 0, 'error_count' => 0, 'status' => 'inactive'];
+        }
     }
 
     private function currentStatus(): string

--- a/tests/Unit/Services/QueueStatsServiceTest.php
+++ b/tests/Unit/Services/QueueStatsServiceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Laravel\Horizon\Contracts\WorkloadRepository;
+use Seatplus\Web\Services\QueueStatsService;
+
+it('degrades to empty stats when the Horizon workload cannot be computed', function () {
+    // Horizon's WaitTimeCalculator needs a real queue driver; under Queue::fake() it calls
+    // QueueFake::readyNow() (which does not exist) and throws. The optional settings-page widget
+    // must degrade rather than 500 the whole Inertia response.
+    $mock = Mockery::mock(WorkloadRepository::class);
+    $mock->shouldReceive('get')->andThrow(new BadMethodCallException('Call to undefined method readyNow()'));
+    app()->instance(WorkloadRepository::class, $mock);
+
+    expect(app(QueueStatsService::class)->get())
+        ->toBe(['queue_count' => 0, 'error_count' => 0, 'status' => 'inactive']);
+});


### PR DESCRIPTION
## Problem

`SettingsNavigationTest` fails on **iPhone** with:
```
BadMethodCallException: Call to undefined method Illuminate\Support\Testing\Fakes\QueueFake::readyNow()
```

The settings-page **HorizonStats** widget polls the `queueStats` optional Inertia prop on mount. Resolving it runs `QueueStatsService::get()` → Horizon's `WaitTimeCalculator` → `RedisQueue::readyNow()`. Under `Queue::fake()` (all browser/feature tests) the queue is a `QueueFake`, which has no `readyNow()`, so it **throws and 500s** the Inertia response.

Desktop tolerated the background 500 (the test deliberately omits `assertNoSmoke`), but the iPhone `deviceVisit` (`PendingAwaitablePage`) surfaces it as a fatal navigation error → the page never renders "Available Settings".

Not a regression from the `<script setup>` migration — the HorizonStats poll is unchanged; this is inherent to `Queue::fake()` + Horizon's wait-time calc.

## Fix

A best-effort stats widget must never crash the page. Wrap `QueueStatsService::get()` so any Horizon error (faked/unavailable queue, Horizon not running) degrades to empty stats `{queue_count: 0, error_count: 0, status: 'inactive'}`. **Production behaviour is unchanged** (real Redis queue → real values). Adds a unit test that mocks `WorkloadRepository` to throw and asserts the graceful default.

Fixes the iPhone `SettingsNavigationTest` and removes the tolerated desktop 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)