### PR TITLE
chore(deps): require auth + eveapi ^5.0 (resolve affiliated ids live)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "php": "^8.5",
         "laravel/framework": "^13.0",
         "laravel/socialite": "^5.0",
-        "seatplus/eveapi": "^4.2.0",
-        "seatplus/auth": "^4.2",
+        "seatplus/eveapi": "^5.0",
+        "seatplus/auth": "^5.0",
         "inertiajs/inertia-laravel": "^3.0",
         "laravel/wayfinder": "^0.1.16"
     },

--- a/src/Services/GetAffiliatedIds.php
+++ b/src/Services/GetAffiliatedIds.php
@@ -28,6 +28,7 @@ namespace Seatplus\Web\Services;
 
 use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Permissions\CanUserService;
+use Seatplus\Auth\Services\Roles\AffiliationResolver;
 
 class GetAffiliatedIds
 {
@@ -111,15 +112,37 @@ class GetAffiliatedIds
     }
 
     /**
+     * Resolve the affiliated ids granted by the given permissions live, via {@see AffiliationResolver}.
+     *
+     * The cached permission object no longer carries a materialised `permissions` id-array slice (removed in
+     * auth 5.0); it carries `permission_roles` (permission → the ids of the user's roles that grant it). We
+     * union those role ids and enumerate their affiliated character/corporation/alliance ids through the
+     * resolver's set-based subqueries — the conflated, cross-id-space array shape the consumers expect.
+     *
      * @param  array<int,string>  $permissions
      * @return array<int,int>
      */
     private function getPermissionBasedIds(array $permissions, array $userPermission): array
     {
-        return collect($permissions)
-            ->map(fn (string $permission) => data_get($userPermission, "permissions.$permission", []))
-            ->collapse()
-            ->toArray();
+        $roleIds = collect($permissions)
+            ->flatMap(fn (string $permission) => data_get($userPermission, "permission_roles.$permission", []))
+            ->unique()
+            ->values()
+            ->all();
+
+        if ($roleIds === []) {
+            return [];
+        }
+
+        $resolver = new AffiliationResolver;
+
+        $affiliatedIds = array_merge(
+            $resolver->characterIdsSubquery($roleIds)->pluck('affiliated_id')->all(),
+            $resolver->corporationIdsSubquery($roleIds)->pluck('affiliated_id')->all(),
+            $resolver->allianceIdsSubquery($roleIds)->pluck('affiliated_id')->all(),
+        );
+
+        return array_map('intval', $affiliatedIds);
     }
 
     /**


### PR DESCRIPTION
## Why

Closes the last link of the 5.x alignment chain. `auth` 5.0 reworked affiliation/permission resolution: the cached `user_permissions_{id}` object **no longer carries the materialised `permissions` (permission → affiliated-id array) slice**. It now carries `permission_roles` (permission → the ids of the user's roles that grant it), and affiliation is resolved live in set-based SQL via `AffiliationResolver`.

`eveapi` 5.0 is a non-breaking alignment major.

## What

- **Bump** `seatplus/auth ^4.2 → ^5.0` and `seatplus/eveapi ^4.2.0 → ^5.0`.
- **Rewire `GetAffiliatedIds::getPermissionBasedIds()`** — the sole web reader of the removed slice — off `permissions.$permission` and onto `permission_roles.$permission`, unioning the granting role ids and enumerating their affiliated character/corporation/alliance ids through the resolver's `characterIdsSubquery()` / `corporationIdsSubquery()` / `allianceIdsSubquery()` façades.

The public `GetAffiliatedIds::get()` still returns the same conflated, cross-id-space `int[]`, so the ~15 downstream consumers (Controller filter, CheckAffiliationForApplication, GetAffiliatedEntitiesAction, Observation, DispatchJob/DispatchIndividualJob, GetRecruitIdsService, GetCorporationMemberComplianceAffiliatedIdsService, …) keep their existing contract unchanged.

## Not in scope (follow-up)

The enumeration façades are `->pluck()`-ed to arrays here to preserve the current shape — the same materialisation profile the removed cache slice had. Pushing the *subquery* form all the way into the enumeration consumers as `whereIn($col, $subquery)` (so inverse/alliance roles never materialise the universe in PHP) is a separate **perf** refactor: each consumer needs its OR-predicates wrapped in a nested closure to avoid boolean-precedence auth-bypass, and it can't be validated in the dev container (web vendor is a symlink). Kept out of this correctness/bump PR deliberately.

## Testing

Can't run web's suite locally (vendor symlink); relies on CI (Frontend Lint) + the "Browser (vs core)" job, which does the real fresh `auth ^5` / `eveapi ^5` install. `composer validate` passes; Pint passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)