### PR TITLE
fix(sso-settings): skip entities with a null id when saving SSO settings

### DIFF
--- a/src/Services/SsoSettings/UpdateOrCreateSsoSettings.php
+++ b/src/Services/SsoSettings/UpdateOrCreateSsoSettings.php
@@ -64,6 +64,10 @@ class UpdateOrCreateSsoSettings
                     $entity_id = Arr::get($entity, 'id');
                     $category = Arr::get($entity, 'category');
 
+                    if ($entity_id === null) {
+                        return;
+                    }
+
                     $morphable_type = match ($category) {
                         'corporation' => CorporationInfo::class,
                         'alliance' => AllianceInfo::class,

--- a/tests/Unit/Services/SsoSettings/UpdateOrCreateSsoSettingsTest.php
+++ b/tests/Unit/Services/SsoSettings/UpdateOrCreateSsoSettingsTest.php
@@ -67,6 +67,31 @@ it('calls corporation info action', function () {
     expect(SsoScopes::where('morphable_id', 1_184_675_423)->first()->selected_scopes)->toHaveCount(3);
 });
 
+it('skips entities without an id', function () {
+    Bus::fake();
+
+    $request = [
+        'selectedEntities' => [
+            [
+                'corporation_id' => null,
+                'id' => null,
+                'name' => 'Amok.',
+                'category' => 'corporation',
+            ],
+        ],
+        'selectedScopes' => [
+            'esi-assets.read_assets.v1,esi-universe.read_structures.v1',
+            'publicData',
+        ],
+        'type' => 'default',
+    ];
+
+    (new UpdateOrCreateSsoSettings($request))->execute();
+
+    Bus::assertNotDispatched(CorporationInfoJob::class);
+    Bus::assertNotDispatched(AllianceInfoJob::class);
+});
+
 /**
  * @runInSeparateProcess
  *


### PR DESCRIPTION
## Problem

Saving SSO settings could throw a production `TypeError`:

```
DispatchCorporationOrAllianceInfoJob::handle(): Argument #2 ($id) must be of type int, null given
```

`DispatchCorporationOrAllianceInfoJob::handle(string $type, int $id)` (`src/Services/DispatchCorporationOrAllianceInfoJob.php:35`) declares a **non-nullable** `int $id`.

In `src/Services/SsoSettings/UpdateOrCreateSsoSettings::execute()`, the per-entity closure computes:

- `$entity_id = Arr::get($entity, 'id')` (line 64) — can be `null`
- `$morphable_type` from the category (lines 67-71)

A null `morphable_type` was already guarded (early `return`, lines 73-75), but a valid `corporation`/`alliance` category with a **null id** still fell through to the `handle($morphable_type, $entity_id)` call (line 77), passing `null` into the non-nullable `int $id` → `TypeError`. It would also have written a half-formed `SsoScopes` row with `morphable_id = null` (lines 79-85).

## Fix

Add a null-id guard immediately after `$entity_id`/`$category` are read, mirroring the existing null-`morphable_type` guard exactly:

```php
if ($entity_id === null) {
    return;
}
```

The entity is skipped: no job dispatched, no `SsoScopes` row written.

## Why the valid path is unchanged

The guard only short-circuits entities whose `id` is `null`. Entities with a real id skip the guard and reach the unchanged dispatch + `updateOrCreate` code, so existing behaviour for valid corp/alliance entities is identical (covered by the existing "calls alliance/corporation info action" and "creates sso settings" tests).

## Tests

Added a DB-free unit test `it('skips entities without an id')` asserting no `CorporationInfoJob`/`AllianceInfoJob` is dispatched for a null-id entity (uses `Bus::fake()`, no DB access on the guarded path). DB-backed tests deferred to CI.

## Gate results

- `vendor/bin/pint` — passed
- `vendor/bin/pint --test` — passed
- `php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress` — `[OK] No errors`
- pest not run locally (DB unreachable in dev container); DB tests deferred to CI.

Closes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)