### PR TITLE
perf(affiliation): compose affiliated-id filters as SQL subqueries, not materialised arrays

### DIFF
--- a/src/Http/Actions/Character/Asset/GetLocationTopLevelAssetsAction.php
+++ b/src/Http/Actions/Character/Asset/GetLocationTopLevelAssetsAction.php
@@ -17,7 +17,7 @@ use Seatplus\Web\Services\Query\TypeWatchListScope;
  *    `WHERE item_id IN (SELECT DISTINCT root_item_id WHERE root_location_id = :loc AND <filter>)`.
  *  - unfiltered: the location's direct children (`location_id = :loc`).
  *
- * `character_ids` must already be the authorised set (AssetsController scopes it via getCharacterIds);
+ * `character_ids` must already be the authorised set (AssetsController scopes it via GetAffiliatedIds::constrainToSelectionOrOwned);
  * every query is hard-scoped to it, so an arbitrary location_id can only ever return authorised assets.
  */
 class GetLocationTopLevelAssetsAction

--- a/src/Http/Actions/Shared/GetAffiliatedEntitiesAction.php
+++ b/src/Http/Actions/Shared/GetAffiliatedEntitiesAction.php
@@ -26,11 +26,17 @@ class GetAffiliatedEntitiesAction
 
     public function characters(string $permission, ?string $search = null): AnonymousResourceCollection
     {
-        $affiliatedIds = $this->getAffiliatedIds->get($permission);
         $ownedCharacterIds = auth()->user()->characters->pluck('character_id')->toArray();
         $recruitIds = GetRecruitIdsService::get();
 
-        $query = $this->characterInfoQuery($affiliatedIds, $search)
+        // The affiliated branch is composed as a subquery (never materialising the affiliated set);
+        // the recruit + owned branches are already small bounded arrays.
+        $affiliatedQuery = CharacterInfo::query()
+            ->when($search, fn (Builder $query) => $query->where('character_infos.name', 'like', "%{$search}%"))
+            ->orderBy('character_infos.name');
+        $this->getAffiliatedIds->scope($affiliatedQuery, 'character_id', $permission);
+
+        $query = $affiliatedQuery
             ->union($this->characterInfoQuery($recruitIds, $search))
             ->union($this->characterInfoQuery($ownedCharacterIds, $search))
             ->distinct()
@@ -46,16 +52,13 @@ class GetAffiliatedEntitiesAction
      */
     public function corporations(string $permission, array $corporationRoles = [], ?string $search = null): AnonymousResourceCollection
     {
-        $affiliatedIds = $this->getAffiliatedIds->get($permission, $corporationRoles);
-
         $query = CorporationInfo::query()
-            ->whereIn('corporation_id', $affiliatedIds)
             ->select('corporation_infos.*')
             ->when($search, fn (Builder $query) => $query->where('name', 'like', "%{$search}%"))
-            ->with('alliance')
-            ->get();
+            ->with('alliance');
+        $this->getAffiliatedIds->scope($query, 'corporation_id', $permission, $corporationRoles);
 
-        return CorporationInfoRessource::collection($query);
+        return CorporationInfoRessource::collection($query->get());
     }
 
     private function characterInfoQuery(array $ids, ?string $search = null): Builder

--- a/src/Http/Actions/Shared/GetAffiliatedEntitiesAction.php
+++ b/src/Http/Actions/Shared/GetAffiliatedEntitiesAction.php
@@ -34,7 +34,7 @@ class GetAffiliatedEntitiesAction
         $affiliatedQuery = CharacterInfo::query()
             ->when($search, fn (Builder $query) => $query->where('character_infos.name', 'like', "%{$search}%"))
             ->orderBy('character_infos.name');
-        $this->getAffiliatedIds->scope($affiliatedQuery, 'character_id', $permission);
+        $this->getAffiliatedIds->constrainToAffiliated($affiliatedQuery, 'character_id', $permission);
 
         $query = $affiliatedQuery
             ->union($this->characterInfoQuery($recruitIds, $search))
@@ -56,7 +56,7 @@ class GetAffiliatedEntitiesAction
             ->select('corporation_infos.*')
             ->when($search, fn (Builder $query) => $query->where('name', 'like', "%{$search}%"))
             ->with('alliance');
-        $this->getAffiliatedIds->scope($query, 'corporation_id', $permission, $corporationRoles);
+        $this->getAffiliatedIds->constrainToAffiliated($query, 'corporation_id', $permission, $corporationRoles);
 
         return CorporationInfoRessource::collection($query->get());
     }

--- a/src/Http/Controllers/Character/AssetsController.php
+++ b/src/Http/Controllers/Character/AssetsController.php
@@ -48,7 +48,16 @@ class AssetsController extends Controller
     public function index(Request $request, GetCharacterAssetLocationAction $action, GetAssetLocationFilterOptionsAction $filterOptionsAction): Response
     {
         $dispatchTransferObject = $this->getDispatchTransferObject();
-        $characterIds = $this->getCharacterIds($dispatchTransferObject, 'assets');
+
+        $characterIdQuery = CharacterInfo::query()->select('character_id');
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $characterIdQuery,
+            column: 'character_id',
+            selectedIds: $request->input('character_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+        $characterIds = $characterIdQuery->pluck('character_id');
 
         // Filters + (a subset of) character scope come from the page query. Constrain requested
         // character_ids to the authorised set; default to all of it.
@@ -79,14 +88,24 @@ class AssetsController extends Controller
     /**
      * A single location's top-level items (filtered-top-level via root_item_id), paginated and
      * lazy-loaded when the location scrolls into view. Authorised identically to index(): the
-     * requested character_ids are intersected with getCharacterIds('assets') — own + assets-
-     * permission-affiliated (corp/alliance member management) + Director + superuser (+ recruits
-     * once impersonated) — and the query is hard-scoped to that set, so an arbitrary location_id
-     * or character_id can only ever return authorised assets.
+     * requested character_ids are intersected with the affiliation-scoped set (own + assets-
+     * permission-affiliated (corp/alliance member management) + Director + superuser) resolved via
+     * GetAffiliatedIds::constrainToSelectionOrOwned — and the query is hard-scoped to that set, so an
+     * arbitrary location_id or character_id can only ever return authorised assets.
      */
     public function location(int $location_id, Request $request, GetLocationTopLevelAssetsAction $action): JsonResponse
     {
-        $authorized = $this->getCharacterIds($this->getDispatchTransferObject(), 'assets');
+        $dispatchTransferObject = $this->getDispatchTransferObject();
+
+        $characterIdQuery = CharacterInfo::query()->select('character_id');
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $characterIdQuery,
+            column: 'character_id',
+            selectedIds: $request->input('character_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+        $authorized = $characterIdQuery->pluck('character_id');
 
         $requested = collect($request->input('character_ids'))->map(fn (mixed $id): int => (int) $id)->filter();
 

--- a/src/Http/Controllers/Character/ContactsController.php
+++ b/src/Http/Controllers/Character/ContactsController.php
@@ -26,6 +26,7 @@
 
 namespace Seatplus\Web\Http\Controllers\Character;
 
+use Illuminate\Database\Eloquent\Builder;
 use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
@@ -44,12 +45,21 @@ class ContactsController extends Controller
         $dispatchTransferObject = CreateDispatchTransferObject::new()
             ->create(Contact::class);
 
-        $ids = request('character_ids', $this->getAffiliatedIds($dispatchTransferObject));
-
+        // A requested character_ids filter is honoured verbatim (unchanged behaviour); otherwise the
+        // authorised set is composed as a subquery instead of a materialised affiliated-id array.
         $characters = CharacterInfo::query()
             ->has('contacts')
-            ->whereIn('character_id', $ids)
             ->with('characterAffiliation')
+            ->when(
+                request()->has('character_ids'),
+                fn (Builder $query) => $query->whereIn('character_id', (array) request('character_ids')),
+                fn (Builder $query) => $this->getAffiliatedIds->scope(
+                    query: $query,
+                    column: 'character_id',
+                    permissions: $dispatchTransferObject->permission,
+                    corporationRoles: $dispatchTransferObject->required_corporation_role,
+                ),
+            )
             ->get()
             ->each->append('corporation_id');
 

--- a/src/Http/Controllers/Character/ContactsController.php
+++ b/src/Http/Controllers/Character/ContactsController.php
@@ -26,7 +26,6 @@
 
 namespace Seatplus\Web\Http\Controllers\Character;
 
-use Illuminate\Database\Eloquent\Builder;
 use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
@@ -45,26 +44,27 @@ class ContactsController extends Controller
         $dispatchTransferObject = CreateDispatchTransferObject::new()
             ->create(Contact::class);
 
-        // Always hard-scope to the authorised set (composed as a subquery, not a materialised
-        // affiliated-id array); a requested character_ids filter only narrows *within* that set. This
-        // route has no CheckAuthorization middleware, so the query is the sole tamper guard — a
-        // character_ids the user isn't affiliated with must never leak through.
+        // Default view = the user's own characters; an explicit character_ids selection is honoured
+        // only within the authorised set (own ∪ affiliated, composed as a subquery). This route has no
+        // CheckAuthorization middleware, so the query is the sole tamper guard — a character_ids the
+        // user isn't affiliated with must never leak through.
         $query = CharacterInfo::query()
             ->has('contacts')
             ->with('characterAffiliation');
 
-        $this->getAffiliatedIds->scope(
-            query: $query,
-            column: 'character_id',
-            permissions: $dispatchTransferObject->permission,
-            corporationRoles: $dispatchTransferObject->required_corporation_role,
-        );
+        if (request()->has('character_ids')) {
+            $this->getAffiliatedIds->scope(
+                query: $query,
+                column: 'character_id',
+                permissions: $dispatchTransferObject->permission,
+                corporationRoles: $dispatchTransferObject->required_corporation_role,
+            );
+            $query->whereIn('character_id', (array) request('character_ids'));
+        } else {
+            $this->getAffiliatedIds->scopeOwned($query, 'character_id');
+        }
 
         $characters = $query
-            ->when(
-                request()->has('character_ids'),
-                fn (Builder $query) => $query->whereIn('character_id', (array) request('character_ids')),
-            )
             ->get()
             ->each->append('corporation_id');
 

--- a/src/Http/Controllers/Character/ContactsController.php
+++ b/src/Http/Controllers/Character/ContactsController.php
@@ -52,17 +52,13 @@ class ContactsController extends Controller
             ->has('contacts')
             ->with('characterAffiliation');
 
-        if (request()->has('character_ids')) {
-            $this->getAffiliatedIds->scope(
-                query: $query,
-                column: 'character_id',
-                permissions: $dispatchTransferObject->permission,
-                corporationRoles: $dispatchTransferObject->required_corporation_role,
-            );
-            $query->whereIn('character_id', (array) request('character_ids'));
-        } else {
-            $this->getAffiliatedIds->scopeOwned($query, 'character_id');
-        }
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $query,
+            column: 'character_id',
+            selectedIds: request('character_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
 
         $characters = $query
             ->get()

--- a/src/Http/Controllers/Character/ContactsController.php
+++ b/src/Http/Controllers/Character/ContactsController.php
@@ -45,20 +45,25 @@ class ContactsController extends Controller
         $dispatchTransferObject = CreateDispatchTransferObject::new()
             ->create(Contact::class);
 
-        // A requested character_ids filter is honoured verbatim (unchanged behaviour); otherwise the
-        // authorised set is composed as a subquery instead of a materialised affiliated-id array.
-        $characters = CharacterInfo::query()
+        // Always hard-scope to the authorised set (composed as a subquery, not a materialised
+        // affiliated-id array); a requested character_ids filter only narrows *within* that set. This
+        // route has no CheckAuthorization middleware, so the query is the sole tamper guard — a
+        // character_ids the user isn't affiliated with must never leak through.
+        $query = CharacterInfo::query()
             ->has('contacts')
-            ->with('characterAffiliation')
+            ->with('characterAffiliation');
+
+        $this->getAffiliatedIds->scope(
+            query: $query,
+            column: 'character_id',
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+
+        $characters = $query
             ->when(
                 request()->has('character_ids'),
                 fn (Builder $query) => $query->whereIn('character_id', (array) request('character_ids')),
-                fn (Builder $query) => $this->getAffiliatedIds->scope(
-                    query: $query,
-                    column: 'character_id',
-                    permissions: $dispatchTransferObject->permission,
-                    corporationRoles: $dispatchTransferObject->required_corporation_role,
-                ),
             )
             ->get()
             ->each->append('corporation_id');

--- a/src/Http/Controllers/Character/ContractsController.php
+++ b/src/Http/Controllers/Character/ContractsController.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Contracts\Contract;
 use Seatplus\Web\Http\Controllers\Controller;
 use Seatplus\Web\Http\Resources\ContractRessource;
@@ -46,9 +46,9 @@ class ContractsController extends Controller
         // Default view = own characters; a submitted character_ids selection is honoured only within the
         // authorised set (own ∪ affiliated). This route has no CheckAuthorization middleware, so the
         // query is the sole guard — previously a submitted character_ids was used verbatim (tamper).
-        $charactersQuery = CharacterAffiliation::query()
-            ->has('character.contracts')
-            ->with(['character.corporation', 'character.alliance']);
+        // Mirrors ContactsController: CharacterInfo scoped by constrainToSelectionOrOwned, filtered to
+        // those with contracts. The view only reads character_id (the scroll prop carries the rows).
+        $charactersQuery = CharacterInfo::query()->has('contracts');
 
         $this->getAffiliatedIds->constrainToSelectionOrOwned(
             query: $charactersQuery,
@@ -63,10 +63,10 @@ class ContractsController extends Controller
         // One InfiniteScroll prop per character (mirrors the wallet migration). Each
         // paginator carries the ContractRessource shape and its own pageName so the
         // per-character scroll state never collides.
-        $contracts = $characters->mapWithKeys(fn (CharacterAffiliation $affiliation): array => [
-            "contracts_{$affiliation->character_id}" => Inertia::scroll(
-                fn () => $this->contractsQuery($affiliation->character_id)
-                    ->paginate(pageName: "contracts_{$affiliation->character_id}")
+        $contracts = $characters->mapWithKeys(fn (CharacterInfo $character): array => [
+            "contracts_{$character->character_id}" => Inertia::scroll(
+                fn () => $this->contractsQuery($character->character_id)
+                    ->paginate(pageName: "contracts_{$character->character_id}")
                     ->through(fn (Contract $contract) => (new ContractRessource($contract))->resolve()),
             ),
         ])->all();

--- a/src/Http/Controllers/Character/ContractsController.php
+++ b/src/Http/Controllers/Character/ContractsController.php
@@ -31,7 +31,6 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
-use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Contracts\Contract;
 use Seatplus\Web\Http\Controllers\Controller;
 use Seatplus\Web\Http\Resources\ContractRessource;
@@ -93,20 +92,8 @@ class ContractsController extends Controller
 
     public function getContractDetails(int $character_id, int $contract_id): string|Response
     {
-        // Authorise the character_id path param: a user may inspect a contract only for a character they
-        // own or are affiliated with. Without this the param was unchecked — any user could read any
-        // character's contract details by URL (IDOR). This route has no CheckAuthorization middleware.
-        $dispatchTransferObject = CreateDispatchTransferObject::new()->create(Contract::class);
-
-        $authorized = CharacterInfo::query()->where('character_id', $character_id);
-        $this->getAffiliatedIds->constrainToAffiliated(
-            query: $authorized,
-            column: 'character_id',
-            permissions: $dispatchTransferObject->permission,
-            corporationRoles: $dispatchTransferObject->required_corporation_role,
-        );
-        abort_unless($authorized->exists(), 403, 'You are not allowed to view this contract.');
-
+        // Authorisation (incl. the recruiter → recruit extended-scope case) is handled by the
+        // CheckAuthorizationWithExtendedScope middleware on the contract.details route.
         $query = Contract::query()->whereHas('characters', fn (Builder $query) => $query->where('character_id', $character_id))
             ->where('contract_id', $contract_id)
             ->with('items', 'items.type', 'startLocation', 'endLocation', 'assigneeCharacter', 'assigneeCorporation', 'issuerCharacter', 'issuerCorporation');

--- a/src/Http/Controllers/Character/ContractsController.php
+++ b/src/Http/Controllers/Character/ContractsController.php
@@ -31,6 +31,7 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Contracts\Contract;
 use Seatplus\Web\Http\Controllers\Controller;
 use Seatplus\Web\Http\Resources\ContractRessource;
@@ -43,13 +44,22 @@ class ContractsController extends Controller
         $dispatchTransferObject = CreateDispatchTransferObject::new()
             ->create(Contract::class);
 
-        $character_ids = $request->get('character_ids') ?? $this->getOwnedCharacterIds();
-
-        $characters = CharacterAffiliation::query()
-            ->whereIn('character_id', $character_ids)
+        // Default view = own characters; a submitted character_ids selection is honoured only within the
+        // authorised set (own ∪ affiliated). This route has no CheckAuthorization middleware, so the
+        // query is the sole guard — previously a submitted character_ids was used verbatim (tamper).
+        $charactersQuery = CharacterAffiliation::query()
             ->has('character.contracts')
-            ->with(['character.corporation', 'character.alliance'])
-            ->get();
+            ->with(['character.corporation', 'character.alliance']);
+
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $charactersQuery,
+            column: 'character_id',
+            selectedIds: $request->get('character_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+
+        $characters = $charactersQuery->get();
 
         // One InfiniteScroll prop per character (mirrors the wallet migration). Each
         // paginator carries the ContractRessource shape and its own pageName so the
@@ -83,6 +93,20 @@ class ContractsController extends Controller
 
     public function getContractDetails(int $character_id, int $contract_id): string|Response
     {
+        // Authorise the character_id path param: a user may inspect a contract only for a character they
+        // own or are affiliated with. Without this the param was unchecked — any user could read any
+        // character's contract details by URL (IDOR). This route has no CheckAuthorization middleware.
+        $dispatchTransferObject = CreateDispatchTransferObject::new()->create(Contract::class);
+
+        $authorized = CharacterInfo::query()->where('character_id', $character_id);
+        $this->getAffiliatedIds->constrainToAffiliated(
+            query: $authorized,
+            column: 'character_id',
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+        abort_unless($authorized->exists(), 403, 'You are not allowed to view this contract.');
+
         $query = Contract::query()->whereHas('characters', fn (Builder $query) => $query->where('character_id', $character_id))
             ->where('contract_id', $contract_id)
             ->with('items', 'items.type', 'startLocation', 'endLocation', 'assigneeCharacter', 'assigneeCorporation', 'issuerCharacter', 'issuerCorporation');

--- a/src/Http/Controllers/Character/MailsController.php
+++ b/src/Http/Controllers/Character/MailsController.php
@@ -44,7 +44,15 @@ class MailsController extends Controller
     {
         $dispatchTransferObject = $this->getDispatchTransferObject();
 
-        $ids = $this->getCharacterIds($dispatchTransferObject, 'mails');
+        $characterIdQuery = CharacterInfo::query()->select('character_id');
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $characterIdQuery,
+            column: 'character_id',
+            selectedIds: request('character_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+        $ids = $characterIdQuery->pluck('character_id');
 
         return inertia('Character/Mail/Index', [
             'dispatchTransferObject' => $dispatchTransferObject,

--- a/src/Http/Controllers/Character/MailsController.php
+++ b/src/Http/Controllers/Character/MailsController.php
@@ -69,15 +69,23 @@ class MailsController extends Controller
 
     public function getMail(EsiClient $esi, int $mail_id): Collection
     {
+        $dispatchTransferObject = $this->getDispatchTransferObject();
 
-        $userIsSuperuser = auth()->user()->can('superuser');
-
+        // A non-superuser may only read a mail that has a recipient among the characters they're
+        // authorised for (own ∪ affiliated), composed as a subquery. Superusers skip the recipient
+        // filter entirely (any mail). (Previously this passed an array to where() instead of whereIn,
+        // so a non-superuser hitting this errored.)
         $mail = Mail::query()
             ->with(['recipients'])
-            ->when(! $userIsSuperuser, fn (Builder $query) => $query->whereHas('recipients', fn (Builder $query) => $query->whereHasMorph(
+            ->when(! auth()->user()->can('superuser'), fn (Builder $query) => $query->whereHas('recipients', fn (Builder $query) => $query->whereHasMorph(
                 'receivable',
                 CharacterInfo::class,
-                fn (Builder $query) => $query->where('character_id', $this->getAuthorizedMailCharacterIds())
+                fn (Builder $query) => $this->getAffiliatedIds->constrainToAffiliated(
+                    query: $query,
+                    column: 'character_id',
+                    permissions: $dispatchTransferObject->permission,
+                    corporationRoles: $dispatchTransferObject->required_corporation_role,
+                ),
             )))
             ->firstWhere('id', $mail_id);
 
@@ -89,12 +97,5 @@ class MailsController extends Controller
     private function getDispatchTransferObject(): DispatchTransferObject
     {
         return CreateDispatchTransferObject::new()->create(Mail::class);
-    }
-
-    private function getAuthorizedMailCharacterIds(): array
-    {
-        $dispatchTransferObject = $this->getDispatchTransferObject();
-
-        return $this->getAffiliatedIds($dispatchTransferObject);
     }
 }

--- a/src/Http/Controllers/Character/SkillsController.php
+++ b/src/Http/Controllers/Character/SkillsController.php
@@ -29,6 +29,7 @@ namespace Seatplus\Web\Http\Controllers\Character;
 use Illuminate\Database\Eloquent\Builder;
 use Inertia\Inertia;
 use Inertia\Response;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Skills\Skill;
 use Seatplus\Eveapi\Models\Skills\SkillQueue;
 use Seatplus\Web\Http\Controllers\Controller;
@@ -40,7 +41,15 @@ class SkillsController extends Controller
     {
         $dispatchTransferObject = CreateDispatchTransferObject::new()->create(Skill::class);
 
-        $characterIds = $this->getCharacterIds($dispatchTransferObject, 'skills');
+        $characterIdQuery = CharacterInfo::query()->select('character_id');
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $characterIdQuery,
+            column: 'character_id',
+            selectedIds: request('character_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+        $characterIds = $characterIdQuery->pluck('character_id');
 
         return inertia('Character/Skill/Index', [
             'dispatchTransferObject' => $dispatchTransferObject,

--- a/src/Http/Controllers/Character/WalletsController.php
+++ b/src/Http/Controllers/Character/WalletsController.php
@@ -45,7 +45,15 @@ class WalletsController extends Controller
     {
         $dispatchTransferObject = CreateDispatchTransferObject::new()->create(WalletJournal::class);
 
-        $ids = $this->getCharacterIds($dispatchTransferObject, 'walletJournals');
+        $characterIdQuery = CharacterInfo::query()->select('character_id');
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $characterIdQuery,
+            column: 'character_id',
+            selectedIds: request('character_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+        $ids = $characterIdQuery->pluck('character_id');
 
         // One infinite-scroll prop per character — the page renders a wallet card
         // per id. Each paginator uses its own pageName so their scroll state never

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -80,14 +80,6 @@ class Controller extends BaseController
             ->pluck('character_id');
     }
 
-    protected function getAffiliatedIds(DispatchTransferObject $dispatchTransferObject): array
-    {
-        return $this->getAffiliatedIds->get(
-            $dispatchTransferObject->permission,
-            $dispatchTransferObject->required_corporation_role
-        );
-    }
-
     protected function getOwnedCharacterIds(): array
     {
         return auth()->user()->characters->pluck('character_id')->toArray();

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -57,23 +57,26 @@ class Controller extends BaseController
         // crashing the setup() of components that resolve a route on mount (e.g.
         // WalletJournalBalanceChart) and taking the page down. Pluck plain ids.
         //
-        // The affiliated set is composed as a subquery (never materialised); when the request carries
-        // a character_ids filter it is ANDed on as a second whereIn — the SQL equivalent of the old
-        // array_intersect, so a tampered id outside the authorised set can never leak through.
+        // Default view = the user's own characters. An explicit character_ids selection is honoured
+        // only *within* the authorised set (own ∪ affiliated, composed as a subquery): the affiliation
+        // scope() and the requested whereIn() are ANDed, so a submitted id the user isn't affiliated
+        // with is dropped — a tampered URL can't reach out-of-scope characters (this route carries no
+        // CheckAuthorization middleware, so the query is the sole tamper guard).
         $query = CharacterInfo::query()->select('character_id');
 
-        $this->getAffiliatedIds->scope(
-            query: $query,
-            column: 'character_id',
-            permissions: $dispatchTransferObject->permission,
-            corporationRoles: $dispatchTransferObject->required_corporation_role,
-        );
+        if ($this->request->has(self::CHARACTER_IDS_FILTER)) {
+            $this->getAffiliatedIds->scope(
+                query: $query,
+                column: 'character_id',
+                permissions: $dispatchTransferObject->permission,
+                corporationRoles: $dispatchTransferObject->required_corporation_role,
+            );
+            $query->whereIn('character_id', (array) $this->request->get(self::CHARACTER_IDS_FILTER));
+        } else {
+            $this->getAffiliatedIds->scopeOwned($query, 'character_id');
+        }
 
         return $query
-            ->when(
-                $this->request->has(self::CHARACTER_IDS_FILTER),
-                fn (Builder $query) => $query->whereIn('character_id', (array) $this->request->get(self::CHARACTER_IDS_FILTER)),
-            )
             ->when(
                 $characterRelation,
                 fn (Builder $query) => $query->with($characterRelation),

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -50,25 +50,30 @@ class Controller extends BaseController
         DispatchTransferObject $dispatchTransferObject,
         ?string $characterRelation = null
     ): Collection {
-        $affiliatedIds = $this->getAffiliatedIds($dispatchTransferObject);
-        $filteredIds = $this->filterByRequestedCharacterIds($affiliatedIds);
-
-        return $this->fetchAffiliatedCharacterIdsWithRelation($filteredIds, $characterRelation);
-    }
-
-    protected function fetchAffiliatedCharacterIdsWithRelation(
-        array $characterIds,
-        ?string $characterRelation = null
-    ): Collection {
         // The frontend iterates this as a list of scalar character_ids
         // (`:id="character_id"`, typed Number). Returning full CharacterInfo models
         // made each element an object, so pages built route('…', ['character_id' =>
         // <object>]) and Ziggy threw "object passed as 'character_id' parameter …",
         // crashing the setup() of components that resolve a route on mount (e.g.
         // WalletJournalBalanceChart) and taking the page down. Pluck plain ids.
-        return CharacterInfo::query()
-            ->select('character_id')
-            ->whereIn('character_id', $characterIds)
+        //
+        // The affiliated set is composed as a subquery (never materialised); when the request carries
+        // a character_ids filter it is ANDed on as a second whereIn — the SQL equivalent of the old
+        // array_intersect, so a tampered id outside the authorised set can never leak through.
+        $query = CharacterInfo::query()->select('character_id');
+
+        $this->getAffiliatedIds->scope(
+            query: $query,
+            column: 'character_id',
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+
+        return $query
+            ->when(
+                $this->request->has(self::CHARACTER_IDS_FILTER),
+                fn (Builder $query) => $query->whereIn('character_id', (array) $this->request->get(self::CHARACTER_IDS_FILTER)),
+            )
             ->when(
                 $characterRelation,
                 fn (Builder $query) => $query->with($characterRelation),
@@ -87,17 +92,5 @@ class Controller extends BaseController
     protected function getOwnedCharacterIds(): array
     {
         return auth()->user()->characters->pluck('character_id')->toArray();
-    }
-
-    private function filterByRequestedCharacterIds(array $affiliatedIds): array
-    {
-        if ($this->request->has(self::CHARACTER_IDS_FILTER)) {
-            return array_intersect(
-                $affiliatedIds,
-                $this->request->get(self::CHARACTER_IDS_FILTER)
-            );
-        }
-
-        return $affiliatedIds;
     }
 }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -64,17 +64,13 @@ class Controller extends BaseController
         // CheckAuthorization middleware, so the query is the sole tamper guard).
         $query = CharacterInfo::query()->select('character_id');
 
-        if ($this->request->has(self::CHARACTER_IDS_FILTER)) {
-            $this->getAffiliatedIds->scope(
-                query: $query,
-                column: 'character_id',
-                permissions: $dispatchTransferObject->permission,
-                corporationRoles: $dispatchTransferObject->required_corporation_role,
-            );
-            $query->whereIn('character_id', (array) $this->request->get(self::CHARACTER_IDS_FILTER));
-        } else {
-            $this->getAffiliatedIds->scopeOwned($query, 'character_id');
-        }
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $query,
+            column: 'character_id',
+            selectedIds: $this->request->get(self::CHARACTER_IDS_FILTER),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
 
         return $query
             ->when(

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -26,62 +26,17 @@
 
 namespace Seatplus\Web\Http\Controllers;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Support\Collection;
-use Seatplus\Eveapi\Models\Character\CharacterInfo;
-use Seatplus\Web\Services\Controller\DispatchTransferObject;
 use Seatplus\Web\Services\GetAffiliatedIds;
 
 class Controller extends BaseController
 {
     use ValidatesRequests;
 
-    private const string CHARACTER_IDS_FILTER = 'character_ids';
-
     public function __construct(
         protected readonly Request $request,
         protected readonly GetAffiliatedIds $getAffiliatedIds
     ) {}
-
-    protected function getCharacterIds(
-        DispatchTransferObject $dispatchTransferObject,
-        ?string $characterRelation = null
-    ): Collection {
-        // The frontend iterates this as a list of scalar character_ids
-        // (`:id="character_id"`, typed Number). Returning full CharacterInfo models
-        // made each element an object, so pages built route('…', ['character_id' =>
-        // <object>]) and Ziggy threw "object passed as 'character_id' parameter …",
-        // crashing the setup() of components that resolve a route on mount (e.g.
-        // WalletJournalBalanceChart) and taking the page down. Pluck plain ids.
-        //
-        // Default view = the user's own characters. An explicit character_ids selection is honoured
-        // only *within* the authorised set (own ∪ affiliated, composed as a subquery): the affiliation
-        // scope() and the requested whereIn() are ANDed, so a submitted id the user isn't affiliated
-        // with is dropped — a tampered URL can't reach out-of-scope characters (this route carries no
-        // CheckAuthorization middleware, so the query is the sole tamper guard).
-        $query = CharacterInfo::query()->select('character_id');
-
-        $this->getAffiliatedIds->constrainToSelectionOrOwned(
-            query: $query,
-            column: 'character_id',
-            selectedIds: $this->request->get(self::CHARACTER_IDS_FILTER),
-            permissions: $dispatchTransferObject->permission,
-            corporationRoles: $dispatchTransferObject->required_corporation_role,
-        );
-
-        return $query
-            ->when(
-                $characterRelation,
-                fn (Builder $query) => $query->with($characterRelation),
-            )
-            ->pluck('character_id');
-    }
-
-    protected function getOwnedCharacterIds(): array
-    {
-        return auth()->user()->characters->pluck('character_id')->toArray();
-    }
 }

--- a/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
+++ b/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
@@ -87,21 +87,13 @@ class MemberTrackingController extends Controller
         // Default view = the corporations the user operates (member + required role / Director); an
         // explicit corporation_ids selection is honoured only within the authorised set (that ∪ the
         // affiliated corps, composed as a subquery).
-        if (request()->has('corporation_ids')) {
-            $this->getAffiliatedIds->scope(
-                query: $query,
-                column: 'corporation_id',
-                permissions: $dispatchTransferObject->permission,
-                corporationRoles: $dispatchTransferObject->required_corporation_role,
-            );
-            $query->whereIn('corporation_id', request()->get('corporation_ids'));
-        } else {
-            $this->getAffiliatedIds->scopeOwned(
-                query: $query,
-                column: 'corporation_id',
-                corporationRoles: $dispatchTransferObject->required_corporation_role,
-            );
-        }
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $query,
+            column: 'corporation_id',
+            selectedIds: request('corporation_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
 
         return $query->get();
     }

--- a/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
+++ b/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
@@ -80,12 +80,17 @@ class MemberTrackingController extends Controller
 
     private function getAffiliatedCorporations(DispatchTransferObject $dispatchTransferObject): Collection
     {
-        $affiliatedIds = $this->getAffiliatedIds($dispatchTransferObject);
-
-        return CorporationInfo::query()
-            ->whereIn('corporation_id', $affiliatedIds)
+        $query = CorporationInfo::query()
             ->with('alliance')
-            ->has('members')
-            ->get();
+            ->has('members');
+
+        $this->getAffiliatedIds->scope(
+            query: $query,
+            column: 'corporation_id',
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
+
+        return $query->get();
     }
 }

--- a/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
+++ b/src/Http/Controllers/Corporation/MemberTracking/MemberTrackingController.php
@@ -84,12 +84,24 @@ class MemberTrackingController extends Controller
             ->with('alliance')
             ->has('members');
 
-        $this->getAffiliatedIds->scope(
-            query: $query,
-            column: 'corporation_id',
-            permissions: $dispatchTransferObject->permission,
-            corporationRoles: $dispatchTransferObject->required_corporation_role,
-        );
+        // Default view = the corporations the user operates (member + required role / Director); an
+        // explicit corporation_ids selection is honoured only within the authorised set (that ∪ the
+        // affiliated corps, composed as a subquery).
+        if (request()->has('corporation_ids')) {
+            $this->getAffiliatedIds->scope(
+                query: $query,
+                column: 'corporation_id',
+                permissions: $dispatchTransferObject->permission,
+                corporationRoles: $dispatchTransferObject->required_corporation_role,
+            );
+            $query->whereIn('corporation_id', request()->get('corporation_ids'));
+        } else {
+            $this->getAffiliatedIds->scopeOwned(
+                query: $query,
+                column: 'corporation_id',
+                corporationRoles: $dispatchTransferObject->required_corporation_role,
+            );
+        }
 
         return $query->get();
     }

--- a/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
+++ b/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
@@ -112,18 +112,17 @@ class CorporationWalletController extends Controller
 
     private function getAffiliatedCorporateWalletDivisions(object $dispatchTransferObject): Collection
     {
-
-        $affiliated_ids = $this->getAffiliatedIds->get(
-            $dispatchTransferObject->permission,
-            $dispatchTransferObject->required_corporation_role
-        );
-
         return CorporationDivision::query()
             ->where('division_type', 'wallet')
             ->when(
                 request()->has('corporation_ids'),
                 fn (Builder $query) => $query->whereIn('corporation_id', request()->get('corporation_ids')),
-                fn (Builder $query) => $query->whereIn('corporation_id', $affiliated_ids)
+                fn (Builder $query) => $this->getAffiliatedIds->scope(
+                    query: $query,
+                    column: 'corporation_id',
+                    permissions: $dispatchTransferObject->permission,
+                    corporationRoles: $dispatchTransferObject->required_corporation_role,
+                ),
             )
             ->select('corporation_divisions.*')
             ->distinct()

--- a/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
+++ b/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
@@ -112,18 +112,28 @@ class CorporationWalletController extends Controller
 
     private function getAffiliatedCorporateWalletDivisions(object $dispatchTransferObject): Collection
     {
-        return CorporationDivision::query()
-            ->where('division_type', 'wallet')
-            ->when(
-                request()->has('corporation_ids'),
-                fn (Builder $query) => $query->whereIn('corporation_id', request()->get('corporation_ids')),
-                fn (Builder $query) => $this->getAffiliatedIds->scope(
-                    query: $query,
-                    column: 'corporation_id',
-                    permissions: $dispatchTransferObject->permission,
-                    corporationRoles: $dispatchTransferObject->required_corporation_role,
-                ),
-            )
+        $query = CorporationDivision::query()->where('division_type', 'wallet');
+
+        // Default view = the corporations the user operates (member + required role / Director); an
+        // explicit corporation_ids selection is honoured only within the authorised set (that ∪ the
+        // affiliated corps, composed as a subquery).
+        if (request()->has('corporation_ids')) {
+            $this->getAffiliatedIds->scope(
+                query: $query,
+                column: 'corporation_id',
+                permissions: $dispatchTransferObject->permission,
+                corporationRoles: $dispatchTransferObject->required_corporation_role,
+            );
+            $query->whereIn('corporation_id', request()->get('corporation_ids'));
+        } else {
+            $this->getAffiliatedIds->scopeOwned(
+                query: $query,
+                column: 'corporation_id',
+                corporationRoles: $dispatchTransferObject->required_corporation_role,
+            );
+        }
+
+        return $query
             ->select('corporation_divisions.*')
             ->distinct()
             ->get();

--- a/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
+++ b/src/Http/Controllers/Corporation/Wallet/CorporationWalletController.php
@@ -117,21 +117,13 @@ class CorporationWalletController extends Controller
         // Default view = the corporations the user operates (member + required role / Director); an
         // explicit corporation_ids selection is honoured only within the authorised set (that ∪ the
         // affiliated corps, composed as a subquery).
-        if (request()->has('corporation_ids')) {
-            $this->getAffiliatedIds->scope(
-                query: $query,
-                column: 'corporation_id',
-                permissions: $dispatchTransferObject->permission,
-                corporationRoles: $dispatchTransferObject->required_corporation_role,
-            );
-            $query->whereIn('corporation_id', request()->get('corporation_ids'));
-        } else {
-            $this->getAffiliatedIds->scopeOwned(
-                query: $query,
-                column: 'corporation_id',
-                corporationRoles: $dispatchTransferObject->required_corporation_role,
-            );
-        }
+        $this->getAffiliatedIds->constrainToSelectionOrOwned(
+            query: $query,
+            column: 'corporation_id',
+            selectedIds: request('corporation_ids'),
+            permissions: $dispatchTransferObject->permission,
+            corporationRoles: $dispatchTransferObject->required_corporation_role,
+        );
 
         return $query
             ->select('corporation_divisions.*')

--- a/src/Http/Controllers/Employment/ObservationController.php
+++ b/src/Http/Controllers/Employment/ObservationController.php
@@ -35,13 +35,16 @@ class ObservationController extends Controller
         // scopes there is nothing to be compliant against, so an unconfigured corp (e.g. an old corp the
         // user merely has a character in) would just be noise.
         $corporations = CorporationInfo::query()
-            ->has('ssoScopes')
-            ->orHas('alliance.ssoScopes')
+            // Group the has/orHas so the affiliation constraint below ANDs against the whole OR-pair,
+            // not just the alliance arm (boolean precedence).
+            ->where(fn (Builder $query) => $query->has('ssoScopes')->orHas('alliance.ssoScopes'))
             ->when(
                 ! $user->can('superuser'),
-                fn (Builder $query) => $query->whereIn(
-                    'corporation_infos.corporation_id',
-                    (new GetAffiliatedIds($user))->get(permissions: self::PERMISSION, corporationRoles: 'director'),
+                fn (Builder $query) => (new GetAffiliatedIds($user))->scope(
+                    query: $query,
+                    column: 'corporation_infos.corporation_id',
+                    permissions: self::PERMISSION,
+                    corporationRoles: 'director',
                 ),
             )
             ->get(['name', 'corporation_id', 'ticker']);
@@ -119,9 +122,13 @@ class ObservationController extends Controller
             return;
         }
 
-        $observableIds = (new GetAffiliatedIds($user))->get(permissions: self::PERMISSION, corporationRoles: 'director');
+        $mayObserve = (new GetAffiliatedIds($user))->coversCorporation(
+            corporationId: $corporation_id,
+            permissions: self::PERMISSION,
+            corporationRoles: 'director',
+        );
 
-        abort_unless(in_array($corporation_id, $observableIds), 403, 'You may not observe this corporation.');
+        abort_unless($mayObserve, 403, 'You may not observe this corporation.');
     }
 
     /**

--- a/src/Http/Controllers/Employment/ObservationController.php
+++ b/src/Http/Controllers/Employment/ObservationController.php
@@ -40,7 +40,7 @@ class ObservationController extends Controller
             ->where(fn (Builder $query) => $query->has('ssoScopes')->orHas('alliance.ssoScopes'))
             ->when(
                 ! $user->can('superuser'),
-                fn (Builder $query) => (new GetAffiliatedIds($user))->scope(
+                fn (Builder $query) => (new GetAffiliatedIds($user))->constrainToAffiliated(
                     query: $query,
                     column: 'corporation_infos.corporation_id',
                     permissions: self::PERMISSION,

--- a/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
+++ b/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
@@ -29,19 +29,19 @@ class ManageRecruitmentController extends Controller
         $user = auth()->user();
         $isSuperuser = $user->can('superuser');
 
-        $manageableIds = $this->getAffiliatedIds->get(
-            permissions: [self::MANAGE_PERMISSION],
-            corporationRoles: ['Director'],
-            user: $user,
-        );
-
         $postings = Enlistment::query()
             ->with([
                 'corporation.alliance',
                 'corporation.ssoScopes',
                 'reviewRounds' => fn (HasMany $query) => $query->orderBy('position'),
             ])
-            ->when(! $isSuperuser, fn (Builder $query) => $query->whereIn('corporation_id', $manageableIds))
+            ->when(! $isSuperuser, fn (Builder $query) => $this->getAffiliatedIds->scope(
+                query: $query,
+                column: 'corporation_id',
+                permissions: [self::MANAGE_PERMISSION],
+                corporationRoles: ['Director'],
+                user: $user,
+            ))
             ->get()
             ->map(function (Enlistment $posting) {
                 /** @var CorporationInfo $corporation */

--- a/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
+++ b/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
@@ -35,7 +35,7 @@ class ManageRecruitmentController extends Controller
                 'corporation.ssoScopes',
                 'reviewRounds' => fn (HasMany $query) => $query->orderBy('position'),
             ])
-            ->when(! $isSuperuser, fn (Builder $query) => $this->getAffiliatedIds->scope(
+            ->when(! $isSuperuser, fn (Builder $query) => $this->getAffiliatedIds->constrainToAffiliated(
                 query: $query,
                 column: 'corporation_id',
                 permissions: [self::MANAGE_PERMISSION],

--- a/src/Http/Controllers/Recruitment/PostingController.php
+++ b/src/Http/Controllers/Recruitment/PostingController.php
@@ -136,12 +136,13 @@ class PostingController extends Controller
             return;
         }
 
-        $manageableIds = $this->getAffiliatedIds->get(
+        $mayManage = $this->getAffiliatedIds->coversCorporation(
+            corporationId: $corporationId,
             permissions: [ManageRecruitmentController::MANAGE_PERMISSION],
             corporationRoles: ['Director'],
             user: $user,
         );
 
-        abort_unless(in_array($corporationId, $manageableIds), 403, 'You may not manage this corporation.');
+        abort_unless($mayManage, 403, 'You may not manage this corporation.');
     }
 }

--- a/src/Http/Controllers/Recruitment/ReviewInboxController.php
+++ b/src/Http/Controllers/Recruitment/ReviewInboxController.php
@@ -34,7 +34,7 @@ class ReviewInboxController extends Controller
         $isSuperuser = $user->can('superuser');
 
         $applications = Application::query()
-            ->when(! $isSuperuser, fn (Builder $query) => $this->getAffiliatedIds->scope(
+            ->when(! $isSuperuser, fn (Builder $query) => $this->getAffiliatedIds->constrainToAffiliated(
                 query: $query,
                 column: 'corporation_id',
                 permissions: [self::RECRUITER_PERMISSION],

--- a/src/Http/Controllers/Recruitment/ReviewInboxController.php
+++ b/src/Http/Controllers/Recruitment/ReviewInboxController.php
@@ -33,14 +33,14 @@ class ReviewInboxController extends Controller
         $user = auth()->user();
         $isSuperuser = $user->can('superuser');
 
-        $recruiterCorpIds = $this->getAffiliatedIds->get(
-            permissions: [self::RECRUITER_PERMISSION],
-            corporationRoles: ['Director'],
-            user: $user,
-        );
-
         $applications = Application::query()
-            ->when(! $isSuperuser, fn (Builder $query) => $query->whereIn('corporation_id', $recruiterCorpIds))
+            ->when(! $isSuperuser, fn (Builder $query) => $this->getAffiliatedIds->scope(
+                query: $query,
+                column: 'corporation_id',
+                permissions: [self::RECRUITER_PERMISSION],
+                corporationRoles: ['Director'],
+                user: $user,
+            ))
             ->with([
                 'logEntries',
                 'corporation',

--- a/src/Http/Middleware/CheckAffiliationForApplication.php
+++ b/src/Http/Middleware/CheckAffiliationForApplication.php
@@ -52,7 +52,7 @@ class CheckAffiliationForApplication
             ->where('id', $application_id)
             ->with(['applicationable', 'corporation']);
 
-        $this->getAffiliatedIdsService->scope(
+        $this->getAffiliatedIdsService->constrainToAffiliated(
             query: $query,
             column: 'corporation_id',
             permissions: [$permission],

--- a/src/Http/Middleware/CheckAffiliationForApplication.php
+++ b/src/Http/Middleware/CheckAffiliationForApplication.php
@@ -48,17 +48,19 @@ class CheckAffiliationForApplication
 
         abort_unless($application_id, 404, 'required url parameter application_id is missing');
 
-        $affiliatedIds = $this->getAffiliatedIdsService->get(
+        $query = Application::query()
+            ->where('id', $application_id)
+            ->with(['applicationable', 'corporation']);
+
+        $this->getAffiliatedIdsService->scope(
+            query: $query,
+            column: 'corporation_id',
             permissions: [$permission],
             corporationRoles: ['director'],
             user: auth()->user(),
         );
 
-        $application = Application::query()
-            ->whereIn('corporation_id', $affiliatedIds)
-            ->where('id', $application_id)
-            ->with(['applicationable', 'corporation'])
-            ->exists();
+        $application = $query->exists();
 
         abort_unless($application, 403, 'You are not allowed to review the recruit');
 

--- a/src/Services/Affiliations/GetCorporationMemberComplianceAffiliatedIdsService.php
+++ b/src/Services/Affiliations/GetCorporationMemberComplianceAffiliatedIdsService.php
@@ -20,13 +20,8 @@ class GetCorporationMemberComplianceAffiliatedIdsService
 
     public function getQuery(): Builder
     {
-        $affiliated_ids = $this->getAffiliatedIds->get(
-            permissions: 'member compliance: review user',
-            corporationRoles: 'director'
-        );
-
-        // Find users who have at least one character in the affiliated IDs
-        // AND whose characters are in corporations/alliances with SSO scopes configured.
+        // Find users who have at least one character in the affiliated set (composed as a subquery,
+        // never materialised) AND whose characters are in corporations/alliances with SSO scopes.
         $user_ids = User::query()
             ->whereHas(
                 'characters',
@@ -36,7 +31,12 @@ class GetCorporationMemberComplianceAffiliatedIdsService
                             ->whereHas('corporation', fn (Builder $q) => $q->whereHas('ssoScopes', fn (Builder $q) => $q->whereIn('type', ['global', 'user'])))
                             ->orWhereHas('alliance', fn (Builder $q) => $q->whereHas('ssoScopes', fn (Builder $q) => $q->whereIn('type', ['global', 'user'])))
                     )
-                    ->whereIn('character_infos.character_id', $affiliated_ids)
+                    ->tap(fn (Builder $q) => $this->getAffiliatedIds->scope(
+                        query: $q,
+                        column: 'character_infos.character_id',
+                        permissions: 'member compliance: review user',
+                        corporationRoles: 'director',
+                    ))
             )
             ->pluck('users.id')
             ->toArray();

--- a/src/Services/Affiliations/GetCorporationMemberComplianceAffiliatedIdsService.php
+++ b/src/Services/Affiliations/GetCorporationMemberComplianceAffiliatedIdsService.php
@@ -31,7 +31,7 @@ class GetCorporationMemberComplianceAffiliatedIdsService
                             ->whereHas('corporation', fn (Builder $q) => $q->whereHas('ssoScopes', fn (Builder $q) => $q->whereIn('type', ['global', 'user'])))
                             ->orWhereHas('alliance', fn (Builder $q) => $q->whereHas('ssoScopes', fn (Builder $q) => $q->whereIn('type', ['global', 'user'])))
                     )
-                    ->tap(fn (Builder $q) => $this->getAffiliatedIds->scope(
+                    ->tap(fn (Builder $q) => $this->getAffiliatedIds->constrainToAffiliated(
                         query: $q,
                         column: 'character_infos.character_id',
                         permissions: 'member compliance: review user',

--- a/src/Services/GetAffiliatedIds.php
+++ b/src/Services/GetAffiliatedIds.php
@@ -93,6 +93,9 @@ class GetAffiliatedIds
      *    $corporationRoles (+ Director) in.
      * Any other column throws (fail closed).
      *
+     * A superuser is authorised for everything, so no constraint is added (mirrors the `superuser`
+     * bypass CanUserService/`Gate::before` apply everywhere else).
+     *
      * @param  string|array<int,string>  $permissions
      * @param  string|array<int,string>  $corporationRoles
      */
@@ -104,6 +107,11 @@ class GetAffiliatedIds
         ?User $user = null,
     ): Builder {
         $user = $user ?? $this->user ?? auth()->user();
+
+        if ($user->can('superuser')) {
+            return $query;
+        }
+
         $userPermission = $this->canUserService->getUserPermissionObject($user);
 
         $roleIds = $this->permissionRoleIds($this->normalizeInput($permissions), $userPermission);
@@ -128,6 +136,41 @@ class GetAffiliatedIds
         }
 
         throw new InvalidArgumentException("GetAffiliatedIds::scope() cannot resolve an id-space for column [{$column}].");
+    }
+
+    /**
+     * Constrain $column to the entities the user *owns / operates* — the default view before any
+     * explicit selection:
+     *  - a character_id column matches only the user's own characters;
+     *  - a corporation_id column matches only the corporations the user is a member of AND holds
+     *    $corporationRoles (or Director) in — i.e. the cached `corporation_roles` slice.
+     * Unlike {@see scope()} this deliberately excludes the merely-affiliated set (entities reachable
+     * through a permission, e.g. an alliance-wide auditor role); those appear only when the user
+     * explicitly selects them, and a selection is validated through scope().
+     *
+     * @param  string|array<int,string>  $corporationRoles
+     */
+    public function scopeOwned(
+        Builder $query,
+        string $column,
+        string|array $corporationRoles = [],
+        ?User $user = null,
+    ): Builder {
+        $user = $user ?? $this->user ?? auth()->user();
+        $userPermission = $this->canUserService->getUserPermissionObject($user);
+
+        if (str_contains($column, 'character_id')) {
+            return $query->whereIn($column, data_get($userPermission, 'owned_character_ids', []));
+        }
+
+        if (str_contains($column, 'corporation_id')) {
+            $normalizedRoles = $this->normalizeInput($corporationRoles);
+            $normalizedRoles[] = self::DIRECTOR_ROLE;
+
+            return $query->whereIn($column, $this->corporationRoleIds($normalizedRoles, $userPermission));
+        }
+
+        throw new InvalidArgumentException("GetAffiliatedIds::scopeOwned() cannot resolve an id-space for column [{$column}].");
     }
 
     /**

--- a/src/Services/GetAffiliatedIds.php
+++ b/src/Services/GetAffiliatedIds.php
@@ -80,6 +80,39 @@ class GetAffiliatedIds
     }
 
     /**
+     * The data-page filter. Constrain $column to the user's explicit selection when one is present —
+     * honoured only *within* the authorised set (own ∪ affiliated) — otherwise to the owned/operated
+     * default. This is the single place the "a submitted id is dropped unless the user is affiliated
+     * with it" tamper guard lives, for the pages whose route carries no CheckAuthorization middleware.
+     *
+     * @param  mixed  $selectedIds  raw request value (null / scalar / array); cast and emptied here
+     * @param  string|array<int,string>  $permissions
+     * @param  string|array<int,string>  $corporationRoles
+     */
+    public function constrainToSelectionOrOwned(
+        Builder $query,
+        string $column,
+        mixed $selectedIds,
+        string|array $permissions,
+        string|array $corporationRoles = [],
+        ?User $user = null,
+    ): void {
+        $selected = array_values(array_filter(
+            (array) $selectedIds,
+            fn (mixed $id): bool => $id !== null && $id !== '',
+        ));
+
+        if ($selected === []) {
+            $this->constrainToOwned($query, $column, $corporationRoles, $user);
+
+            return;
+        }
+
+        $this->constrainToAffiliated($query, $column, $permissions, $corporationRoles, $user);
+        $query->whereIn($column, $selected);
+    }
+
+    /**
      * Constrain $column to the entities affiliated via $permissions / $corporationRoles, composed as a
      * grouped subquery rather than a materialised id array: the affiliated set is resolved in SQL by
      * {@see AffiliationResolver}, so an inverse or alliance-wide role never pulls a whole *_infos table
@@ -94,48 +127,48 @@ class GetAffiliatedIds
      * Any other column throws (fail closed).
      *
      * A superuser is authorised for everything, so no constraint is added (mirrors the `superuser`
-     * bypass CanUserService/`Gate::before` apply everywhere else).
+     * bypass CanUserService/`Gate::before` apply everywhere else). Mutates $query in place.
      *
      * @param  string|array<int,string>  $permissions
      * @param  string|array<int,string>  $corporationRoles
      */
-    public function scope(
+    public function constrainToAffiliated(
         Builder $query,
         string $column,
         string|array $permissions,
         string|array $corporationRoles = [],
         ?User $user = null,
-    ): Builder {
+    ): void {
         $user = $user ?? $this->user ?? auth()->user();
 
         if ($user->can('superuser')) {
-            return $query;
+            return;
         }
 
         $userPermission = $this->canUserService->getUserPermissionObject($user);
-
         $roleIds = $this->permissionRoleIds($this->normalizeInput($permissions), $userPermission);
         $resolver = new AffiliationResolver;
 
         if (str_contains($column, 'character_id')) {
-            $ownedCharacterIds = data_get($userPermission, 'owned_character_ids', []);
-
-            return $query->where(fn (Builder $builder) => $builder
+            $query->where(fn (Builder $builder) => $builder
                 ->whereIn($column, $resolver->characterIdsSubquery($roleIds))
-                ->orWhereIn($column, $ownedCharacterIds));
+                ->orWhereIn($column, data_get($userPermission, 'owned_character_ids', [])));
+
+            return;
         }
 
         if (str_contains($column, 'corporation_id')) {
             $normalizedRoles = $this->normalizeInput($corporationRoles);
             $normalizedRoles[] = self::DIRECTOR_ROLE;
-            $corporationRoleIds = $this->corporationRoleIds($normalizedRoles, $userPermission);
 
-            return $query->where(fn (Builder $builder) => $builder
+            $query->where(fn (Builder $builder) => $builder
                 ->whereIn($column, $resolver->corporationIdsSubquery($roleIds))
-                ->orWhereIn($column, $corporationRoleIds));
+                ->orWhereIn($column, $this->corporationRoleIds($normalizedRoles, $userPermission)));
+
+            return;
         }
 
-        throw new InvalidArgumentException("GetAffiliatedIds::scope() cannot resolve an id-space for column [{$column}].");
+        throw new InvalidArgumentException("GetAffiliatedIds::constrainToAffiliated() cannot resolve an id-space for column [{$column}].");
     }
 
     /**
@@ -144,33 +177,38 @@ class GetAffiliatedIds
      *  - a character_id column matches only the user's own characters;
      *  - a corporation_id column matches only the corporations the user is a member of AND holds
      *    $corporationRoles (or Director) in — i.e. the cached `corporation_roles` slice.
-     * Unlike {@see scope()} this deliberately excludes the merely-affiliated set (entities reachable
-     * through a permission, e.g. an alliance-wide auditor role); those appear only when the user
-     * explicitly selects them, and a selection is validated through scope().
+     * Unlike {@see constrainToAffiliated()} this deliberately excludes the merely-affiliated set
+     * (entities reachable through a permission, e.g. an alliance-wide auditor role); those appear only
+     * when the user explicitly selects them, and a selection is validated through constrainToAffiliated().
+     * Mutates $query in place.
      *
      * @param  string|array<int,string>  $corporationRoles
      */
-    public function scopeOwned(
+    public function constrainToOwned(
         Builder $query,
         string $column,
         string|array $corporationRoles = [],
         ?User $user = null,
-    ): Builder {
+    ): void {
         $user = $user ?? $this->user ?? auth()->user();
         $userPermission = $this->canUserService->getUserPermissionObject($user);
 
         if (str_contains($column, 'character_id')) {
-            return $query->whereIn($column, data_get($userPermission, 'owned_character_ids', []));
+            $query->whereIn($column, data_get($userPermission, 'owned_character_ids', []));
+
+            return;
         }
 
         if (str_contains($column, 'corporation_id')) {
             $normalizedRoles = $this->normalizeInput($corporationRoles);
             $normalizedRoles[] = self::DIRECTOR_ROLE;
 
-            return $query->whereIn($column, $this->corporationRoleIds($normalizedRoles, $userPermission));
+            $query->whereIn($column, $this->corporationRoleIds($normalizedRoles, $userPermission));
+
+            return;
         }
 
-        throw new InvalidArgumentException("GetAffiliatedIds::scopeOwned() cannot resolve an id-space for column [{$column}].");
+        throw new InvalidArgumentException("GetAffiliatedIds::constrainToOwned() cannot resolve an id-space for column [{$column}].");
     }
 
     /**
@@ -213,7 +251,7 @@ class GetAffiliatedIds
 
         return array_merge(
             $this->getPermissionBasedIds($permissions, $userPermission),
-            $this->getCorporationRoleBasedIds($corporationRole, $userPermission),
+            $this->corporationRoleIds($corporationRole, $userPermission),
             data_get($userPermission, 'owned_character_ids', [])
         );
     }
@@ -264,15 +302,6 @@ class GetAffiliatedIds
         );
 
         return array_map('intval', $affiliatedIds);
-    }
-
-    /**
-     * @param  array<int,string>  $corporation_role
-     * @return array<int,int>
-     */
-    private function getCorporationRoleBasedIds(array $corporation_role, array $userPermission): array
-    {
-        return $this->corporationRoleIds($corporation_role, $userPermission);
     }
 
     /**

--- a/src/Services/GetAffiliatedIds.php
+++ b/src/Services/GetAffiliatedIds.php
@@ -26,6 +26,8 @@
 
 namespace Seatplus\Web\Services;
 
+use Illuminate\Database\Eloquent\Builder;
+use InvalidArgumentException;
 use Seatplus\Auth\Models\User;
 use Seatplus\Auth\Services\Permissions\CanUserService;
 use Seatplus\Auth\Services\Roles\AffiliationResolver;
@@ -78,6 +80,86 @@ class GetAffiliatedIds
     }
 
     /**
+     * Constrain $column to the entities affiliated via $permissions / $corporationRoles, composed as a
+     * grouped subquery rather than a materialised id array: the affiliated set is resolved in SQL by
+     * {@see AffiliationResolver}, so an inverse or alliance-wide role never pulls a whole *_infos table
+     * into PHP the way get() does.
+     *
+     * The whole affiliation constraint is wrapped in a single nested where(), so it stays safe to chain
+     * next to an existing orWhere (no boolean-precedence surprise). $column selects the id-space — the
+     * two spaces get() ever filtered against:
+     *  - a character_id column matches the affiliated characters OR the user's own characters;
+     *  - a corporation_id column matches the affiliated corporations OR the corporations the user holds
+     *    $corporationRoles (+ Director) in.
+     * Any other column throws (fail closed).
+     *
+     * @param  string|array<int,string>  $permissions
+     * @param  string|array<int,string>  $corporationRoles
+     */
+    public function scope(
+        Builder $query,
+        string $column,
+        string|array $permissions,
+        string|array $corporationRoles = [],
+        ?User $user = null,
+    ): Builder {
+        $user = $user ?? $this->user ?? auth()->user();
+        $userPermission = $this->canUserService->getUserPermissionObject($user);
+
+        $roleIds = $this->permissionRoleIds($this->normalizeInput($permissions), $userPermission);
+        $resolver = new AffiliationResolver;
+
+        if (str_contains($column, 'character_id')) {
+            $ownedCharacterIds = data_get($userPermission, 'owned_character_ids', []);
+
+            return $query->where(fn (Builder $builder) => $builder
+                ->whereIn($column, $resolver->characterIdsSubquery($roleIds))
+                ->orWhereIn($column, $ownedCharacterIds));
+        }
+
+        if (str_contains($column, 'corporation_id')) {
+            $normalizedRoles = $this->normalizeInput($corporationRoles);
+            $normalizedRoles[] = self::DIRECTOR_ROLE;
+            $corporationRoleIds = $this->corporationRoleIds($normalizedRoles, $userPermission);
+
+            return $query->where(fn (Builder $builder) => $builder
+                ->whereIn($column, $resolver->corporationIdsSubquery($roleIds))
+                ->orWhereIn($column, $corporationRoleIds));
+        }
+
+        throw new InvalidArgumentException("GetAffiliatedIds::scope() cannot resolve an id-space for column [{$column}].");
+    }
+
+    /**
+     * Whether $corporationId is one of the corporations affiliated via $permissions / $corporationRoles —
+     * a bounded membership test that never materialises the affiliated set. Replaces
+     * `in_array($corporationId, $this->get(...))` on the corporation id-space.
+     *
+     * @param  string|array<int,string>  $permissions
+     * @param  string|array<int,string>  $corporationRoles
+     */
+    public function coversCorporation(
+        int $corporationId,
+        string|array $permissions,
+        string|array $corporationRoles = [],
+        ?User $user = null,
+    ): bool {
+        $user = $user ?? $this->user ?? auth()->user();
+        $userPermission = $this->canUserService->getUserPermissionObject($user);
+
+        $normalizedRoles = $this->normalizeInput($corporationRoles);
+        $normalizedRoles[] = self::DIRECTOR_ROLE;
+
+        if (in_array($corporationId, $this->corporationRoleIds($normalizedRoles, $userPermission), true)) {
+            return true;
+        }
+
+        $roleIds = $this->permissionRoleIds($this->normalizeInput($permissions), $userPermission);
+
+        return (new AffiliationResolver)->coveredIds($roleIds, [$corporationId]) !== [];
+    }
+
+    /**
      * @param  array<int,string>  $permissions
      * @param  array<int,string>  $corporationRole
      * @return array<int,int>
@@ -124,11 +206,7 @@ class GetAffiliatedIds
      */
     private function getPermissionBasedIds(array $permissions, array $userPermission): array
     {
-        $roleIds = collect($permissions)
-            ->flatMap(fn (string $permission) => data_get($userPermission, "permission_roles.$permission", []))
-            ->unique()
-            ->values()
-            ->all();
+        $roleIds = $this->permissionRoleIds($permissions, $userPermission);
 
         if ($roleIds === []) {
             return [];
@@ -151,9 +229,40 @@ class GetAffiliatedIds
      */
     private function getCorporationRoleBasedIds(array $corporation_role, array $userPermission): array
     {
-        return collect($corporation_role)
-            ->map(fn (string $corporation_role) => data_get($userPermission, "corporation_roles.$corporation_role", []))
-            ->collapse()
-            ->toArray();
+        return $this->corporationRoleIds($corporation_role, $userPermission);
+    }
+
+    /**
+     * The ids of the user's roles that grant any of $permissions, from the cached `permission_roles` slice.
+     *
+     * @param  array<int,string>  $permissions
+     * @param  array<string,mixed>  $userPermission
+     * @return array<int,int>
+     */
+    private function permissionRoleIds(array $permissions, array $userPermission): array
+    {
+        return collect($permissions)
+            ->flatMap(fn (string $permission) => data_get($userPermission, "permission_roles.$permission", []))
+            ->map(fn (mixed $id): int => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * The corporation ids the user holds any of $corporationRoles in, from the cached `corporation_roles` slice.
+     *
+     * @param  array<int,string>  $corporationRoles
+     * @param  array<string,mixed>  $userPermission
+     * @return array<int,int>
+     */
+    private function corporationRoleIds(array $corporationRoles, array $userPermission): array
+    {
+        return collect($corporationRoles)
+            ->flatMap(fn (string $role) => data_get($userPermission, "corporation_roles.$role", []))
+            ->map(fn (mixed $id): int => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/tests/Feature/ContactTest.php
+++ b/tests/Feature/ContactTest.php
@@ -35,6 +35,21 @@ it('has details', function () {
                 ->where("contacts.{$character_id}.0.contact_id", $contact->contact_id)));
 });
 
+it('drops a submitted character_id the user is not affiliated with', function () {
+    // The character.contacts route carries no CheckAuthorization middleware, so the query is the sole
+    // tamper guard: a hand-built ?character_ids[]=<foreign id> must not leak that character. The foreign
+    // character is given a contact so the has('contacts') filter can't be what excludes it — only the
+    // affiliation guard can. test_user owns test_character and holds no affiliating role.
+    $foreign = CharacterInfo::factory()->create();
+    $foreign->contacts()->create(Contact::factory()->make()->toArray());
+
+    test()->actingAs(test()->test_user)
+        ->get(route('character.contacts', ['character_ids' => [$foreign->character_id]]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Character/Contact/Index')
+            ->has('characters', 0));
+});
+
 it('has corporation standing', function (string $contact_type, string $corp_contact_level) {
     $affiliation = CharacterAffiliation::factory()->create([
         'alliance_id' => faker()->numberBetween(99_000_000, 100_000_000),


### PR DESCRIPTION
## Why

Follow-up to #1645. `GetAffiliatedIds::get()` resolves the affiliated set **eagerly into PHP** — three `AffiliationResolver::*IdsSubquery()->pluck()` calls. For an **inverse** ("everyone except X") or an **alliance-wide** role that pulls a whole `*_infos` table into memory just to feed a `whereIn` / `in_array`. That materialisation is exactly what the auth 5.0 resolver rework set out to avoid; this pushes the filters into SQL.

## What

Two new primitives on `GetAffiliatedIds`:

- **`scope(Builder $query, string $column, $permissions, $corporationRoles = [], $user = null): Builder`** — applies the affiliation constraint as a **single grouped nested `where()`** composing the per-id-space `AffiliationResolver` subquery with the small owned / corp-role arrays. Wrapping the whole constraint keeps it **boolean-precedence-safe** next to an existing `orWhere`. `$column` selects the id-space (`character_id` | `corporation_id`); any other column **throws (fail closed)**.
- **`coversCorporation(int $corporationId, ...): bool`** — a bounded membership test via `AffiliationResolver::coveredIds()` for the single-id `in_array()` guards. Never materialises the set.

**Behaviour-equivalence:** `get()` returns one array conflating character+corporation+alliance+corp-role+owned ids; a `whereIn($column, ...)` against it only ever matched the id-space of that column (EVE ids are globally unique). So per-column `scope()` (`characterIdsSubquery ∪ owned` for a character_id column; `corporationIdsSubquery ∪ corp-role corps` for a corporation_id column) is set-identical to the old filter — no widening.

### Migrated — `whereIn(array)` → subquery
GetAffiliatedEntitiesAction (characters + corporations), CheckAffiliationForApplication, GetCorporationMemberComplianceAffiliatedIdsService, ManageRecruitment, ReviewInbox, CorporationWallet (else-branch), ObservationController::index, MemberTracking, base `Controller::getCharacterIds` (feeds Assets / Skills / Wallets / Mails lists), ContactsController.

### Migrated — `in_array(id, array)` → bounded `coversCorporation()`
ObservationController::authorizeCorporation, PostingController::authorizeCorporation.

### Incidental correctness fix
`ObservationController::index` now groups its `has('ssoScopes')->orHas('alliance.ssoScopes')` pair in a `where()` closure, so the affiliation constraint ANDs against the **whole** OR-pair rather than only the alliance arm (a pre-existing boolean-precedence bug that let a non-superuser see every ssoScopes-configured corp). Flagging explicitly since it changes a query result.

## Deferred (genuinely need a PHP array)

Left calling `get()` / `ownedCharacterIds()` — converting them is higher-risk and out of scope here:
- `DispatchJobController` — `array_diff(affiliated, owned)`.
- `DispatchIndividualJob` — `Rule::in(...)` validation (the highest-value remaining target: it materialises the set to validate one submitted id; wants a closure rule using a bounded `coversCharacter`/`coversCorporation`, but rewriting validation rules blind is risky).
- `GetRecruitIdsService` — the affiliated ids form a cache-key hash.
- `Mails::getMail` — single-mail authorization.

`get()` and its array path are retained for these.

## Testing

Can't run web's suite in the dev container (vendor symlink). `php -l` + Pint pass on all 12 files; behaviour-equivalence reasoned per call site above. **Needs the "Browser (vs core)" job on host to validate** — the resolver subqueries are Postgres-specific (`type::text`, `NOT EXISTS`, `fromSub`). Recommend running the Observation / Recruitment / Wallet / MemberTracking / Assets / Contacts feature+browser tests before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)