### PR TITLE
fix(recruitment): stop a posting save from rewriting the corporation's SSO scopes

### DIFF
--- a/resources/js/Pages/Recruitment/Manage/ManagePostingCard.vue
+++ b/resources/js/Pages/Recruitment/Manage/ManagePostingCard.vue
@@ -171,7 +171,7 @@
         class="inline-flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-500"
         @click="scopesOpen = !scopesOpen"
       >
-        {{ scopesOpen ? 'Hide' : 'Manage' }} required SSO scopes
+        {{ scopesOpen ? 'Hide' : 'Manage' }} corporation-wide SSO scopes
         <span
           v-if="form.selected_scopes.length > 0"
           class="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700"
@@ -185,17 +185,37 @@
         v-if="scopesOpen"
         class="space-y-4"
       >
-        <p class="text-xs text-gray-500">
-          Characters must have granted these ESI scopes to be compliant for this corporation — checked
-          both while reviewing an applicant and while observing an employee. Clearing every scope removes
-          the corporation from Observation.
-        </p>
+        <div class="rounded-md border border-amber-200 bg-amber-50 p-3 space-y-1">
+          <p class="text-xs font-medium text-amber-900">
+            This edits the corporation's SSO requirement, not a posting-only setting.
+          </p>
+          <p class="text-xs text-amber-800">
+            The same record is used by Configuration &rarr; Scopes (superuser only), by member
+            compliance and by Observation. Characters must have granted these ESI scopes to be
+            compliant for this corporation, so changes here apply to
+            <span class="font-medium">every</span> character in it, not only to applicants.
+          </p>
+          <p class="text-xs text-amber-800">
+            Applies to: <span class="font-medium">{{ scopeTypeLabel }}</span>
+            <template v-if="posting.required_scopes_type">
+              &mdash; kept as configured; only Configuration &rarr; Scopes can change the level.
+            </template>
+          </p>
+        </div>
 
+        <!--
+          Both pickers snapshot their props during setup and emit the whole selection, so the one
+          that was not touched would otherwise write back its stale array and drop the other's
+          scopes. Re-key them on the shared selection to force a resync — the same pattern as
+          Configuration/Scopes/ScopeSettings.vue.
+        -->
         <CharacterScopes
+          :key="`character ${scopesAsString}`"
           v-model:selected-scopes="form.selected_scopes"
           :scopes="availableScopes.character"
         />
         <CorporationScopes
+          :key="`corporation ${scopesAsString}`"
           v-model:selected-scopes="form.selected_scopes"
           :scopes="availableScopes.corporation"
         />
@@ -220,6 +240,29 @@
         Save posting
       </button>
     </div>
+
+    <teleport to="#destination">
+      <ModalWithFooter v-model="confirmScopeClearing">
+        <template #title>
+          Remove the SSO requirement of {{ posting.corporation.name }}?
+        </template>
+        <template #description>
+          Saving with nothing selected deletes the corporation's SSO requirement outright: the
+          corporation leaves Observation and member compliance, no scope is asked of its applicants or
+          members any more, and the configured level ({{ scopeTypeLabel }}) is lost — adding scopes
+          back later starts again from the default level.
+        </template>
+        <template #buttons>
+          <button
+            type="button"
+            class="inline-flex w-full justify-center rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 sm:w-auto"
+            @click="submit"
+          >
+            Remove and save
+          </button>
+        </template>
+      </ModalWithFooter>
+    </teleport>
   </div>
 </template>
 
@@ -233,6 +276,14 @@ import Autosuggest from "@/Shared/Components/Autosuggest.vue";
 import DismissibleButton from "@/Shared/Layout/Buttons/DismissibleButton.vue";
 import CharacterScopes from "@/Pages/Configuration/Scopes/CharacterScopes.vue";
 import CorporationScopes from "@/Pages/Configuration/Scopes/CorporationScopes.vue";
+import ModalWithFooter from "@/Shared/Modals/ModalWithFooter.vue";
+
+// How far a configured requirement reaches, in the words of Configuration -> Scopes.
+const SCOPE_TYPE_LABELS = {
+  default: "only the characters in this corporation",
+  user: "every character of an account with a character in this corporation",
+  global: "every character in this installation",
+};
 
 const props = defineProps({
   posting: {
@@ -265,11 +316,25 @@ const closeForm = useForm({});
 
 const watchlistOpen = ref(false);
 const scopesOpen = ref(false);
+const confirmScopeClearing = ref(false);
 // Re-key the items autosuggest after each selection so it clears its input.
 const itemsKey = ref(0);
 
 // Surfaced on the (collapsed) toggle so a configured watchlist is visible at a glance.
 const watchlistCount = computed(() => form.systems.length + form.regions.length + form.items.length);
+
+// Re-key for the two scope pickers (see the template).
+const scopesAsString = computed(() => form.selected_scopes.join(","));
+
+const scopeTypeLabel = computed(
+  () => SCOPE_TYPE_LABELS[props.posting.required_scopes_type] ?? "nothing yet — no requirement is configured",
+);
+
+// Only a save that removes an existing requirement is destructive; saving a corporation that never
+// had one is not worth a modal.
+const clearsRequiredScopes = computed(
+  () => form.selected_scopes.length === 0 && (props.posting.required_scopes?.length ?? 0) > 0,
+);
 
 function addStage() {
   form.stages.push({ label: "", role_id: null });
@@ -291,6 +356,18 @@ function removeItem(id) {
 }
 
 function save() {
+  if (clearsRequiredScopes.value) {
+    confirmScopeClearing.value = true;
+
+    return;
+  }
+
+  submit();
+}
+
+function submit() {
+  confirmScopeClearing.value = false;
+
   form.put(props.posting.save_url, {
     preserveScroll: true,
   });

--- a/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
+++ b/src/Http/Controllers/Recruitment/ManageRecruitmentController.php
@@ -66,6 +66,10 @@ class ManageRecruitmentController extends Controller
                     'watched' => (new WatchedArrayAction)->execute($posting->corporation_id),
                     // The corporation's currently required SSO scopes (compliance + application), edited here.
                     'required_scopes' => $ssoScopes instanceof SsoScopes ? ($ssoScopes->selected_scopes ?? []) : [],
+                    // The requirement level of that record ('default' | 'user' | 'global'), null while
+                    // none is configured. Surfaced so the card can state what it is editing; a posting
+                    // save preserves it rather than resetting it to 'default'.
+                    'required_scopes_type' => $ssoScopes instanceof SsoScopes ? $ssoScopes->type : null,
                 ];
             })
             ->all();

--- a/src/Http/Controllers/Recruitment/PostingController.php
+++ b/src/Http/Controllers/Recruitment/PostingController.php
@@ -66,8 +66,8 @@ class PostingController extends Controller
     }
 
     /**
-     * Persist a posting's configuration in one request: its ordered review stages and its
-     * item/location watchlist.
+     * Persist a posting's configuration in one request: its ordered review stages, its item/location
+     * watchlist and — the one part that is not posting-local — the corporation's required SSO scopes.
      */
     public function save(Request $request, int $corporation_id, UpdateWatchlistAction $watchlist): RedirectResponse
     {
@@ -82,8 +82,11 @@ class PostingController extends Controller
             'items' => ['array'],
             'items.*.watchable_id' => ['required'],
             'items.*.watchable_type' => ['required'],
-            // The corporation's required SSO scopes (managed here as the corp 'default' type).
-            'selected_scopes' => ['array'],
+            // The corporation-wide required SSO scopes. 'sometimes' matters: a request that omits the
+            // key must leave the corporation's record alone, and only an explicitly submitted empty
+            // array clears it. (Were this form ever to carry a file, Inertia would switch to FormData,
+            // which drops empty arrays — a clear would then arrive as an omission and no-op.)
+            'selected_scopes' => ['sometimes', 'array'],
             'selected_scopes.*' => ['string'],
         ]);
 
@@ -102,21 +105,37 @@ class PostingController extends Controller
 
         $watchlist->execute($corporation_id, $validated);
 
-        $this->saveRequiredScopes($corporation_id, $validated['selected_scopes'] ?? []);
+        if (array_key_exists('selected_scopes', $validated)) {
+            $this->saveRequiredScopes($corporation_id, array_values($validated['selected_scopes']));
+        }
 
         return back()->with('success', 'Posting saved');
     }
 
     /**
-     * Persist (or clear) the corporation's required SSO scopes as the corp 'default' type. Clearing
-     * removes the record entirely, so the corporation drops out of the SSO-gated observation list.
+     * Persist (or clear) the corporation's required SSO scopes.
+     *
+     * This is not posting-local state. sso_scopes holds at most one row per corporation — both
+     * CorporationInfo::ssoScopes() and every reader treat it as a morphOne — and that row is shared
+     * with Configuration -> Scopes, member compliance and Observation. A posting save therefore
+     * carries the configured requirement level ('type') over rather than forcing it back to
+     * 'default', which used to silently downgrade a stricter 'user' requirement.
      *
      * @param  array<int, string>  $selectedScopes
      */
     private function saveRequiredScopes(int $corporation_id, array $selectedScopes): void
     {
+        $existing = SsoScopes::query()
+            ->where('morphable_id', $corporation_id)
+            ->where('morphable_type', CorporationInfo::class)
+            ->first();
+
         if ($selectedScopes === []) {
-            SsoScopes::query()->where('morphable_id', $corporation_id)->delete();
+            // Scoped to this corporation's own row (an alliance may share the id) and deleted through
+            // the model, so seatplus/auth's SsoScopeObserver flushes the permission caches — a mass
+            // delete skips model events entirely. Keeping an empty row instead is not an option: it
+            // would leave the corporation in Observation and member compliance with nothing to check.
+            $existing?->delete();
 
             return;
         }
@@ -124,7 +143,7 @@ class PostingController extends Controller
         (new UpdateOrCreateSsoSettings([
             'selectedScopes' => $selectedScopes,
             'selectedEntities' => [['id' => $corporation_id, 'category' => 'corporation']],
-            'type' => 'default',
+            'type' => $existing instanceof SsoScopes ? $existing->type : 'default',
         ]))->execute();
     }
 

--- a/src/Services/SsoSettings/UpdateOrCreateSsoSettings.php
+++ b/src/Services/SsoSettings/UpdateOrCreateSsoSettings.php
@@ -76,11 +76,13 @@ class UpdateOrCreateSsoSettings
 
                     (new DispatchCorporationOrAllianceInfoJob)->handle($morphable_type, $entity_id);
 
+                    // Matched on the whole morph, not on the id alone: a corporation and an alliance
+                    // may share an id, and matching by id would let one hijack the other's record.
                     SsoScopes::updateOrCreate([
                         'morphable_id' => $entity_id,
+                        'morphable_type' => $morphable_type,
                     ], [
                         'selected_scopes' => $this->selected_scopes->unique(),
-                        'morphable_type' => $morphable_type,
                         'type' => $this->type,
                     ]);
                 })

--- a/tests/Feature/Recruitment/ManageRecruitmentTest.php
+++ b/tests/Feature/Recruitment/ManageRecruitmentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Inertia\Testing\AssertableInertia as Assert;
+use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\SsoScopes;
 use Seatplus\Web\Models\Recruitment\Enlistment;
@@ -24,6 +25,24 @@ it('renders the manage workspace with the manageable postings', function () {
             ->has('postings.0.required_scopes')
             ->has('controlGroups')
             ->has('availableScopes')
+        );
+});
+
+it('exposes the requirement level of the corporation SSO scopes', function () {
+    $corp = CorporationInfo::factory()->create();
+    Enlistment::query()->create(['corporation_id' => $corp->corporation_id, 'type' => 'user']);
+    SsoScopes::factory()->create([
+        'morphable_id' => $corp->corporation_id,
+        'morphable_type' => CorporationInfo::class,
+        'type' => 'user',
+        'selected_scopes' => ['esi-assets.read_assets.v1'],
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->get(route('recruitment.manage'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('postings.0.required_scopes_type', 'user')
         );
 });
 
@@ -56,7 +75,7 @@ it('replaces the review stages of a posting', function () {
         ->toBe(['Screen', 'Final']);
 });
 
-it('saves the corporation required SSO scopes as the default type', function () {
+it('creates the corporation required SSO scopes with the default type when none exist yet', function () {
     $corp = CorporationInfo::factory()->create();
     Enlistment::query()->create(['corporation_id' => $corp->corporation_id, 'type' => 'user']);
     EnlistmentReviewRound::factory()->create(['corporation_id' => $corp->corporation_id, 'position' => 0, 'label' => 'Open']);
@@ -68,14 +87,74 @@ it('saves the corporation required SSO scopes as the default type', function () 
         ])
         ->assertRedirect();
 
-    $scopes = SsoScopes::query()->where('morphable_id', $corp->corporation_id)->first();
+    $scopes = SsoScopes::query()
+        ->where('morphable_id', $corp->corporation_id)
+        ->where('morphable_type', CorporationInfo::class)
+        ->first();
 
     expect($scopes)->not->toBeNull()
         ->and($scopes->type)->toBe('default')
+        ->and($scopes->morphable_type)->toBe(CorporationInfo::class)
         ->and($scopes->selected_scopes)->toContain('esi-assets.read_assets.v1');
 });
 
-it('removes the required SSO scopes when the selection is cleared', function () {
+// Regression test for #1665: the posting screen used to hardcode 'default', downgrading a stricter
+// 'user' requirement and dropping the corporation's members out of member compliance.
+it('preserves the configured requirement level when a posting is saved', function () {
+    $corp = CorporationInfo::factory()->create();
+    Enlistment::query()->create(['corporation_id' => $corp->corporation_id, 'type' => 'user']);
+    EnlistmentReviewRound::factory()->create(['corporation_id' => $corp->corporation_id, 'position' => 0, 'label' => 'Open']);
+    SsoScopes::factory()->create([
+        'morphable_id' => $corp->corporation_id,
+        'morphable_type' => CorporationInfo::class,
+        'type' => 'user',
+        'selected_scopes' => ['esi-assets.read_assets.v1'],
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->put(route('recruitment.posting.save', $corp->corporation_id), [
+            'stages' => [['label' => 'Open', 'role_id' => null]],
+            'selected_scopes' => ['esi-skills.read_skills.v1'],
+        ])
+        ->assertRedirect();
+
+    $scopes = SsoScopes::query()
+        ->where('morphable_id', $corp->corporation_id)
+        ->where('morphable_type', CorporationInfo::class)
+        ->first();
+
+    expect($scopes->type)->toBe('user')
+        ->and($scopes->selected_scopes)->toBe(['esi-skills.read_skills.v1']);
+});
+
+it('leaves the corporation SSO scopes untouched when the request omits the selection', function () {
+    $corp = CorporationInfo::factory()->create();
+    Enlistment::query()->create(['corporation_id' => $corp->corporation_id, 'type' => 'user']);
+    EnlistmentReviewRound::factory()->create(['corporation_id' => $corp->corporation_id, 'position' => 0, 'label' => 'Open']);
+    SsoScopes::factory()->create([
+        'morphable_id' => $corp->corporation_id,
+        'morphable_type' => CorporationInfo::class,
+        'type' => 'user',
+        'selected_scopes' => ['esi-assets.read_assets.v1'],
+    ]);
+
+    test()->actingAs(test()->test_user)
+        ->put(route('recruitment.posting.save', $corp->corporation_id), [
+            'stages' => [['label' => 'Open', 'role_id' => null]],
+        ])
+        ->assertRedirect();
+
+    $scopes = SsoScopes::query()
+        ->where('morphable_id', $corp->corporation_id)
+        ->where('morphable_type', CorporationInfo::class)
+        ->first();
+
+    expect($scopes)->not->toBeNull()
+        ->and($scopes->type)->toBe('user')
+        ->and($scopes->selected_scopes)->toBe(['esi-assets.read_assets.v1']);
+});
+
+it('removes only the corporations own SSO scopes when the selection is cleared', function () {
     $corp = CorporationInfo::factory()->create();
     Enlistment::query()->create(['corporation_id' => $corp->corporation_id, 'type' => 'user']);
     EnlistmentReviewRound::factory()->create(['corporation_id' => $corp->corporation_id, 'position' => 0, 'label' => 'Open']);
@@ -83,6 +162,14 @@ it('removes the required SSO scopes when the selection is cleared', function () 
         'morphable_id' => $corp->corporation_id,
         'morphable_type' => CorporationInfo::class,
         'type' => 'default',
+        'selected_scopes' => ['esi-assets.read_assets.v1'],
+    ]);
+    // An alliance sharing the corporation's id must not be collateral damage.
+    SsoScopes::factory()->create([
+        'morphable_id' => $corp->corporation_id,
+        'morphable_type' => AllianceInfo::class,
+        'type' => 'user',
+        'selected_scopes' => ['esi-skills.read_skills.v1'],
     ]);
 
     test()->actingAs(test()->test_user)
@@ -92,7 +179,8 @@ it('removes the required SSO scopes when the selection is cleared', function () 
         ])
         ->assertRedirect();
 
-    expect(SsoScopes::query()->where('morphable_id', $corp->corporation_id)->exists())->toBeFalse();
+    expect(SsoScopes::query()->where('morphable_id', $corp->corporation_id)->where('morphable_type', CorporationInfo::class)->exists())->toBeFalse()
+        ->and(SsoScopes::query()->where('morphable_id', $corp->corporation_id)->where('morphable_type', AllianceInfo::class)->exists())->toBeTrue();
 });
 
 it('closes a posting and cascades its stages', function () {

--- a/tests/Unit/Services/SsoSettings/UpdateOrCreateSsoSettingsTest.php
+++ b/tests/Unit/Services/SsoSettings/UpdateOrCreateSsoSettingsTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Bus;
 use Seatplus\Eveapi\Jobs\Alliances\AllianceInfoJob;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationInfoJob;
+use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\SsoScopes;
 use Seatplus\Web\Services\SsoSettings\UpdateOrCreateSsoSettings;
 
@@ -100,4 +101,32 @@ it('creates sso settings', function () {
     \Pest\Laravel\assertDatabaseHas('sso_scopes', [
         'morphable_id' => 1_184_675_423,
     ]);
+});
+
+it('does not hijack the row of another morphable type sharing the id', function () {
+    Bus::fake();
+
+    // The eveapi factory defaults selected_scopes to a JSON string, which the array cast would
+    // double-encode — pass a real array.
+    $alliance_scopes = SsoScopes::factory()->create([
+        'morphable_id' => 1_184_675_423,
+        'morphable_type' => AllianceInfo::class,
+        'type' => 'user',
+        'selected_scopes' => ['esi-skills.read_skills.v1'],
+    ]);
+
+    (new UpdateOrCreateSsoSettings([
+        'selectedEntities' => [
+            [
+                'id' => 1_184_675_423,
+                'category' => 'corporation',
+            ],
+        ],
+        'selectedScopes' => ['esi-assets.read_assets.v1'],
+        'type' => 'default',
+    ]))->execute();
+
+    expect(SsoScopes::query()->where('morphable_id', 1_184_675_423)->count())->toBe(2)
+        ->and($alliance_scopes->fresh()->type)->toBe('user')
+        ->and($alliance_scopes->fresh()->selected_scopes)->toBe(['esi-skills.read_skills.v1']);
 });


### PR DESCRIPTION
Saving a job posting rewrote the corporation's shared `sso_scopes` row as the `default` type, and deleted it outright when no scopes were selected — from a screen where nobody expects corporation-wide SSO configuration to change.

Closes #1665.

## What was wrong

`PostingController::saveRequiredScopes()` hardcoded `'type' => 'default'` and cleared with an unfiltered `where('morphable_id', …)->delete()`. Three losses, all silent:

1. **Downgrade.** A corporation configured as the stricter `user` type was rewritten to `default` on the first posting save. `GetCorporationMemberComplianceAffiliatedIdsService` filters on `whereIn('type', ['global', 'user'])`, so its members silently dropped out of member compliance.
2. **Accidental wipe.** `save()` read `$validated['selected_scopes'] ?? []`, so a request that merely *omitted* the key was read as "cleared" and deleted the row. The existing `it('replaces the review stages of a posting')` test posts exactly that shape.
3. **Unscoped delete.** No `morphable_type` filter, so an alliance sharing the id was collateral — and being a *mass* delete it never fired `seatplus/auth`'s `SsoScopeObserver`, leaving the permission caches that observer exists to flush stale.

## Why the scopes stay on the corporation

There is no posting-local home for them. `sso_scopes` holds one row per entity — `CorporationInfo::ssoScopes()` is a `morphOne` and every reader treats it as one — and two of the compliance readers (`BuildScopesArrayService`, `IsUserCompliantService`) live in `seatplus/auth`, outside this package, so a posting-scoped requirement could not be enforced. The card therefore keeps editing the corporation's row, but non-destructively, and now says so on screen.

## What changed

- **`PostingController`** — `selected_scopes` is `sometimes|array`, so an omitted key leaves the record alone and only an explicitly submitted `[]` clears it. The existing row is looked up scoped by `morphable_id` **and** `morphable_type`, its `type` is carried over (`'default'` only when creating), and the clearing path deletes that model instance so the observer fires.
- **`ManageRecruitmentController`** — passes `required_scopes_type` so the card can name the level in force.
- **`ManagePostingCard.vue`** — the section is now *Manage corporation-wide SSO scopes*, with a callout saying the record is shared with Configuration → Scopes, member compliance and Observation, and naming which level applies. A save that would remove an existing requirement goes through a `ModalWithFooter` confirmation first. Configuration → Scopes is **named, not linked**: that page is superuser-only, and a director managing a posting cannot open it.

Two adjacent defects in the same path, fixed here:

- **`UpdateOrCreateSsoSettings`** matched its upsert on `morphable_id` alone, so a corporation save could hijack an alliance row with the same id. Now matched on the whole morph. No behaviour change for existing rows — `morphable_type` was always written, so the match still hits.
- **`ManagePostingCard.vue`** omitted the `:key` re-keying that `Configuration/Scopes/ScopeSettings.vue` has. Both scope pickers snapshot `props.selectedScopes` at setup and emit the whole selection, so toggling a corporation scope discarded the character scopes just picked, and vice versa.

## Tests

All four new tests were confirmed to fail against the old code and pass with the fix.

- `it('preserves the configured requirement level when a posting is saved')` — the #1665 regression test.
- `it('leaves the corporation SSO scopes untouched when the request omits the selection')`.
- `it('removes only the corporations own SSO scopes when the selection is cleared')` — an alliance row sharing the id survives.
- `it('does not hijack the row of another morphable type sharing the id')` (unit).
- The two cases that encoded the old behaviour were rewritten; `it('creates … with the default type when none exist yet')` now also asserts the morph.

`composer run test` (Pint, PHPStan, 100% type coverage) and `npm run lint` are clean. The Pest run has one pre-existing order-dependent flake, `Tests\Unit\Jobs\ManualDispatchedJobTest` — verified to fail identically on the base tree with the same random seed, and to pass in isolation.

## Residuals, deliberately not fixed here

- **Last write wins.** Two surfaces still edit one row with no concurrency control: the card renders a page-load snapshot, so a director's posting save can still overwrite a superuser's concurrent scope edit. Mitigated only by the new labelling.
- **Clearing still loses the level.** Unavoidable — keeping the row with `selected_scopes => []` would leave the corporation inside `ObservationController`'s `has('ssoScopes')` and inside the member-compliance `whereIn('type', …)` with nothing to check. The modal says the level is lost.
- **Worth their own issues:** a unique index on `(morphable_type, morphable_id)` in `seatplus/eveapi` plus `morphable_type` in `SsoSettingsController::getEntity()`/`deleteSsoScopeSetting()` and auth's `BuildScopesArrayService`; every posting save still dispatching `CorporationInfoJob` for an already-imported corporation; and the real fix for the picker snapshot smell (a rewrite across `CharacterScopes`/`CorporationScopes`/`ScopeToggle`, shared with the superuser Configuration page) — the `:key` here matches the established pattern rather than reopening those three components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
