### PR TITLE
refactor: fix GetAffiliatedIds DI violation and remove dead ?User params

### DIFF
--- a/src/Http/Controllers/Employment/ObservationController.php
+++ b/src/Http/Controllers/Employment/ObservationController.php
@@ -41,7 +41,7 @@ class ObservationController extends Controller
                 ! $user->can('superuser'),
                 fn (Builder $query) => $query->whereIn(
                     'corporation_infos.corporation_id',
-                    (new GetAffiliatedIds($user))->get(permissions: self::PERMISSION, corporationRoles: 'director'),
+                    (new GetAffiliatedIds)->get(permissions: self::PERMISSION, corporationRoles: 'director'),
                 ),
             )
             ->get(['name', 'corporation_id', 'ticker']);
@@ -119,7 +119,7 @@ class ObservationController extends Controller
             return;
         }
 
-        $observableIds = (new GetAffiliatedIds($user))->get(permissions: self::PERMISSION, corporationRoles: 'director');
+        $observableIds = (new GetAffiliatedIds)->get(permissions: self::PERMISSION, corporationRoles: 'director');
 
         abort_unless(in_array($corporation_id, $observableIds), 403, 'You may not observe this corporation.');
     }

--- a/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
+++ b/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
@@ -32,7 +32,6 @@ class ManageRecruitmentController extends Controller
         $manageableIds = $this->getAffiliatedIds->get(
             permissions: [self::MANAGE_PERMISSION],
             corporationRoles: ['Director'],
-            user: $user,
         );
 
         $postings = Enlistment::query()

--- a/src/Http/Controllers/Recruitment/PostingController.php
+++ b/src/Http/Controllers/Recruitment/PostingController.php
@@ -139,7 +139,6 @@ class PostingController extends Controller
         $manageableIds = $this->getAffiliatedIds->get(
             permissions: [ManageRecruitmentController::MANAGE_PERMISSION],
             corporationRoles: ['Director'],
-            user: $user,
         );
 
         abort_unless(in_array($corporationId, $manageableIds), 403, 'You may not manage this corporation.');

--- a/src/Http/Controllers/Recruitment/ReviewInboxController.php
+++ b/src/Http/Controllers/Recruitment/ReviewInboxController.php
@@ -36,7 +36,6 @@ class ReviewInboxController extends Controller
         $recruiterCorpIds = $this->getAffiliatedIds->get(
             permissions: [self::RECRUITER_PERMISSION],
             corporationRoles: ['Director'],
-            user: $user,
         );
 
         $applications = Application::query()

--- a/src/Http/Middleware/CheckAffiliationForApplication.php
+++ b/src/Http/Middleware/CheckAffiliationForApplication.php
@@ -51,7 +51,6 @@ class CheckAffiliationForApplication
         $affiliatedIds = $this->getAffiliatedIdsService->get(
             permissions: [$permission],
             corporationRoles: ['director'],
-            user: auth()->user(),
         );
 
         $application = Application::query()

--- a/src/Services/Affiliations/GetCorporationMemberComplianceAffiliatedIdsService.php
+++ b/src/Services/Affiliations/GetCorporationMemberComplianceAffiliatedIdsService.php
@@ -15,7 +15,7 @@ class GetCorporationMemberComplianceAffiliatedIdsService
 
     public static function make(): self
     {
-        return new self(new GetAffiliatedIds(auth()->user()));
+        return new self(new GetAffiliatedIds);
     }
 
     public function getQuery(): Builder

--- a/src/Services/GetAffiliatedIds.php
+++ b/src/Services/GetAffiliatedIds.php
@@ -34,10 +34,8 @@ class GetAffiliatedIds
     private const string DIRECTOR_ROLE = 'Director';
 
     public function __construct(
-        private ?User $user = null,
         private ?CanUserService $canUserService = null
     ) {
-        $this->user = $user ?? auth()->user();
         $this->canUserService = $canUserService ?? new CanUserService;
     }
 
@@ -49,15 +47,15 @@ class GetAffiliatedIds
     public function get(
         string|array $permissions,
         string|array $corporationRoles = [],
-        ?User $user = null
     ): array {
         $normalized_permissions = $this->normalizeInput($permissions);
         $normalizedRoles = $this->normalizeInput($corporationRoles);
+
+        // A Director always manages their corporation, so the role is implicitly in scope for every
+        // affiliation lookup regardless of the corporation roles the caller asked for.
         $normalizedRoles[] = self::DIRECTOR_ROLE;
 
-        $this->user = $user ?? $this->user;
-
-        return (new self($user))->collectAffiliatedIds($normalized_permissions, $normalizedRoles);
+        return $this->collectAffiliatedIds($normalized_permissions, $normalizedRoles);
     }
 
     /**
@@ -70,8 +68,8 @@ class GetAffiliatedIds
     public function ownedCharacterIds(?User $user = null): array
     {
         // Re-resolve auth() at call time: a container-injected instance may have been
-        // built before the auth middleware ran, leaving $this->user null.
-        $user = $user ?? $this->user ?? auth()->user();
+        // built before the auth middleware ran.
+        $user = $user ?? auth()->user();
 
         return data_get($this->canUserService->getUserPermissionObject($user), 'owned_character_ids', []);
     }
@@ -83,7 +81,9 @@ class GetAffiliatedIds
      */
     private function collectAffiliatedIds(array $permissions, array $corporationRole): array
     {
-        $userPermission = $this->canUserService->getUserPermissionObject($this->user);
+        // Resolve auth() at call time rather than in the constructor: a container-injected instance
+        // may have been built before the auth middleware ran.
+        $userPermission = $this->canUserService->getUserPermissionObject(auth()->user());
 
         return array_merge(
             $this->getPermissionBasedIds($permissions, $userPermission),

--- a/src/Services/GetRecruitIdsService.php
+++ b/src/Services/GetRecruitIdsService.php
@@ -61,7 +61,6 @@ class GetRecruitIdsService
         $affiliated_ids = $this->affiliatedIdsService->get(
             self::PERMISSION,
             self::CORPORATION_ROLE,
-            auth()->user()
         );
 
         return $this->getCachedRecruits($affiliated_ids);


### PR DESCRIPTION
## Summary

Fixes three defects in `src/Services/GetAffiliatedIds.php` (absorbs #1480 and #1484). No behaviour change — the same affiliated ids are returned.

### The three defects & fixes

1. **DI violation (#1480).** `get()` did `return (new self($user))->collectAffiliatedIds(...)`, constructing a fresh instance and **discarding the container-injected `CanUserService`**. `$this->canUserService` was never used. Fixed by calling `$this->collectAffiliatedIds(...)` on the already-injected instance.
2. **Dead mutation (#1480).** `$this->user = $user ?? $this->user;` was immediately thrown away by the `new self()` on the next line. Removed.
3. **Unused `?User` params (#1480 + #1484).** Removed the unused 3rd `?User $user` param on `get()` **and** the dead `private ?User $user` constructor param. The user is now resolved lazily via `auth()->user()` inside `collectAffiliatedIds()` / `ownedCharacterIds()` at call time (post-auth-middleware).

**Why removing the constructor param is required, not optional churn:** the old `new self($user)` was accidentally masking the container auto-wire bug noted in #1484 — when Laravel auto-wires `GetAffiliatedIds` (constructor injection into controllers/middleware), it resolves `?User $user = null` as an empty `new User()`, so `$this->user` was an id-less model. `new self()` rebuilt the instance with the (usually null) `get()` arg, falling back to `auth()->user()`. Removing `new self()` without removing the constructor param would have surfaced that empty user in `collectAffiliatedIds()`. Resolving `auth()->user()` lazily eliminates the whole class of problem.

## Consumer map (proves the signature change is safe)

Callers of `->get()` that passed the now-removed 3rd `user:` / `$user` arg — **every one passed `auth()->user()`**, identical to the lazy fallback:

| Caller | How it reached `get()` | Arg passed | Updated |
|---|---|---|---|
| `Http/Middleware/CheckAffiliationForApplication` | container-injected | `user: auth()->user()` | ✅ removed |
| `Services/GetRecruitIdsService` | manual `new GetAffiliatedIds` | `auth()->user()` | ✅ removed |
| `Http/Controllers/Recruitment/ManageRecruitmentController` | inherited `$this->getAffiliatedIds` | `user: $user` (=`auth()->user()`) | ✅ removed |
| `Http/Controllers/Recruitment/PostingController` | inherited `$this->getAffiliatedIds` | `user: $user` (=`auth()->user()`) | ✅ removed |
| `Http/Controllers/Recruitment/ReviewInboxController` | inherited `$this->getAffiliatedIds` | `user: $user` (=`auth()->user()`) | ✅ removed |

Callers that constructed `new GetAffiliatedIds($user)` — **both passed `auth()->user()`**, now the implicit resolution:

| Caller | Arg | Updated |
|---|---|---|
| `Http/Controllers/Employment/ObservationController` (×2) | `$user` (=`auth()->user()`) | ✅ `new GetAffiliatedIds` |
| `Services/Affiliations/GetCorporationMemberComplianceAffiliatedIdsService` | `auth()->user()` | ✅ `new GetAffiliatedIds` |

Untouched (already correct — no user arg): `Http/Controllers/Controller`, `Http/Actions/Shared/GetAffiliatedEntitiesAction`, `Http/Controllers/Queue/DispatchJobController` (incl. `ownedCharacterIds()` with no arg), `Http/Controllers/Request/DispatchIndividualJob`.

No caller in `packages/auth` or `packages/eveapi` references `GetAffiliatedIds` (web-only service). The one test touching it (`tests/Feature/Controller/DispatchJobControllerTest`) mocks `get`/`ownedCharacterIds` via Mockery and is signature-agnostic — no update needed.

## Gate results

- `vendor/bin/pint` — passed
- `vendor/bin/pint --test` — passed
- `php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress` — **[OK] No errors** (phpstan also flagged the 3 Recruitment controllers, which the initial class-name grep missed because they use the inherited `$this->getAffiliatedIds`)

DB tests deferred to CI (Postgres unreachable locally; running them risks the dev DB).

Closes #1480
Closes #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)