### PR TITLE
perf(sidebar): resolve menu visibility natively, without CanUserService (Phase E)

### DIFF
--- a/src/Services/Sidebar/SidebarPermissionChecker.php
+++ b/src/Services/Sidebar/SidebarPermissionChecker.php
@@ -29,26 +29,47 @@ namespace Seatplus\Web\Services\Sidebar;
 use Illuminate\Database\Eloquent\Builder;
 use Seatplus\Auth\Models\AccessControl\RoleMembership;
 use Seatplus\Auth\Models\User;
-use Seatplus\Auth\Services\Permissions\CanUserService;
-use Seatplus\Auth\Services\Permissions\DTO\ValidateIdsDTO;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Web\Services\HasCharacterNecessaryRole;
 
 class SidebarPermissionChecker
 {
     public function __construct(
         private readonly User $user,
-        private ?CanUserService $canUserService = null,
     ) {
-        $this->canUserService = $canUserService ?? new CanUserService;
+        // eager-load once so the corporation-role check below never lazy-loads per character
+        $this->user->loadMissing('characters.roles');
     }
 
+    /**
+     * Whether a sidebar entry should be shown: a superuser sees everything (the `Gate::before` rule),
+     * the user holds one of the permissions (Spatie), or one of their characters holds one of the required
+     * in-game corporation roles (Director always matches).
+     *
+     * @param  string|array<int,string>  $permissions
+     * @param  string|array<int,string>  $characterRoles
+     */
     public function hasPermissionOrCorporationRole(string|array $permissions, string|array $characterRoles = ''): bool
     {
-        return $this->canUserService->check(
-            user: $this->user,
-            idsDTO: (new ValidateIdsDTO),
-            permissions: $this->normalizeInput($permissions),
-            corporation_roles: $this->normalizeInput($characterRoles),
-        );
+        // superuser short-circuits via the Gate::before rule; safe even if the permission is unregistered
+        if ($this->user->can('superuser')) {
+            return true;
+        }
+
+        $permissions = $this->normalizeInput($permissions);
+
+        if ($permissions !== [] && $this->user->hasAnyPermission($permissions)) {
+            return true;
+        }
+
+        $characterRoles = $this->normalizeInput($characterRoles);
+
+        if ($characterRoles === []) {
+            return false;
+        }
+
+        return $this->user->characters
+            ->contains(fn (CharacterInfo $character) => HasCharacterNecessaryRole::check($character, $characterRoles));
     }
 
     public function isRoleModerator(): bool

--- a/tests/Feature/SidebarTest.php
+++ b/tests/Feature/SidebarTest.php
@@ -8,6 +8,15 @@ beforeEach(function () {
     test()->test_character->roles()->update(['roles' => ['']]);
 });
 
+test('rendering the sidebar does not build the heavy user_permissions cache', function () {
+    test()->actingAs(test()->test_user);
+
+    (new SidebarEntries)->getFilteredEntries();
+
+    // the sidebar now checks permissions/corp-roles directly, without CanUserService::getUserPermissionObject()
+    expect(cache()->has('user_permissions_'.test()->test_user->id))->toBeFalse();
+});
+
 test('user without superuser does not see access control', function () {
     test()->actingAs(test()->test_user);
 


### PR DESCRIPTION
## Context

The `sidebar` Inertia shared prop (`HandleInertiaRequests::share`) runs **~9 `CanUserService::check()` calls per authenticated page load** — one per menu entry that has a `permission`. Each goes `SidebarPermissionChecker::hasPermissionOrCorporationRole → CanUserService::check()` with an **empty** `ValidateIdsDTO`, which builds/reads the heavy `user_permissions_{id}` object just to answer "has this permission OR this in-game corp role". Menu visibility doesn't need the authorization pipeline.

Independent of the auth `AffiliationResolver` work (doesn't touch it); web-only, base `5.x`.

## What this does

`SidebarPermissionChecker` no longer depends on `CanUserService`. `hasPermissionOrCorporationRole()` now:
- **superuser** short-circuits via `$user->can('superuser')` (the `Gate::before` rule in auth's `AuthenticationServiceProvider`; safe even if the permission is unregistered — the hook catches `PermissionDoesNotExist`),
- **permission** via Spatie's native `$user->hasAnyPermission($permissions)`,
- **corp role** via the existing web `HasCharacterNecessaryRole::check()` across `$user->characters` (Director always matches; role names `ucfirst`-normalized),
- one `$user->loadMissing('characters.roles')` instead of the full `user_permissions` build. `isRoleModerator()` is unchanged.

The constructor's unused optional `CanUserService` parameter is dropped (only caller is `SidebarEntries`, which passes just the user).

## Behaviour

Equivalent to before: **superuser OR permission OR any-character-corp-role OR (Access Control) moderator**. Two incidental improvements: the sidebar stops touching the `user_permissions` cache, and lowercase config role names like `'director'` now match directly (previously only saved by the hardcoded `Director` short-circuit).

> Design note: I used Spatie's `hasAnyPermission()` + `can('superuser')` (mirroring the old `validateSimplePermissions` + `check()`'s superuser tail) rather than Gate-aware `canAny($permissions)`. The existing code deliberately uses `hasAnyPermission` for permissions and `can()` only for `superuser`, which indicates plain Spatie permission names are not registered as Gate abilities here — so `canAny` on a permission name could silently under-grant. This keeps it behaviour-identical.

## Tests / verification

Existing `tests/Feature/SidebarTest.php` (superuser / view-access-control / director / accountant cases) covers the behaviour; added a regression test asserting the sidebar render no longer creates a `user_permissions_{id}` cache entry. Pint passes.

⚠️ **I could not run the web PHP suite locally** (the dev-container's web `vendor` is a symlink to the shared vendor, so a worktree autoloads the main checkout's `src`, not this branch's). Please run `SidebarTest` on the host / in CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)